### PR TITLE
feat(input): support all Whisker hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown 0.17.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
 ]
 
@@ -59,8 +59,8 @@ dependencies = [
  "accesskit_consumer",
  "hashbrown 0.17.1",
  "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ dependencies = [
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
- "nom",
+ "nom 7.1.3",
  "pin-project",
  "rand 0.8.7",
  "rust-embed",
@@ -163,7 +163,7 @@ dependencies = [
  "cookie-factory",
  "hkdf",
  "io_tee",
- "nom",
+ "nom 7.1.3",
  "rand 0.8.7",
  "secrecy",
  "sha2 0.10.9",
@@ -299,6 +299,24 @@ name = "ar"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d67af77d68a931ecd5cbd8a3b5987d63a1d1d1278f7f6a60ae33db485cdebb69"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1173,6 +1191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,6 +1802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
+
+[[package]]
 name = "etagere"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1903,12 @@ name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3584,6 +3623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,8 +3751,20 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3717,7 +3777,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3728,7 +3788,7 @@ checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3740,7 +3800,31 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3751,7 +3835,7 @@ checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -3764,7 +3848,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3787,6 +3871,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-link-presentation"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,8 +3900,8 @@ checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3807,7 +3913,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3819,7 +3925,7 @@ dependencies = [
  "bitflags 2.13.1",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -3830,7 +3936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3846,7 +3952,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
@@ -3862,7 +3968,7 @@ checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3875,7 +3981,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3951,6 +4057,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4035,6 +4151,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "phf"
@@ -5963,6 +6090,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6963,6 +7101,7 @@ version = "0.12.0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
+ "arboard",
  "base64 0.22.1",
  "bytemuck",
  "csscolorparser",
@@ -7153,11 +7292,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "whisker-input-desktop"
+version = "0.12.0"
+dependencies = [
+ "csscolorparser",
+ "glyphon",
+ "unicode-segmentation",
+ "whisker-desktop",
+ "whisker-protocol",
+]
+
+[[package]]
 name = "whisker-input-example"
 version = "0.1.0"
 dependencies = [
  "whisker",
  "whisker-input",
+]
+
+[[package]]
+name = "whisker-input-web"
+version = "0.12.0"
+dependencies = [
+ "web-sys",
+ "whisker-protocol",
+ "whisker-web",
 ]
 
 [[package]]
@@ -7900,8 +8059,8 @@ dependencies = [
  "memmap2",
  "ndk",
  "objc2 0.5.2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
@@ -7950,6 +8109,24 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ members = [
     "packages/whisker-image/web",
     "packages/whisker-image/example",
     "packages/whisker-input",
+    "packages/whisker-input/desktop",
+    "packages/whisker-input/web",
     "packages/whisker-input/example",
     "packages/whisker-keyboard",
     "packages/whisker-keyboard/web",

--- a/crates/whisker-cng/src/modules.rs
+++ b/crates/whisker-cng/src/modules.rs
@@ -643,13 +643,13 @@ mod tests {
             .find(|module| module.package == "whisker-svg")
             .unwrap();
         let desktop = svg.rust_host(ModulePlatform::Desktop).unwrap();
-        assert_eq!(desktop.package, "whisker-svg-desktop-host");
+        assert_eq!(desktop.package, "whisker-svg-desktop");
         assert!(matches!(
             &desktop.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/desktop")
         ));
         let web = svg.rust_host(ModulePlatform::Web).unwrap();
-        assert_eq!(web.package, "whisker-svg-web-host");
+        assert_eq!(web.package, "whisker-svg-web");
         assert!(matches!(
             &web.source,
             ResolvedRustHostSource::Path(path) if path.ends_with("whisker-svg/web")

--- a/docs/gpui-text-input-research.md
+++ b/docs/gpui-text-input-research.md
@@ -1,0 +1,404 @@
+# GPUI の Desktop text input 実装調査
+
+調査日: 2026-09-02
+
+対象は `zed-industries/zed` の `main`、commit
+[`97b1e64a177a2fe3c2803e323087b5c2fa6fff1e`](https://github.com/zed-industries/zed/tree/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e)
+である。以下で「GPUI」は特記しない限りこの revision を指す。
+
+## 結論
+
+GPUI は Desktop の editable text をネイティブ `NSTextField` / Win32 Edit /
+GTK entry として配置していない。テキスト、選択、caret、marked text はアプリ側の
+状態として保持し、GPUI の text system と GPU scene で描画する。一方、OS の入力
+システムとは、フォーカス中の描画要素が毎フレーム登録する `InputHandler` を境界に
+接続する。
+
+```text
+OS text system
+  macOS NSTextInputClient / Windows IMM32 / Wayland text-input-v3 / X11 XIM
+        ↕ UTF-16 range、commit/preedit、caret bounds
+PlatformInputHandler
+        ↕
+InputHandler / EntityInputHandler
+        ↕
+field/editor が所有する text・selection・marked range・layout snapshot
+        ↓
+GPUI text shaping + GPU drawing
+```
+
+この分割は Whisker Desktop に適している。推奨は、モバイルと同じ native control
+を Desktop に埋め込むことではなく、`whisker-input` の公開 API は維持しつつ、
+Desktop Host に「editable-text session」という専用境界を追加すること。ただし
+Whisker が現在使う winit 0.30.13 の `Ime::{Preedit, Commit}` だけでは GPUI と同等の
+replacement range、文書問い合わせ、point-to-index、macOS Accessibility Keyboard
+連携を表現できない。winit 経路は段階的な最小実装には使えるが、完全な入力契約の
+最終境界にはしない方がよい。
+
+## 1. GPUI の共通入力境界
+
+### `InputHandler`
+
+中心は [`InputHandler`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/platform.rs#L1693-L1880)
+trait である。コメント上も AppKit の `NSTextInputClient` を基礎にした API と明記され、
+次の双方向操作を持つ。
+
+| 分類 | メソッド | 意味 |
+|---|---|---|
+| 状態問い合わせ | `selected_text_range` | 選択範囲と向きを返す |
+| 状態問い合わせ | `marked_text_range` | IME composition 範囲を返す |
+| 文書問い合わせ | `text_for_range` | 指定範囲の文字列と調整済み範囲を返す |
+| OS → editor | `replace_text_in_range` | commit/通常入力を置換として適用する |
+| OS → editor | `replace_and_mark_text_in_range` | preedit を置換し marked 状態にする |
+| OS → editor | `unmark_text` | composition を終了する |
+| geometry | `bounds_for_range` | candidate window 用の画面上の範囲を返す |
+| geometry | `character_index_for_point` | 画面座標を文字位置へ逆変換する |
+| selection | `set_selected_text_range` | OS 側が動かした選択を反映する |
+| policy | `accepts_text_input` | 現在入力可能か返す |
+| policy | `prefers_ime_for_printable_keys` | keybinding より IME を先にするか返す |
+| assistance | `text_input_configuration` | autocorrect 等の設定を返す |
+
+OS 境界の offset は明示的に UTF-16 code unit である。
+[`UTF16Selection`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/platform.rs#L1680-L1691)
+は range と selection direction を分けて保持する。Rust の UTF-8 byte offset を直接
+OSへ渡していない点が重要である。
+
+`PlatformInputHandler` は `Box<dyn InputHandler>` と `AsyncWindowContext` を保持し、
+platform callback から entity/window state を安全に更新する type erasure 層である。
+委譲処理と candidate bounds の計算は
+[`platform.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/platform.rs#L1440-L1677)
+にある。composition 中は marked range 内の現在の visual line の先頭、通常時は
+selection head の bounds を候補ウィンドウ位置に使う。
+
+### View/entity との接続
+
+通常の view はより型付きの
+[`EntityInputHandler`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/input.rs#L7-L124)
+を実装する。`ElementInputHandler<V>` が entity 更新を `InputHandler` に変換する
+canonical adapter である
+([`input.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/input.rs#L126-L286))。
+
+入力ハンドラは常設の hidden text field ではない。要素の paint 中に
+[`Window::handle_input`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/window.rs#L4848-L4874)
+を呼び、対応する `FocusHandle` が focused の場合だけ次フレームの handler として
+登録される。したがって focus、表示中の layout geometry、OS input session が同じ
+rendered frame に結びつく。
+
+## 2. 入力要素・Editor が持つ状態
+
+### 最小 input example
+
+公式の
+[`crates/gpui/examples/input.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/examples/input.rs#L35-L414)
+は単一行 input の最小モデルであり、次を view state として持つ。
+
+- `content`
+- byte range の `selected_range` と `selection_reversed`
+- `marked_range`
+- geometry/hit-test 用の `last_layout` と `last_bounds`
+- pointer drag selection 用の `is_selecting`
+- `focus_handle`
+
+OS境界では UTF-8 byte offset と UTF-16 offset を相互変換し、左右移動や削除では
+Unicode grapheme boundary を使う。同 example の
+[`EntityInputHandler` 実装](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/examples/input.rs#L278-L403)
+では、preedit を `marked_range` に置き、commit 時は marked range（なければ selection）
+を置換する。
+
+描画も明瞭である。text は `shape_line`、selection と caret は `PaintQuad`、marked text
+は underline 付き `TextRun` として構築し、`paint` で scene に描く
+([`TextElement::prepaint/paint`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/examples/input.rs#L405-L548))。
+つまり native control の外観を透明化して重ねる方式ではなく、表示は GPUI 独自描画
+である。
+
+### Zed Editor
+
+実製品の Editor も同じ trait を実装するが、状態管理はより強い。
+
+- selection は editor の multi-buffer selection model が所有する。
+- composition は `HighlightKey::InputComposition` の anchor ranges として保持される。
+- preedit/commit は実バッファへの transaction として適用し、同じ
+  `ime_transaction` に group する。
+- multi-cursor では OS が見ている一つの replacement range を各 cursor に展開する。
+- preedit 中は auto-close / auto-surround を一時的に止める。
+
+根拠は
+[`Editor` の `EntityInputHandler` 実装](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/editor/src/input.rs#L2764-L3099)
+である。marked text を別の OS-owned shadow buffer に閉じ込めず editor state として
+扱うため、描画、undo grouping、selection、複数 cursor と同じモデル上で整合させられる。
+
+Editor element も paint 時に focused editor を `ElementInputHandler` として登録する
+([`editor/src/element.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/editor/src/element.rs#L9514-L9530))。
+
+## 3. OS ごとの接続
+
+### macOS: `NSTextInputClient` を custom `NSView` に直接実装
+
+GPUI の native view class は `NSTextInputClient` protocol を追加し、`hasMarkedText`、
+`markedRange`、`selectedRange`、`firstRectForCharacterRange`、`insertText`、
+`setMarkedText`、`unmarkText`、`attributedSubstringForProposedRange`、
+`characterIndexForPoint` を登録する
+([`gpui_macos/src/window.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_macos/src/window.rs#L239-L303))。
+
+各 Objective-C callback は `PlatformInputHandler` に委譲する。character range の
+bounds は GPUI 座標から macOS screen 座標へ変換され、`insertText` は commit、
+`setMarkedText` は preedit と local selection を渡す
+([`window.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_macos/src/window.rs#L3014-L3230))。
+
+Apple の公式仕様も、独自 text view は `NSView` を subclass して
+`NSTextInputClient` を実装できるとしており、この protocol を text input system と
+正しく連携するための契約としている
+([Apple: `NSTextInputClient`](https://developer.apple.com/documentation/appkit/nstextinputclient))。
+Apple の Text Editing guide は first responder の client が input context に接続され、
+`insertText` / `setMarkedText` / `doCommandBySelector` を受け、scroll 等で座標が変われば
+`invalidateCharacterCoordinates` を通知する流れを説明している
+([Apple: Text Editing](https://developer.apple.com/library/archive/documentation/TextFonts/Conceptual/CocoaTextArchitecture/TextEditing/TextEditing.html))。
+GPUI の `update_ime_position` も `NSTextInputContext.invalidateCharacterCoordinates` を
+呼ぶ
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_macos/src/window.rs#L1931-L1948))。
+
+keybinding と IME の競合も platform adapter で調停する。composition 中、非 printing
+key、または日本語等の composition-based input source で handler が希望する場合は
+`NSTextInputContext.handleEvent` を先に呼び、処理できない key は
+`doCommandBySelector` から GPUI key dispatch に戻す
+([`handle_key_event`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_macos/src/window.rs#L2328-L2510))。
+
+### Windows: TSF ではなく IMM32
+
+現在の GPUI Windows backend は Text Services Framework の `ITextStoreACP` 等ではなく、
+window procedure で `WM_CHAR`、`WM_IME_STARTCOMPOSITION`、
+`WM_IME_COMPOSITION` を処理する IMM32 実装である
+([message dispatch](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L143-L160))。
+
+- 通常文字は `WM_CHAR` から `replace_text_in_range(None, text)` へ送る
+  ([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L473-L481))。
+- `WM_IME_COMPOSITION` の `GCS_RESULTSTR` を commit、`GCS_COMPSTR` を marked text、
+  `GCS_CURSORPOS` を composition 内 caret として処理する
+  ([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L725-L778))。
+- `ImmGetCompositionStringW` で UTF-16 data を読む
+  ([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L1658-L1709))。
+- `ImmSetCompositionWindow` と `ImmSetCandidateWindow` へ caret bounds を渡す
+  ([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L646-L693))。
+- focused handler の `accepts_text_input` に応じて `ImmAssociateContextEx` で IME context
+  を有効化/解除する
+  ([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_windows/src/events.rs#L695-L723))。
+
+Microsoft の仕様でも、self-drawn composition を扱うアプリは
+`WM_IME_COMPOSITION` の flags を調べ `ImmGetCompositionString` で状態を取得する
+([`WM_IME_COMPOSITION`](https://learn.microsoft.com/en-us/windows/win32/intl/wm-ime-composition),
+[`ImmGetCompositionStringW`](https://learn.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immgetcompositionstringw))。
+候補/comp window の位置 API も GPUI の利用法と一致する
+([`ImmSetCandidateWindow`](https://learn.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immsetcandidatewindow),
+[`ImmSetCompositionWindow`](https://learn.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immsetcompositionwindow))。
+
+### Wayland: `zwp_text_input_v3`
+
+Wayland backend は `zwp_text_input_manager_v3` から seat ごとの
+`zwp_text_input_v3` を取得する
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/wayland/client.rs#L1677-L1706))。
+focus/acceptance に応じて enable/disable し、cursor rectangle を protocol に設定する
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/wayland/client.rs#L535-L590))。
+
+イベントは `PreeditString` を一旦保持し、同じ transaction の `Done` で
+`SetMarkedText`、`CommitString` で commit を handler に送る
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/wayland/client.rs#L1980-L2057),
+[`ImeInput` adapter](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/wayland/window.rs#L1413-L1451))。
+
+注意点として、protocol が持つ `set_surrounding_text` と
+`delete_surrounding_text` は現在の GPUI code path では使われず、event match の残りは
+無視される。したがって Wayland backend は共通 `InputHandler` の全文書問い合わせ能力
+を使い切っていない。protocol 自体の要求・イベント一覧は Wayland Protocols の
+一次仕様にある
+([`text-input-unstable-v3.xml`](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/afb614d5fcbd02d261a6ae91920aa91cf3915a8a/unstable/text-input/text-input-unstable-v3.xml))。
+
+### X11: XIM callback style
+
+X11 backend は Zed の `xim-rs` を通じて XIM input context を作り、
+`PREEDIT_CALLBACKS`、client/focus window を設定する
+([`xim_handler.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/x11/xim_handler.rs#L31-L137))。
+XIM の commit callback は `replace_text_in_range`、preedit draw callback は
+`replace_and_mark_text_in_range` に変換される
+([client callback routing](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/x11/client.rs#L1427-L1509),
+[window adapter](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_linux/src/linux/x11/window.rs#L1212-L1265))。
+
+candidate spot は input handler の selection bounds から `SpotLocation` として XIC に
+設定する。XIM feedback と callback の caret/change offsets は現状捨て、preedit 全体を
+再設定している。X.Org の Xlib specification でも `XIMPreeditCallbacks` は
+preedit start/done/draw/caret callbacks を client が提供する style と定義されている
+([Xlib specification, chapter 13](https://www.x.org/releases/current/doc/libX11/libX11/libX11.html))。
+
+## 4. focus、clipboard、accessibility
+
+### focus
+
+`FocusHandle` と render dispatch tree が論理 focus を所有し、入力 element は
+`track_focus` する。`handle_input` が focused handle のみを platform に公開するため、
+複数 field が同時に OS input target になることはない
+([`FocusHandle`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/window.rs#L528-L613),
+[`handle_input`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/window.rs#L4848-L4874))。
+
+### clipboard
+
+Clipboard は editable-text trait の隠れた責務ではなく `Platform` service である。
+`read_from_clipboard` / `write_to_clipboard` と Linux primary selection が共通 trait に
+定義される
+([`Platform` clipboard API](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/platform.rs#L300-L328))。
+input example は copy/cut/paste action からこの service を使う
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/examples/input.rs#L137-L180))。
+`InputHandler::paste` には platform 主導 paste 用の default があり、plain text を現在の
+selection に挿入する。
+
+### accessibility
+
+GPUI 自体は AccessKit tree と action routing を提供し、macOS、Windows、Linux の
+platform adapter に渡す
+([GPUI accessibility guide](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/_accessibility.rs),
+[`Window` initialization](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/window.rs#L1447-L1504))。
+guide は custom text editor を `Role::TextInput` と synthetic `TextRun`、
+`TextSelection` で表現する例も示す
+([source](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui/src/_accessibility.rs#L227-L269))。
+
+ただし text input と accessibility は同じ trait ではない。公式の最小 input example
+は text-input role/tree を実装しておらず、`InputHandler` を実装しただけで accessible
+text field が自動生成されるわけではない。Whisker でも IME 対応完了と accessibility
+対応完了を同一視してはいけない。
+
+## 5. GPUI の build/composition 形状
+
+GPUI の共通 trait/state は `gpui`、OS接続は `gpui_macos`、`gpui_windows`、
+`gpui_linux` に分離される。`gpui_platform::current_platform` が target `cfg` に応じて
+一つを構築する
+([`gpui_platform.rs`](https://github.com/zed-industries/zed/blob/97b1e64a177a2fe3c2803e323087b5c2fa6fff1e/crates/gpui_platform/src/gpui_platform.rs#L44-L70))。
+すべて最終的には単一 Rust executable に link され、OS object と共通 view state の間に
+JSON/FFI bridge はない。
+
+これは Whisker の `whisker-desktop` と薄い `whisker-macos` / `whisker-windows` /
+`whisker-linux` という構成に近い。GPUIから借りるべきなのは個別の editor 実装ではなく、
+「共通の豊かな editable-text contract」と「OS別 adapter」を明確に分離する形である。
+
+## 6. winit 0.30.13 との差
+
+Whisker Desktop は winit 0.30.13 を使用している。一方、現在の
+[`DesktopApplication::window_event`](../platforms/desktop/src/app.rs)
+は resize、pointer、wheel、touch 等だけを処理し、`WindowEvent::KeyboardInput`、
+`WindowEvent::Ime`、`Focused` はまだ処理していない。
+
+winit の公開 API には以下がある。
+
+- `WindowEvent::Ime(Ime)` を明示的に有効化する `Window::set_ime_allowed`。
+- `Ime::Preedit(String, Option<(byte_start, byte_end)>)` と `Ime::Commit(String)`。
+- candidate box のための `Window::set_ime_cursor_area`。
+
+仕様は
+[`Ime`](https://github.com/rust-windowing/winit/blob/v0.30.13/src/event.rs#L774-L807) と
+[`Window::set_ime_cursor_area` / `set_ime_allowed`](https://github.com/rust-windowing/winit/blob/v0.30.13/src/window.rs#L1211-L1286)
+にある。これだけなら GPUI の Linux/Windows に近い基本的な preedit/commit 表示は
+共通コードで開始できる。
+
+しかし winit event は文書 range の query/replace protocol ではない。特に macOS の
+winit 0.30.13 `NSTextInputClient` 実装は次の制限をコード上で明記している。
+
+- `selectedRange` は常に `NSNotFound`。
+- `setMarkedText` と `insertText` の `replacementRange` を無視する。
+- `attributedSubstringForProposedRange` は `None`。
+- `characterIndexForPoint` は `0`。
+- `firstRectForCharacterRange` はアプリが設定した一つの IME area を返す。
+
+根拠は winit の
+[`WinitView: NSTextInputClient`](https://github.com/rust-windowing/winit/blob/v0.30.13/src/platform_impl/macos/view.rs#L243-L410)
+である。したがって winit の `Ime` event だけでは、GPUI が可能にしている macOS の
+replacement range、周辺文字列問い合わせ、point-to-character、system-driven selection
+を Whisker state に反映できない。
+
+## 7. Whisker Desktop への推奨境界
+
+### 推奨: native control ではなく Host-owned editable-text session
+
+`packages/whisker-input` の app-facing schema (`value`/`text`, `on_input`, `on_change`,
+`on_focus`, `on_blur`, `on_submit`, `focus`/`blur`/`clear`/`setValue`) は維持する。
+Desktop 実装は次の責務で分けるのがよい。
+
+1. `whisker-input` Desktop module
+   - schema property/command/event ID を binding する。
+   - node ごとの `EditableTextState` を作る。
+2. `whisker-desktop` 共通 editable-text layer
+   - text、selection direction、marked range、scroll offset、focus、revision を保持する。
+   - UTF-8/UTF-16/grapheme の変換を一箇所に集約する。
+   - glyphon/cosmic-text の layout snapshot から caret/range bounds と hit-test を返す。
+   - selection、caret、composition underline、placeholder、secure mask を scene として描く。
+3. OS adapter
+   - macOS: GPUI と同種の `NSTextInputClient` bridge。
+   - Windows: まず IMM32。将来 TSF が必要なら同じ共通 contract の別 adapter とする。
+   - Wayland: text-input-v3。`set_surrounding_text` と
+     `delete_surrounding_text` も共通 contract に接続する。
+   - X11: XIM callback/spot-location adapter。
+
+現在の [`DesktopNativeElement`](../platforms/desktop/src/element.rs) は property、command、
+raster、measurement、scroll の境界であり、window event、focus、IME session、layout
+range query を受け取れない。入力を単なる `DesktopNativeElement::rasterize` 実装に
+押し込めるのではなく、scene/window loop と協調する専用 capability を追加すべきである。
+例えば `DesktopNativeElement` から opt-in の `editable_text()` handle を取得し、
+`DesktopApplication` が focused node の handle だけを OS adapter に公開する形なら、
+既存 module composition と両立する。
+
+### 最小 trait の候補
+
+GPUIをそのままコピーする必要はないが、少なくとも次の意味を Host 内部契約に持たせる。
+
+```rust,ignore
+trait DesktopEditableText {
+    fn selected_range_utf16(&self) -> DirectedRange;
+    fn marked_range_utf16(&self) -> Option<Range<usize>>;
+    fn text_utf16(&self, range: Range<usize>) -> Option<AdjustedText>;
+
+    fn commit(&mut self, replacement: Option<Range<usize>>, text: &str);
+    fn set_preedit(
+        &mut self,
+        replacement: Option<Range<usize>>,
+        text: &str,
+        selection_in_preedit: Option<Range<usize>>,
+    );
+    fn unmark(&mut self);
+    fn set_selection_utf16(&mut self, range: DirectedRange);
+
+    fn bounds_for_range(&self, range: Range<usize>) -> Option<LogicalRect>;
+    fn index_utf16_for_point(&self, point: LogicalPoint) -> Option<usize>;
+    fn configuration(&self) -> TextInputConfiguration;
+}
+```
+
+この trait は public component API ではなく Host 内部の OS/editor seam とする。
+Whisker の既存 RFC が要求している `host_state_revision` と stale controlled-value の
+拒否もこの state machine に統合する。composition 中の外部 `value` 更新を単純代入すると
+marked range と caret を壊すためである。
+
+### 実装順序
+
+1. winit の `Ime::Preedit/Commit`、`set_ime_allowed`、`set_ime_cursor_area` で
+   GPU-drawn single-line input の縦断 prototype を作る。
+2. focus、selection、grapheme navigation、clipboard、secure、multiline、scroll を
+   Host-owned state として追加する。
+3. composition と controlled-value revision の conformance tests を追加する。
+4. macOS の replacement/document-query 要件を満たす native bridge を追加する。
+5. Wayland surrounding-text/delete、Windows IMM32、X11 XIM の差を OS adapter tests で
+   固定する。
+6. AccessKit に `TextInput`/`TextRun`/selection/actions を別 capability として公開する。
+
+最初から native child control を合成しない判断には利点がある。Whisker の Taffy layout、
+clip/transform/opacity、GPU paint order と自然に一致し、mobile の wrapper/native-view
+制約を Desktop へ持ち込まずに済む。一方で native control が無料で提供する selection、
+caret、IME、clipboard、accessibility、password semantics をすべて Host が実装する責任も
+引き受ける。GPUI の設計はこの選択が実用可能であることを示すが、最小 input example
+だけを移植すれば完成するわけではない。
+
+## 8. 判断表
+
+| 方針 | 長所 | 制約 | 推奨 |
+|---|---|---|---|
+| Desktop native text control を子Viewとして合成 | OS標準機能が多い | GPU scene のclip/transform/z-order、3 OS の native embedding、見た目の一致が難しい | mobile には継続、Desktop の第一候補にはしない |
+| winit `Ime` event + GPU描画 | 現行 Host に最短、3 OS 共通の入口 | replacement/document query/selection/a11y が不足 | prototype と段階1に採用 |
+| GPUI型の rich contract + OS adapter + GPU描画 | state/layout/revisionをWhiskerで統一、将来の完全対応が可能 | 実装量とOS別検証が必要 | Desktop の目標設計 |
+
+最終提案は「winit で小さく開始し、公開 component と Host 内部 contract は最初から
+GPUI 相当の情報量を持たせる」である。これなら最初の Desktop 対応を阻害せず、winit
+の抽象化で失われる情報を後から OS adapter で補っても app-facing API を変更せずに済む。

--- a/packages/whisker-input/Cargo.toml
+++ b/packages/whisker-input/Cargo.toml
@@ -9,10 +9,10 @@ authors.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Text-input component for Whisker — a native single-line / multiline field (UITextField / UITextView on iOS, EditText on Android) with Leptos-style two-way binding, placeholder / caret / selection colors, keyboard + return-key configuration, and an imperative focus / blur / clear / value handle."
+description = "Cross-platform text-input element for Whisker with two-way binding, native IME integration, and an imperative focus / blur / clear / value handle."
 
 # Explicit `include` list — mirrors `whisker-image`. A `cargo publish`
-# ships the Kotlin + Swift platform sources alongside `src/lib.rs`,
+# ships the Kotlin, Swift, and Rust Host sources alongside `src/lib.rs`,
 # but never the local Gradle / Xcode build artifacts that would
 # accidentally bloat the published crate if a stale build dir lingers.
 include = [
@@ -22,7 +22,10 @@ include = [
     "src/lib.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
-    "README.md",
+    "desktop/**/*.rs",
+    "desktop/Cargo.toml",
+    "web/**/*.rs",
+    "web/Cargo.toml",
 ]
 
 [lib]
@@ -32,7 +35,11 @@ crate-type = ["rlib"]
 # crate as a Whisker module; `whisker-build` walks the consuming app's
 # dep tree, picks out every dep carrying it, and wires the Android
 # Gradle subproject + iOS SwiftPM package into the host build.
-[package.metadata.whisker]
+[package.metadata.whisker.module.platforms]
+android = { manifest = "build.gradle.kts" }
+ios = { manifest = "Package.swift" }
+web = { manifest = "web/Cargo.toml" }
+desktop = { manifest = "desktop/Cargo.toml" }
 
 [dependencies]
 whisker = { workspace = true }

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -22,7 +22,7 @@ import PackageDescription
 // so this module builds for an app created outside the whisker repo.
 let package = Package(
     name: "whisker-input",
-    platforms: [.iOS(.v13), .macOS(.v13)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
@@ -35,22 +35,22 @@ class InputModule : Module() {
             // ---- behaviour props -------------------------------------------
 
             Prop("multiline") { view: WhiskerInputView, value ->
-                view.setMultiline(value.asString() ?: "false")
+                view.setMultiline(value.asBool() ?: false)
             }
             Prop("lines") { view: WhiskerInputView, value ->
-                view.setLines(value.asString() ?: "0")
+                view.setLines(value.asInt() ?: 0)
             }
             Prop("secure") { view: WhiskerInputView, value ->
-                view.setSecure(value.asString() ?: "false")
+                view.setSecure(value.asBool() ?: false)
             }
             Prop("editable") { view: WhiskerInputView, value ->
-                view.setEditable(value.asString() ?: "true")
+                view.setEditable(value.asBool() ?: true)
             }
             Prop("auto-focus") { view: WhiskerInputView, value ->
-                view.setAutoFocus(value.asString() ?: "false")
+                view.setAutoFocus(value.asBool() ?: false)
             }
             Prop("max-length") { view: WhiskerInputView, value ->
-                view.setMaxLength(value.asString() ?: "0")
+                view.setMaxLength(value.asInt() ?: 0)
             }
             Prop("keyboard-type") { view: WhiskerInputView, value ->
                 view.setKeyboardType(value.asString() ?: "default")
@@ -62,10 +62,10 @@ class InputModule : Module() {
                 view.setAutoCapitalize(value.asString() ?: "sentences")
             }
             Prop("autocorrect") { view: WhiskerInputView, value ->
-                view.setAutocorrect(value.asString() ?: "true")
+                view.setAutocorrect(value.asBool() ?: true)
             }
             Prop("spell-check") { view: WhiskerInputView, value ->
-                view.setSpellCheck(value.asString() ?: "true")
+                view.setSpellCheck(value.asBool() ?: true)
             }
 
             // Declaration-only metadata (parity with the iOS module);

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -18,7 +18,6 @@ package rs.whisker.elements.input
 
 import android.content.Context
 import android.graphics.Color
-import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.os.Build
 import android.text.Editable
@@ -286,7 +285,7 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         val et = view()
         val parsed = parseColor(color) ?: return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            et.textCursorDrawable?.setColorFilter(parsed, PorterDuff.Mode.SRC_IN)
+            et.textCursorDrawable?.setTint(parsed)
         }
         // Pre-API-29 the caret keeps the theme color: there is no typed
         // cursor-tint API, and the `mCursorDrawableRes` reflection hack is
@@ -299,10 +298,9 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         et.highlightColor = parsed
     }
 
-    fun setMultiline(flag: String) {
+    fun setMultiline(multiline: Boolean) {
         val et = view()
-        val multi = flag == "true"
-        if (multi) {
+        if (multiline) {
             et.isSingleLine = false
             et.inputType = et.inputType or InputType.TYPE_TEXT_FLAG_MULTI_LINE
             // Top-align, matching iOS.
@@ -316,18 +314,18 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         applyTextFlags()
     }
 
-    fun setLines(countStr: String) {
+    fun setLines(count: Long) {
         val et = view()
-        val n = countStr.toIntOrNull() ?: 0
+        val n = count.coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
         if (n > 0) {
             // CSS is the authoritative height; this is best-effort.
             et.setLines(n)
         }
     }
 
-    fun setSecure(flag: String) {
+    fun setSecure(secure: Boolean) {
         val et = view()
-        if (flag == "true") {
+        if (secure) {
             // Preserve the current class (text vs number), replace variation.
             val base = et.inputType and InputType.TYPE_MASK_CLASS
             et.inputType = base or InputType.TYPE_TEXT_VARIATION_PASSWORD
@@ -339,16 +337,18 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         applyTextFlags()
     }
 
-    fun setEditable(flag: String) {
+    fun setEditable(editable: Boolean) {
         val et = view()
-        val enabled = flag != "false"
-        et.isEnabled = enabled
-        et.isFocusable = enabled
-        et.isFocusableInTouchMode = enabled
+        et.isEnabled = editable
+        et.isFocusable = editable
+        et.isFocusableInTouchMode = editable
     }
 
-    fun setAutoFocus(flag: String) {
-        if (flag != "true") return
+    fun setAutoFocus(autoFocus: Boolean) {
+        if (!autoFocus) {
+            pendingAutoFocus = false
+            return
+        }
         val et = view()
         if (et.isAttachedToWindow) {
             focusField()
@@ -357,9 +357,9 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         }
     }
 
-    fun setMaxLength(countStr: String) {
+    fun setMaxLength(count: Long) {
         val et = view()
-        val n = countStr.toIntOrNull() ?: 0
+        val n = count.coerceIn(0, Int.MAX_VALUE.toLong()).toInt()
         if (n > 0) {
             et.filters = arrayOf(InputFilter.LengthFilter(n))
         } else {
@@ -409,14 +409,14 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         applyTextFlags()
     }
 
-    fun setAutocorrect(flag: String) {
-        autoCorrectFlag = if (flag == "false") 0 else InputType.TYPE_TEXT_FLAG_AUTO_CORRECT
+    fun setAutocorrect(enabled: Boolean) {
+        autoCorrectFlag = if (enabled) InputType.TYPE_TEXT_FLAG_AUTO_CORRECT else 0
         applyTextFlags()
     }
 
-    fun setSpellCheck(flag: String) {
+    fun setSpellCheck(enabled: Boolean) {
         // `spell_check` is the inverse of the `NO_SUGGESTIONS` flag.
-        noSuggestionsFlag = if (flag == "false") InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS else 0
+        noSuggestionsFlag = if (enabled) 0 else InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
         applyTextFlags()
     }
 

--- a/packages/whisker-input/desktop/Cargo.toml
+++ b/packages/whisker-input/desktop/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "whisker-input-desktop"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Native Desktop Host implementation for whisker-input."
+
+[dependencies]
+csscolorparser = "0.7.2"
+glyphon = "0.9.0"
+unicode-segmentation = "1"
+whisker-desktop = { workspace = true }
+whisker-protocol = { workspace = true }

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -1,0 +1,772 @@
+//! Native Desktop Host implementation for `whisker-input`.
+//!
+//! The value, selection, marked text, and glyph raster live in this package.
+//! `whisker-desktop` only routes window focus, keyboard, clipboard, and IME
+//! messages through its generic editable-text seam.
+
+use std::fmt;
+use std::sync::{Mutex, OnceLock};
+
+use glyphon::{
+    Attrs, Buffer, Color as GlyphColor, Family, FontSystem, Metrics, Shaping, Style, SwashCache,
+    Weight, Wrap, cosmic_text::Cursor,
+};
+use unicode_segmentation::UnicodeSegmentation;
+use whisker_desktop::{
+    DesktopEventEmitter, DesktopNativeEvent, DesktopRaster, DesktopTextInputEvent,
+    DesktopTextInputKey, DesktopViewDefinition, ModuleDefinition, WhiskerModule, WhiskerTextStyle,
+    WhiskerValue,
+};
+use whisker_protocol::{MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, PaintColor};
+
+const MODULE_NAME: &str = "whisker-input:Input";
+
+struct RasterState {
+    cached: Option<CachedRaster>,
+}
+
+struct TextRasterizer {
+    font_system: FontSystem,
+    swash_cache: SwashCache,
+}
+
+struct CachedRaster {
+    generation: u64,
+    width: u32,
+    height: u32,
+    scale_bits: u32,
+    raster: DesktopRaster,
+}
+
+struct InputDesktopView {
+    emitter: DesktopEventEmitter,
+    value: String,
+    placeholder: String,
+    placeholder_color: String,
+    caret_color: String,
+    selection_color: String,
+    multiline: bool,
+    secure: bool,
+    editable: bool,
+    max_length: usize,
+    focused: bool,
+    selection: (usize, usize),
+    composition: Option<(usize, usize)>,
+    text_style: Option<WhiskerTextStyle>,
+    generation: u64,
+    raster: Mutex<RasterState>,
+}
+
+impl fmt::Debug for InputDesktopView {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("InputDesktopView")
+            .field("value", &self.value)
+            .field("focused", &self.focused)
+            .field("selection", &self.selection)
+            .finish_non_exhaustive()
+    }
+}
+
+impl InputDesktopView {
+    fn new(emitter: DesktopEventEmitter) -> Self {
+        Self {
+            emitter,
+            value: String::new(),
+            placeholder: String::new(),
+            placeholder_color: String::new(),
+            caret_color: String::new(),
+            selection_color: String::new(),
+            multiline: false,
+            secure: false,
+            editable: true,
+            max_length: 0,
+            focused: false,
+            selection: (0, 0),
+            composition: None,
+            text_style: None,
+            generation: 1,
+            raster: Mutex::new(RasterState { cached: None }),
+        }
+    }
+
+    fn invalidate(&mut self) {
+        self.generation = self.generation.wrapping_add(1).max(1);
+        self.raster
+            .lock()
+            .expect("Input raster lock poisoned")
+            .cached = None;
+    }
+
+    fn set_value(&mut self, value: &str) {
+        if self.value == value {
+            return;
+        }
+        self.value.clear();
+        self.value.push_str(value);
+        let end = self.value.len();
+        self.selection = (end, end);
+        self.composition = None;
+        self.invalidate();
+    }
+
+    fn set_focus(&mut self, focused: bool) {
+        if self.focused == focused || (focused && !self.editable) {
+            return;
+        }
+        self.focused = focused;
+        self.composition = None;
+        self.invalidate();
+        self.emitter.emit(DesktopNativeEvent {
+            event: if focused { "focus" } else { "blur" }.into(),
+            detail: WhiskerValue::Null,
+        });
+        if !focused {
+            self.emit_value("change");
+        }
+    }
+
+    fn emit_value(&self, event: &str) {
+        self.emitter.emit(DesktopNativeEvent {
+            event: event.into(),
+            detail: WhiskerValue::map([("value", WhiskerValue::String(self.value.clone()))]),
+        });
+    }
+
+    fn replace_selection(&mut self, inserted: &str) {
+        if !self.editable {
+            return;
+        }
+        let (start, end) = ordered(self.selection);
+        let available = if self.max_length == 0 {
+            usize::MAX
+        } else {
+            self.max_length.saturating_sub(
+                self.value[..start].chars().count() + self.value[end..].chars().count(),
+            )
+        };
+        let inserted = inserted.chars().take(available).collect::<String>();
+        self.value.replace_range(start..end, &inserted);
+        let caret = start + inserted.len();
+        self.selection = (caret, caret);
+        self.composition = None;
+        self.invalidate();
+        self.emit_value("input");
+    }
+
+    fn preedit(&mut self, text: &str, cursor: Option<(usize, usize)>) {
+        if !self.editable {
+            return;
+        }
+        if let Some(range) = self.composition.take() {
+            self.selection = range;
+        }
+        let (start, end) = ordered(self.selection);
+        let available = if self.max_length == 0 {
+            usize::MAX
+        } else {
+            self.max_length.saturating_sub(
+                self.value[..start].chars().count() + self.value[end..].chars().count(),
+            )
+        };
+        let inserted = text.chars().take(available).collect::<String>();
+        self.value.replace_range(start..end, &inserted);
+        let composition_end = start + inserted.len();
+        self.composition = (!inserted.is_empty()).then_some((start, composition_end));
+        let caret = cursor
+            .map(|(_, end)| start + char_boundary_at_or_before(&inserted, end.min(inserted.len())))
+            .unwrap_or(composition_end);
+        self.selection = (caret, caret);
+        self.invalidate();
+        self.emit_value("input");
+    }
+
+    fn commit(&mut self, text: &str) {
+        if let Some(range) = self.composition.take() {
+            self.selection = range;
+        }
+        self.replace_selection(text);
+    }
+
+    fn move_caret(&mut self, next: usize, shift: bool) {
+        let next = next.min(self.value.len());
+        self.selection = if shift {
+            (self.selection.0, next)
+        } else {
+            (next, next)
+        };
+        self.composition = None;
+        self.invalidate();
+    }
+
+    fn handle_key(&mut self, key: DesktopTextInputKey, shift: bool) {
+        let (start, end) = ordered(self.selection);
+        match key {
+            DesktopTextInputKey::Backspace if start != end => self.replace_selection(""),
+            DesktopTextInputKey::Backspace => {
+                let previous = previous_grapheme(&self.value, start);
+                self.selection = (previous, start);
+                self.replace_selection("");
+            }
+            DesktopTextInputKey::Delete if start != end => self.replace_selection(""),
+            DesktopTextInputKey::Delete => {
+                let next = next_grapheme(&self.value, end);
+                self.selection = (end, next);
+                self.replace_selection("");
+            }
+            DesktopTextInputKey::ArrowLeft => {
+                let next = if !shift && start != end {
+                    start
+                } else {
+                    previous_grapheme(&self.value, self.selection.1)
+                };
+                self.move_caret(next, shift);
+            }
+            DesktopTextInputKey::ArrowRight => {
+                let next = if !shift && start != end {
+                    end
+                } else {
+                    next_grapheme(&self.value, self.selection.1)
+                };
+                self.move_caret(next, shift);
+            }
+            DesktopTextInputKey::Home => self.move_caret(0, shift),
+            DesktopTextInputKey::End => self.move_caret(self.value.len(), shift),
+            DesktopTextInputKey::Enter if self.multiline => self.replace_selection("\n"),
+            DesktopTextInputKey::Enter => self.emit_value("submit"),
+        }
+    }
+
+    fn handle_input(&mut self, event: &DesktopTextInputEvent) {
+        match event {
+            DesktopTextInputEvent::Commit(text) => self.commit(text),
+            DesktopTextInputEvent::Preedit { text, cursor } => self.preedit(text, *cursor),
+            DesktopTextInputEvent::Key { key, shift } => self.handle_key(*key, *shift),
+            DesktopTextInputEvent::SelectAll => {
+                self.selection = (0, self.value.len());
+                self.invalidate();
+            }
+            DesktopTextInputEvent::Cut => {
+                let (start, end) = ordered(self.selection);
+                if start != end {
+                    self.replace_selection("");
+                }
+            }
+            DesktopTextInputEvent::Paste(text) => self.replace_selection(text),
+        }
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        let (start, end) = ordered(self.selection);
+        (start != end).then(|| self.value[start..end].to_owned())
+    }
+
+    fn rasterize(&self, width: u32, height: u32, scale: f32) -> Option<DesktopRaster> {
+        if width == 0 || height == 0 {
+            return None;
+        }
+        let mut state = self.raster.lock().expect("Input raster lock poisoned");
+        if let Some(cache) = &state.cached
+            && cache.generation == self.generation
+            && cache.width == width
+            && cache.height == height
+            && cache.scale_bits == scale.to_bits()
+        {
+            return Some(cache.raster.clone());
+        }
+        let mut text = text_rasterizer()
+            .lock()
+            .expect("Desktop text rasterizer lock poisoned");
+        let pixels = self.draw_pixels(&mut text, width, height, scale);
+        let raster = DesktopRaster::new(self.generation, width, height, pixels).ok()?;
+        state.cached = Some(CachedRaster {
+            generation: self.generation,
+            width,
+            height,
+            scale_bits: scale.to_bits(),
+            raster: raster.clone(),
+        });
+        Some(raster)
+    }
+
+    fn draw_pixels(
+        &self,
+        state: &mut TextRasterizer,
+        width: u32,
+        height: u32,
+        scale: f32,
+    ) -> Vec<u8> {
+        let mut pixels = vec![0; width as usize * height as usize * 4];
+        let default_style = whisker_protocol::TextMeasureStyle::default();
+        let style = self
+            .text_style
+            .as_ref()
+            .map_or(&default_style, |style| &style.style);
+        let font_size = style.font_size * scale;
+        let line_height = match style.line_height {
+            MeasureLineHeight::Normal => font_size * 1.2,
+            MeasureLineHeight::LogicalPixels(value) => value * scale,
+        };
+        let mut buffer = Buffer::new(&mut state.font_system, Metrics::new(font_size, line_height));
+        buffer.set_size(
+            &mut state.font_system,
+            Some(width as f32),
+            Some(height as f32),
+        );
+        buffer.set_wrap(
+            &mut state.font_system,
+            if self.multiline {
+                Wrap::Word
+            } else {
+                Wrap::None
+            },
+        );
+        let family = style
+            .font_families
+            .iter()
+            .map(|family| match family {
+                MeasureFontFamily::System => Family::SansSerif,
+                MeasureFontFamily::Named(name) => Family::Name(name),
+            })
+            .next()
+            .unwrap_or(Family::SansSerif);
+        let attrs = Attrs::new()
+            .family(family)
+            .weight(Weight(style.font_weight))
+            .style(match style.font_style {
+                MeasureFontStyle::Normal => Style::Normal,
+                MeasureFontStyle::Italic => Style::Italic,
+                MeasureFontStyle::Oblique => Style::Oblique,
+            });
+        let placeholder = self.value.is_empty() && !self.placeholder.is_empty();
+        let display = if placeholder {
+            self.placeholder.clone()
+        } else if self.secure {
+            "•".repeat(self.value.chars().count())
+        } else {
+            self.value.clone()
+        };
+        buffer.set_text(&mut state.font_system, &display, &attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut state.font_system, false);
+
+        if self.focused && !placeholder {
+            let (start, end) = ordered(self.selection);
+            let start = text_cursor(&display, self.display_offset(start));
+            let end = text_cursor(&display, self.display_offset(end));
+            for run in buffer.layout_runs() {
+                if let Some((x, w)) = run.highlight(start, end) {
+                    fill_rect(
+                        &mut pixels,
+                        width,
+                        height,
+                        x.floor() as i32,
+                        run.line_top.floor() as i32,
+                        w.ceil().max(1.0) as u32,
+                        run.line_height.ceil() as u32,
+                        parse_css_color(&self.selection_color, [51, 132, 255, 92]),
+                    );
+                }
+            }
+        }
+
+        let foreground = if placeholder {
+            parse_css_color(&self.placeholder_color, [128, 128, 128, 255])
+        } else {
+            self.text_style
+                .as_ref()
+                .map_or([0, 0, 0, 255], |style| paint_color(&style.paint.foreground))
+        };
+        buffer.draw(
+            &mut state.font_system,
+            &mut state.swash_cache,
+            GlyphColor::rgba(foreground[0], foreground[1], foreground[2], foreground[3]),
+            |x, y, w, h, color| {
+                fill_rect(&mut pixels, width, height, x, y, w, h, color.as_rgba());
+            },
+        );
+
+        if self.focused {
+            let cursor = self.display_offset(self.selection.1);
+            let cursor = text_cursor(&display, cursor.min(display.len()));
+            let mut caret = None;
+            for run in buffer.layout_runs() {
+                if let Some((x, _)) = run.highlight(cursor, cursor) {
+                    caret = Some((x, run.line_top, run.line_height));
+                }
+            }
+            let (x, y, h) = caret.unwrap_or((0.0, 0.0, line_height));
+            fill_rect(
+                &mut pixels,
+                width,
+                height,
+                x.floor() as i32,
+                y.floor() as i32,
+                scale.ceil().max(1.0) as u32,
+                h.ceil() as u32,
+                parse_css_color(&self.caret_color, [0, 122, 255, 255]),
+            );
+        }
+        pixels
+    }
+
+    fn display_offset(&self, value_offset: usize) -> usize {
+        if self.secure {
+            self.value[..value_offset].chars().count() * '•'.len_utf8()
+        } else {
+            value_offset
+        }
+    }
+
+    fn clear(&mut self) {
+        self.selection = (0, self.value.len());
+        self.replace_selection("");
+    }
+}
+
+fn text_rasterizer() -> &'static Mutex<TextRasterizer> {
+    static RASTERIZER: OnceLock<Mutex<TextRasterizer>> = OnceLock::new();
+    RASTERIZER.get_or_init(|| {
+        Mutex::new(TextRasterizer {
+            font_system: FontSystem::new(),
+            swash_cache: SwashCache::new(),
+        })
+    })
+}
+
+struct InputModule;
+
+#[whisker_desktop::WhiskerModule]
+impl WhiskerModule for InputModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new().name(MODULE_NAME).view(
+            DesktopViewDefinition::new(MODULE_NAME, InputDesktopView::new)
+                .prop(
+                    "value",
+                    set_string(|view, value| view.set_value(value)),
+                    |view| view.set_value(""),
+                )
+                .prop(
+                    "placeholder",
+                    set_string(|view, value| {
+                        view.placeholder = value.into();
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.placeholder.clear();
+                        view.invalidate();
+                    },
+                )
+                .prop(
+                    "placeholder-color",
+                    set_string(|view, value| {
+                        view.placeholder_color = value.into();
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.placeholder_color.clear();
+                        view.invalidate();
+                    },
+                )
+                .prop(
+                    "caret-color",
+                    set_string(|view, value| {
+                        view.caret_color = value.into();
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.caret_color.clear();
+                        view.invalidate();
+                    },
+                )
+                .prop(
+                    "selection-color",
+                    set_string(|view, value| {
+                        view.selection_color = value.into();
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.selection_color.clear();
+                        view.invalidate();
+                    },
+                )
+                .prop(
+                    "multiline",
+                    set_bool(|view, value| {
+                        view.multiline = value;
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.multiline = false;
+                        view.invalidate();
+                    },
+                )
+                .prop("lines", |_, value| assert_int(value), |_| {})
+                .prop(
+                    "secure",
+                    set_bool(|view, value| {
+                        view.secure = value;
+                        view.invalidate();
+                    }),
+                    |view| {
+                        view.secure = false;
+                        view.invalidate();
+                    },
+                )
+                .prop(
+                    "editable",
+                    set_bool(|view, value| {
+                        view.editable = value;
+                        if !value {
+                            view.set_focus(false);
+                        }
+                    }),
+                    |view| view.editable = true,
+                )
+                .prop(
+                    "auto-focus",
+                    set_bool(|view, value| {
+                        if value {
+                            view.set_focus(true);
+                        }
+                    }),
+                    |_| {},
+                )
+                .prop(
+                    "max-length",
+                    |view, value| view.max_length = expect_int(value).max(0) as usize,
+                    |view| view.max_length = 0,
+                )
+                .prop("keyboard-type", set_string(|_, _| {}), |_| {})
+                .prop("return-key", set_string(|_, _| {}), |_| {})
+                .prop("auto-capitalize", set_string(|_, _| {}), |_| {})
+                .prop("autocorrect", set_bool(|_, _| {}), |_| {})
+                .prop("spell-check", set_bool(|_, _| {}), |_| {})
+                .event("input")
+                .event("change")
+                .event("focus")
+                .event("blur")
+                .event("submit")
+                .command("focus", |view, _| view.set_focus(true))
+                .command("blur", |view, _| view.set_focus(false))
+                .command("clear", |view, _| view.clear())
+                .command("setValue", |view, arguments| {
+                    let WhiskerValue::Map(arguments) = arguments else {
+                        return;
+                    };
+                    if let Some(WhiskerValue::String(value)) = arguments.get("value") {
+                        view.set_value(value);
+                    }
+                })
+                .text_style(|view, style| {
+                    view.text_style = Some(style.clone());
+                    view.invalidate();
+                })
+                .text_input(
+                    |view| view.focused,
+                    InputDesktopView::set_focus,
+                    InputDesktopView::handle_input,
+                    InputDesktopView::selected_text,
+                )
+                .raster_scaled(InputDesktopView::rasterize),
+        )
+    }
+}
+
+fn set_string(
+    update: impl Fn(&mut InputDesktopView, &str) + Send + Sync + 'static,
+) -> impl Fn(&mut InputDesktopView, &WhiskerValue) + Send + Sync + 'static {
+    move |view, value| {
+        let WhiskerValue::String(value) = value else {
+            unreachable!("Desktop Host validates Input string property")
+        };
+        update(view, value);
+    }
+}
+
+fn set_bool(
+    update: impl Fn(&mut InputDesktopView, bool) + Send + Sync + 'static,
+) -> impl Fn(&mut InputDesktopView, &WhiskerValue) + Send + Sync + 'static {
+    move |view, value| {
+        let WhiskerValue::Bool(value) = value else {
+            unreachable!("Desktop Host validates Input boolean property")
+        };
+        update(view, *value);
+    }
+}
+
+fn assert_int(value: &WhiskerValue) {
+    let WhiskerValue::Int(_) = value else {
+        unreachable!("Desktop Host validates Input integer property")
+    };
+}
+
+fn expect_int(value: &WhiskerValue) -> i64 {
+    let WhiskerValue::Int(value) = value else {
+        unreachable!("Desktop Host validates Input integer property")
+    };
+    *value
+}
+
+fn ordered(selection: (usize, usize)) -> (usize, usize) {
+    if selection.0 <= selection.1 {
+        selection
+    } else {
+        (selection.1, selection.0)
+    }
+}
+
+fn previous_grapheme(value: &str, offset: usize) -> usize {
+    value[..offset]
+        .grapheme_indices(true)
+        .next_back()
+        .map_or(0, |(index, _)| index)
+}
+
+fn next_grapheme(value: &str, offset: usize) -> usize {
+    value[offset..]
+        .grapheme_indices(true)
+        .nth(1)
+        .map_or(value.len(), |(index, _)| offset + index)
+}
+
+fn char_boundary_at_or_before(value: &str, mut offset: usize) -> usize {
+    while !value.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn text_cursor(text: &str, offset: usize) -> Cursor {
+    let mut line = 0;
+    let mut line_start = 0;
+    for (index, byte) in text.bytes().enumerate() {
+        if index >= offset {
+            break;
+        }
+        if byte == b'\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+    Cursor::new(line, offset.saturating_sub(line_start))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fill_rect(
+    pixels: &mut [u8],
+    canvas_width: u32,
+    canvas_height: u32,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    color: [u8; 4],
+) {
+    let right = x
+        .saturating_add(width as i32)
+        .max(0)
+        .min(canvas_width as i32) as u32;
+    let bottom = y
+        .saturating_add(height as i32)
+        .max(0)
+        .min(canvas_height as i32) as u32;
+    for py in y.max(0) as u32..bottom {
+        for px in x.max(0) as u32..right {
+            let index = ((py * canvas_width + px) * 4) as usize;
+            let source_alpha = color[3] as f32 / 255.0;
+            let destination_alpha = pixels[index + 3] as f32 / 255.0;
+            let output_alpha = source_alpha + destination_alpha * (1.0 - source_alpha);
+            if output_alpha > 0.0 {
+                for channel in 0..3 {
+                    let source = color[channel] as f32 / 255.0;
+                    let destination = pixels[index + channel] as f32 / 255.0;
+                    pixels[index + channel] = (((source * source_alpha
+                        + destination * destination_alpha * (1.0 - source_alpha))
+                        / output_alpha)
+                        * 255.0)
+                        .round() as u8;
+                }
+            }
+            pixels[index + 3] = (output_alpha * 255.0).round() as u8;
+        }
+    }
+}
+
+fn parse_css_color(value: &str, fallback: [u8; 4]) -> [u8; 4] {
+    if value.trim().is_empty() {
+        return fallback;
+    }
+    csscolorparser::parse(value).map_or(fallback, |color| color.to_rgba8())
+}
+
+fn paint_color(value: &PaintColor) -> [u8; 4] {
+    match value {
+        PaintColor::Named(name) => parse_css_color(name, [0, 0, 0, 255]),
+        PaintColor::Srgba {
+            red,
+            green,
+            blue,
+            alpha,
+        } => [*red, *green, *blue, (*alpha * 255.0).round() as u8],
+        PaintColor::Hsla {
+            hue_degrees,
+            saturation,
+            lightness,
+            alpha,
+        } => parse_css_color(
+            &format!("hsla({hue_degrees}, {saturation}%, {lightness}%, {alpha})"),
+            [0, 0, 0, 255],
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn editing_is_grapheme_safe_and_emits_typed_values() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.set_value("a👨‍👩‍👧‍👦");
+        input.handle_key(DesktopTextInputKey::Backspace, false);
+        assert_eq!(input.value, "a");
+    }
+
+    #[test]
+    fn module_exports_one_editable_raster_element() {
+        assert_eq!(InputModule::definition().factories().len(), 1);
+    }
+
+    #[test]
+    fn secure_display_offsets_follow_original_selection() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.set_value("aé日");
+        input.secure = true;
+
+        assert_eq!(input.display_offset(0), 0);
+        assert_eq!(input.display_offset(1), '•'.len_utf8());
+        assert_eq!(input.display_offset(3), 2 * '•'.len_utf8());
+        assert_eq!(input.display_offset(input.value.len()), 3 * '•'.len_utf8());
+    }
+
+    #[test]
+    fn raster_pixels_keep_straight_alpha_color_channels() {
+        let mut pixels = vec![0; 4];
+        fill_rect(&mut pixels, 1, 1, 0, 0, 1, 1, [120, 80, 40, 128]);
+
+        assert_eq!(pixels, [120, 80, 40, 128]);
+    }
+
+    #[test]
+    fn preedit_respects_max_length_and_utf8_cursor_boundaries() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.max_length = 2;
+        input.preedit("é日x", Some((0, 1)));
+
+        assert_eq!(input.value, "é日");
+        assert_eq!(input.selection, (0, 0));
+        assert_eq!(input.composition, Some((0, "é日".len())));
+    }
+}

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -388,13 +388,7 @@ impl InputDesktopView {
         if self.focused {
             let cursor = self.display_offset(self.selection.1);
             let cursor = text_cursor(&display, cursor.min(display.len()));
-            let mut caret = None;
-            for run in buffer.layout_runs() {
-                if let Some((x, _)) = run.highlight(cursor, cursor) {
-                    caret = Some((x, run.line_top, run.line_height));
-                }
-            }
-            let (x, y, h) = caret.unwrap_or((0.0, 0.0, line_height));
+            let (x, y, h) = caret_geometry(&buffer, cursor, line_height);
             fill_rect(
                 &mut pixels,
                 width,
@@ -653,6 +647,24 @@ fn text_cursor(text: &str, offset: usize) -> Cursor {
     Cursor::new(line, offset.saturating_sub(line_start))
 }
 
+fn caret_geometry(buffer: &Buffer, cursor: Cursor, line_height: f32) -> (f32, f32, f32) {
+    let mut cursor_line = None;
+    let mut content_bottom = 0.0_f32;
+    for run in buffer.layout_runs() {
+        content_bottom = content_bottom.max(run.line_top + run.line_height);
+        if run.line_i == cursor.line {
+            // An empty line has no glyph boundary for `highlight` to return.
+            // Keeping the latest run also puts a wrapped line's end on its
+            // final visual row if glyph lookup cannot resolve the cursor.
+            cursor_line = Some((run.line_w, run.line_top, run.line_height));
+        }
+        if let Some((x, _)) = run.highlight(cursor, cursor) {
+            return (x, run.line_top, run.line_height);
+        }
+    }
+    cursor_line.unwrap_or((0.0, content_bottom, line_height))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn fill_rect(
     pixels: &mut [u8],
@@ -768,5 +780,56 @@ mod tests {
         assert_eq!(input.value, "é日");
         assert_eq!(input.selection, (0, 0));
         assert_eq!(input.composition, Some((0, "é日".len())));
+    }
+
+    #[test]
+    fn multiline_accepts_text_after_a_trailing_newline() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.multiline = true;
+        input.set_value("test");
+
+        input.handle_input(&DesktopTextInputEvent::Key {
+            key: DesktopTextInputKey::Enter,
+            shift: false,
+        });
+        assert_eq!(input.value, "test\n");
+        assert_eq!(input.selection, (5, 5));
+
+        input.handle_input(&DesktopTextInputEvent::Preedit {
+            text: "に".into(),
+            cursor: Some((0, "に".len())),
+        });
+        assert_eq!(input.value, "test\nに");
+        assert_eq!(input.selection, (8, 8));
+
+        input.handle_input(&DesktopTextInputEvent::Commit("next".into()));
+        assert_eq!(input.value, "test\nnext");
+        assert_eq!(input.selection, (9, 9));
+    }
+
+    #[test]
+    fn multiline_draws_the_caret_on_a_trailing_empty_line() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.multiline = true;
+        input.set_focus(true);
+        input.set_value("test\n");
+
+        let raster = input.rasterize(200, 100, 1.0).expect("input raster");
+        let caret = [0, 122, 255, 255];
+        let caret_rows = raster
+            .pixels()
+            .chunks_exact(4)
+            .enumerate()
+            .filter_map(|(index, pixel)| (pixel == caret).then_some(index / 200))
+            .collect::<Vec<_>>();
+
+        assert!(!caret_rows.is_empty(), "focused input draws its caret");
+        let first_caret_row = caret_rows.iter().copied().min().unwrap();
+        let first_line_height =
+            (whisker_protocol::TextMeasureStyle::default().font_size * 1.2).floor() as usize;
+        assert!(
+            first_caret_row >= first_line_height,
+            "the trailing-line caret must be below the first line; got row {first_caret_row}"
+        );
     }
 }

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -1015,6 +1015,26 @@ mod tests {
     }
 
     #[test]
+    fn ime_caret_rect_tracks_a_selection_inside_the_line() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.set_focus(true);
+        input.set_value("candidate");
+        let end = input.text_input_caret_rect([240.0, 40.0], 2.0);
+
+        input.move_caret("cand".len(), false);
+        let middle = input.text_input_caret_rect([240.0, 40.0], 2.0);
+
+        assert!(
+            middle.x > 10.0,
+            "caret follows preceding glyphs: {middle:?}"
+        );
+        assert!(
+            middle.x < end.x,
+            "caret does not stay at line end: {middle:?}"
+        );
+    }
+
+    #[test]
     fn ime_caret_rect_tracks_the_current_multiline_row() {
         let mut input = InputDesktopView::new(DesktopEventEmitter::default());
         input.multiline = true;

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -385,10 +385,37 @@ impl InputDesktopView {
             },
         );
 
+        if self.focused
+            && !placeholder
+            && let Some((start, end)) = self.composition.map(ordered)
+        {
+            let start = text_cursor(&display, self.display_offset(start));
+            let end = text_cursor(&display, self.display_offset(end));
+            let thickness = scale.ceil().max(1.0);
+            for run in buffer.layout_runs() {
+                if let Some((x, highlight_width)) = run.highlight(start, end) {
+                    fill_rect(
+                        &mut pixels,
+                        width,
+                        height,
+                        x.floor() as i32,
+                        (run.line_top + run.line_height - thickness).floor() as i32,
+                        highlight_width.ceil().max(1.0) as u32,
+                        thickness as u32,
+                        foreground,
+                    );
+                }
+            }
+        }
+
         if self.focused {
-            let cursor = self.display_offset(self.selection.1);
-            let cursor = text_cursor(&display, cursor.min(display.len()));
-            let (x, y, h) = caret_geometry(&buffer, cursor, line_height);
+            let (x, y, h) = if placeholder {
+                (0.0, 0.0, line_height)
+            } else {
+                let cursor = self.display_offset(self.selection.1);
+                let cursor = text_cursor(&display, cursor.min(display.len()));
+                caret_geometry(&buffer, cursor, line_height)
+            };
             fill_rect(
                 &mut pixels,
                 width,
@@ -830,6 +857,48 @@ mod tests {
         assert!(
             first_caret_row >= first_line_height,
             "the trailing-line caret must be below the first line; got row {first_caret_row}"
+        );
+    }
+
+    #[test]
+    fn placeholder_keeps_the_empty_value_caret_at_the_start() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.placeholder = "Type something...".into();
+        input.set_focus(true);
+
+        let raster = input.rasterize(240, 40, 1.0).expect("input raster");
+        let caret = [0, 122, 255, 255];
+        let caret_columns = raster
+            .pixels()
+            .chunks_exact(4)
+            .enumerate()
+            .filter_map(|(index, pixel)| (pixel == caret).then_some(index % 240))
+            .collect::<Vec<_>>();
+
+        assert!(!caret_columns.is_empty(), "focused input draws its caret");
+        assert_eq!(caret_columns.iter().copied().min(), Some(0));
+    }
+
+    #[test]
+    fn preedit_raster_underlines_the_composition_range() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.set_focus(true);
+        input.preedit("IME", Some((0, 3)));
+
+        let raster = input.rasterize(200, 40, 1.0).expect("input raster");
+        let underline_row =
+            (whisker_protocol::TextMeasureStyle::default().font_size * 1.2).floor() as usize - 1;
+        let opaque_pixels = raster
+            .pixels()
+            .chunks_exact(4)
+            .skip(underline_row * 200)
+            .take(200)
+            .filter(|pixel| pixel[3] == 255)
+            .count();
+
+        assert!(
+            opaque_pixels >= 8,
+            "IME composition draws a visible underline; got {opaque_pixels} opaque pixels"
         );
     }
 }

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -30,12 +30,27 @@ struct TextRasterizer {
     swash_cache: SwashCache,
 }
 
+struct InputTextLayout {
+    buffer: Buffer,
+    display: String,
+    placeholder: bool,
+    line_height: f32,
+}
+
+#[derive(Clone, Copy)]
+struct CaretGeometry {
+    x: f32,
+    y: f32,
+    height: f32,
+}
+
 struct CachedRaster {
     generation: u64,
     width: u32,
     height: u32,
     scale_bits: u32,
     raster: DesktopRaster,
+    caret_rect: whisker_protocol::LayoutRect,
 }
 
 struct InputDesktopView {
@@ -277,7 +292,7 @@ impl InputDesktopView {
         let mut text = text_rasterizer()
             .lock()
             .expect("Desktop text rasterizer lock poisoned");
-        let pixels = self.draw_pixels(&mut text, width, height, scale);
+        let (pixels, caret_rect) = self.draw_pixels(&mut text, width, height, scale);
         let raster = DesktopRaster::new(self.generation, width, height, pixels).ok()?;
         state.cached = Some(CachedRaster {
             generation: self.generation,
@@ -285,6 +300,7 @@ impl InputDesktopView {
             height,
             scale_bits: scale.to_bits(),
             raster: raster.clone(),
+            caret_rect,
         });
         Some(raster)
     }
@@ -295,59 +311,16 @@ impl InputDesktopView {
         width: u32,
         height: u32,
         scale: f32,
-    ) -> Vec<u8> {
+    ) -> (Vec<u8>, whisker_protocol::LayoutRect) {
         let mut pixels = vec![0; width as usize * height as usize * 4];
-        let default_style = whisker_protocol::TextMeasureStyle::default();
-        let style = self
-            .text_style
-            .as_ref()
-            .map_or(&default_style, |style| &style.style);
-        let font_size = style.font_size * scale;
-        let line_height = match style.line_height {
-            MeasureLineHeight::Normal => font_size * 1.2,
-            MeasureLineHeight::LogicalPixels(value) => value * scale,
-        };
-        let mut buffer = Buffer::new(&mut state.font_system, Metrics::new(font_size, line_height));
-        buffer.set_size(
-            &mut state.font_system,
-            Some(width as f32),
-            Some(height as f32),
-        );
-        buffer.set_wrap(
-            &mut state.font_system,
-            if self.multiline {
-                Wrap::Word
-            } else {
-                Wrap::None
-            },
-        );
-        let family = style
-            .font_families
-            .iter()
-            .map(|family| match family {
-                MeasureFontFamily::System => Family::SansSerif,
-                MeasureFontFamily::Named(name) => Family::Name(name),
-            })
-            .next()
-            .unwrap_or(Family::SansSerif);
-        let attrs = Attrs::new()
-            .family(family)
-            .weight(Weight(style.font_weight))
-            .style(match style.font_style {
-                MeasureFontStyle::Normal => Style::Normal,
-                MeasureFontStyle::Italic => Style::Italic,
-                MeasureFontStyle::Oblique => Style::Oblique,
-            });
-        let placeholder = self.value.is_empty() && !self.placeholder.is_empty();
-        let display = if placeholder {
-            self.placeholder.clone()
-        } else if self.secure {
-            "•".repeat(self.value.chars().count())
-        } else {
-            self.value.clone()
-        };
-        buffer.set_text(&mut state.font_system, &display, &attrs, Shaping::Advanced);
-        buffer.shape_until_scroll(&mut state.font_system, false);
+        let InputTextLayout {
+            buffer,
+            display,
+            placeholder,
+            line_height,
+        } = self.layout_text(state, width, height, scale);
+
+        let caret = self.caret_geometry(&buffer, &display, placeholder, line_height);
 
         if self.focused && !placeholder {
             let (start, end) = ordered(self.selection);
@@ -409,25 +382,149 @@ impl InputDesktopView {
         }
 
         if self.focused {
-            let (x, y, h) = if placeholder {
-                (0.0, 0.0, line_height)
-            } else {
-                let cursor = self.display_offset(self.selection.1);
-                let cursor = text_cursor(&display, cursor.min(display.len()));
-                caret_geometry(&buffer, cursor, line_height)
-            };
             fill_rect(
                 &mut pixels,
                 width,
                 height,
-                x.floor() as i32,
-                y.floor() as i32,
+                caret.x.floor() as i32,
+                caret.y.floor() as i32,
                 scale.ceil().max(1.0) as u32,
-                h.ceil() as u32,
+                caret.height.ceil() as u32,
                 parse_css_color(&self.caret_color, [0, 122, 255, 255]),
             );
         }
-        pixels
+        (
+            pixels,
+            whisker_protocol::LayoutRect {
+                x: caret.x / scale,
+                y: caret.y / scale,
+                width: 1.0,
+                height: caret.height / scale,
+            },
+        )
+    }
+
+    fn layout_text(
+        &self,
+        state: &mut TextRasterizer,
+        width: u32,
+        height: u32,
+        scale: f32,
+    ) -> InputTextLayout {
+        let default_style = whisker_protocol::TextMeasureStyle::default();
+        let style = self
+            .text_style
+            .as_ref()
+            .map_or(&default_style, |style| &style.style);
+        let font_size = style.font_size * scale;
+        let line_height = match style.line_height {
+            MeasureLineHeight::Normal => font_size * 1.2,
+            MeasureLineHeight::LogicalPixels(value) => value * scale,
+        };
+        let mut buffer = Buffer::new(&mut state.font_system, Metrics::new(font_size, line_height));
+        buffer.set_size(
+            &mut state.font_system,
+            Some(width as f32),
+            Some(height as f32),
+        );
+        buffer.set_wrap(
+            &mut state.font_system,
+            if self.multiline {
+                Wrap::Word
+            } else {
+                Wrap::None
+            },
+        );
+        let family = style
+            .font_families
+            .iter()
+            .map(|family| match family {
+                MeasureFontFamily::System => Family::SansSerif,
+                MeasureFontFamily::Named(name) => Family::Name(name),
+            })
+            .next()
+            .unwrap_or(Family::SansSerif);
+        let attrs = Attrs::new()
+            .family(family)
+            .weight(Weight(style.font_weight))
+            .style(match style.font_style {
+                MeasureFontStyle::Normal => Style::Normal,
+                MeasureFontStyle::Italic => Style::Italic,
+                MeasureFontStyle::Oblique => Style::Oblique,
+            });
+        let placeholder = self.value.is_empty() && !self.placeholder.is_empty();
+        let display = if placeholder {
+            self.placeholder.clone()
+        } else if self.secure {
+            "•".repeat(self.value.chars().count())
+        } else {
+            self.value.clone()
+        };
+        buffer.set_text(&mut state.font_system, &display, &attrs, Shaping::Advanced);
+        buffer.shape_until_scroll(&mut state.font_system, false);
+        InputTextLayout {
+            buffer,
+            display,
+            placeholder,
+            line_height,
+        }
+    }
+
+    fn caret_geometry(
+        &self,
+        buffer: &Buffer,
+        display: &str,
+        placeholder: bool,
+        line_height: f32,
+    ) -> CaretGeometry {
+        let (x, y, height) = if placeholder {
+            (0.0, 0.0, line_height)
+        } else {
+            let cursor = self.display_offset(self.selection.1);
+            let cursor = text_cursor(display, cursor.min(display.len()));
+            caret_geometry(buffer, cursor, line_height)
+        };
+        CaretGeometry { x, y, height }
+    }
+
+    fn text_input_caret_rect(
+        &self,
+        logical_size: [f32; 2],
+        scale: f32,
+    ) -> whisker_protocol::LayoutRect {
+        let width = (logical_size[0] * scale).ceil().max(1.0) as u32;
+        let height = (logical_size[1] * scale).ceil().max(1.0) as u32;
+        if let Some(cached) = self
+            .raster
+            .lock()
+            .expect("Input raster lock poisoned")
+            .cached
+            .as_ref()
+            .filter(|cached| {
+                cached.generation == self.generation
+                    && cached.width == width
+                    && cached.height == height
+                    && cached.scale_bits == scale.to_bits()
+            })
+        {
+            return cached.caret_rect;
+        }
+        let mut state = text_rasterizer()
+            .lock()
+            .expect("Desktop text rasterizer lock poisoned");
+        let layout = self.layout_text(&mut state, width, height, scale);
+        let caret = self.caret_geometry(
+            &layout.buffer,
+            &layout.display,
+            layout.placeholder,
+            layout.line_height,
+        );
+        whisker_protocol::LayoutRect {
+            x: caret.x / scale,
+            y: caret.y / scale,
+            width: 1.0,
+            height: caret.height / scale,
+        }
     }
 
     fn display_offset(&self, value_offset: usize) -> usize {
@@ -590,6 +687,7 @@ impl WhiskerModule for InputModule {
                     InputDesktopView::handle_input,
                     InputDesktopView::selected_text,
                 )
+                .text_input_caret_rect(InputDesktopView::text_input_caret_rect)
                 .raster_scaled(InputDesktopView::rasterize),
         )
     }
@@ -900,5 +998,32 @@ mod tests {
             opaque_pixels >= 8,
             "IME composition draws a visible underline; got {opaque_pixels} opaque pixels"
         );
+    }
+
+    #[test]
+    fn ime_caret_rect_tracks_the_text_end_in_logical_pixels() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.set_focus(true);
+        input.set_value("candidate");
+
+        let rect = input.text_input_caret_rect([240.0, 40.0], 2.0);
+
+        assert!(rect.x > 40.0, "caret follows the shaped text: {rect:?}");
+        assert_eq!(rect.y, 0.0);
+        assert_eq!(rect.width, 1.0);
+        assert!(rect.height > 10.0 && rect.height < 30.0);
+    }
+
+    #[test]
+    fn ime_caret_rect_tracks_the_current_multiline_row() {
+        let mut input = InputDesktopView::new(DesktopEventEmitter::default());
+        input.multiline = true;
+        input.set_focus(true);
+        input.set_value("first\nsecond");
+
+        let rect = input.text_input_caret_rect([240.0, 100.0], 2.0);
+
+        assert!(rect.x > 30.0, "caret follows second-line text: {rect:?}");
+        assert!(rect.y > 10.0, "caret follows the second row: {rect:?}");
     }
 }

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
@@ -36,25 +36,25 @@ public final class InputModule: Module {
                 // ---- Layout mode -----------------------------------------
 
                 Prop("multiline") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setMultiline(value.asString ?? "false")
+                    view.setMultiline(value.asBool ?? false)
                 }
                 Prop("lines") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setLines(value.asString ?? "0")
+                    view.setLines(value.asInt ?? 0)
                 }
 
                 // ---- Input behaviour -------------------------------------
 
                 Prop("secure") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setSecure(value.asString ?? "false")
+                    view.setSecure(value.asBool ?? false)
                 }
                 Prop("editable") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setEditable(value.asString ?? "true")
+                    view.setEditable(value.asBool ?? true)
                 }
                 Prop("auto-focus") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setAutoFocus(value.asString ?? "false")
+                    view.setAutoFocus(value.asBool ?? false)
                 }
                 Prop("max-length") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setMaxLength(value.asString ?? "0")
+                    view.setMaxLength(value.asInt ?? 0)
                 }
 
                 // ---- Keyboard / return key -------------------------------
@@ -69,10 +69,10 @@ public final class InputModule: Module {
                     view.setAutoCapitalize(value.asString ?? "sentences")
                 }
                 Prop("autocorrect") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setAutocorrect(value.asString ?? "true")
+                    view.setAutocorrect(value.asBool ?? true)
                 }
                 Prop("spell-check") { (view: WhiskerInputView, value: WhiskerValue) in
-                    view.setSpellCheck(value.asString ?? "true")
+                    view.setSpellCheck(value.asBool ?? true)
                 }
 
                 TextStyle { (view: WhiskerInputView, style: WhiskerTextStyle) in

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -311,33 +311,32 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
 
     // ---- Layout mode ---------------------------------------------------
 
-    public func setMultiline(_ s: String) {
-        let want = (s == "true")
-        ensureControl(multiline: want)
+    public func setMultiline(_ multiline: Bool) {
+        ensureControl(multiline: multiline)
     }
 
-    public func setLines(_ s: String) {
+    public func setLines(_ lines: Int64) {
         // Deliberately inert: `UITextView` has no visible-line-count API,
         // and CSS `height` / `min-height` is the authoritative sizing.
-        _ = Int(s) ?? 0
+        _ = lines
     }
 
     // ---- Input behaviour -----------------------------------------------
 
-    public func setSecure(_ s: String) {
-        cachedSecure = (s == "true")
+    public func setSecure(_ secure: Bool) {
+        cachedSecure = secure
         textField?.isSecureTextEntry = cachedSecure
         // UITextView doesn't support secure entry.
     }
 
-    public func setEditable(_ s: String) {
-        cachedEditable = (s != "false")
+    public func setEditable(_ editable: Bool) {
+        cachedEditable = editable
         textField?.isEnabled = cachedEditable
         textView?.isEditable = cachedEditable
     }
 
-    public func setAutoFocus(_ s: String) {
-        cachedAutoFocus = (s == "true")
+    public func setAutoFocus(_ autoFocus: Bool) {
+        cachedAutoFocus = autoFocus
         if cachedAutoFocus && controlBuilt {
             DispatchQueue.main.async { [weak self] in
                 self?.textField?.becomeFirstResponder()
@@ -346,8 +345,8 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         }
     }
 
-    public func setMaxLength(_ s: String) {
-        cachedMaxLength = Int(s) ?? 0   // enforced in delegate callbacks
+    public func setMaxLength(_ count: Int64) {
+        cachedMaxLength = max(0, Int(clamping: count)) // enforced in delegate callbacks
     }
 
     // ---- Keyboard / return key -----------------------------------------
@@ -374,16 +373,16 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         if textView?.isFirstResponder == true { textView?.reloadInputViews() }
     }
 
-    public func setAutocorrect(_ s: String) {
-        cachedAutocorrect = (s == "false") ? .no : .default
+    public func setAutocorrect(_ enabled: Bool) {
+        cachedAutocorrect = enabled ? .default : .no
         textField?.autocorrectionType = cachedAutocorrect
         textView?.autocorrectionType = cachedAutocorrect
         if textField?.isFirstResponder == true { textField?.reloadInputViews() }
         if textView?.isFirstResponder == true { textView?.reloadInputViews() }
     }
 
-    public func setSpellCheck(_ s: String) {
-        cachedSpellCheck = (s == "false") ? .no : .default
+    public func setSpellCheck(_ enabled: Bool) {
+        cachedSpellCheck = enabled ? .default : .no
         textField?.spellCheckingType = cachedSpellCheck
         textView?.spellCheckingType = cachedSpellCheck
         if textField?.isFirstResponder == true { textField?.reloadInputViews() }

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -409,8 +409,8 @@ pub fn native_input(
     style: Style,
     on_input: InputEvent,
     on_change: InputEvent,
-    on_focus: InputEvent,
-    on_blur: InputEvent,
+    on_focus: (),
+    on_blur: (),
     on_submit: InputEvent,
 ) {
 }
@@ -548,7 +548,7 @@ pub fn input(
         .unwrap_or_else(ElementRef::new);
 
     let on_focus_cb = {
-        move |_ev: InputEvent| {
+        move || {
             // `whisker-router` reads this registry to blur/restore this exact
             // input across a navigation.
             whisker::focus::note_focused(element_ref);
@@ -558,7 +558,7 @@ pub fn input(
         }
     };
     let on_blur_cb = {
-        move |_ev: InputEvent| {
+        move || {
             whisker::focus::note_blurred(element_ref);
             if let Some(cb) = on_blur {
                 cb.call();

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -1,8 +1,9 @@
-//! `whisker-input` — native text-input component.
+//! `whisker-input` — cross-platform text-input component.
 //!
 //! **API shape — 2 (Component + ref-bound handle).** A native UI
-//! element ([`Input`]) backed by `UITextField` / `UITextView` on iOS
-//! and `EditText` on Android, with a Leptos-style **two-way binding**
+//! element ([`Input`]) backed by native controls on iOS, Android, and Web,
+//! plus Whisker's GPU-rendered editable-text implementation on Desktop,
+//! with a Leptos-style **two-way binding**
 //! as the headline API plus a typed imperative handle ([`InputRef`])
 //! bound on mount via `element_ref:` for `focus` / `blur` / `clear` /
 //! `setValue`.
@@ -144,12 +145,14 @@
 //!   (view: `InputView.swift`)
 //! - Android: `packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt`
 //!   (view: `WhiskerInputView.kt`)
-
-use std::rc::Rc;
+//! - Web: `packages/whisker-input/web/src/lib.rs`
+//! - Desktop: `packages/whisker-input/desktop/src/lib.rs` (shared by macOS,
+//!   Windows, and Linux; OS keyboard/IME events enter through
+//!   `platforms/desktop`)
 
 use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
-use whisker::{ElementRef, Signal, Style};
+use whisker::{Callback, ElementRef, Signal, Style};
 
 /// Payload of an input event (`input` / `change` / `submit`).
 ///
@@ -184,49 +187,6 @@ impl InputEvent {
     /// Take ownership of the field's current text.
     pub fn into_value(self) -> String {
         self.detail.value
-    }
-}
-
-/// A cloneable user callback for an [`Input`] event prop.
-///
-/// Wraps `Rc<dyn Fn(A)>` so it's `Clone` (required: `#[component]`
-/// re-clones every prop for the hot-reload remount path) and so a
-/// bare closure coerces into it via `Into` at the call site
-/// (`on_input: move |s| …`). `A` is `String` for value-carrying
-/// events (`on_input` / `on_change` / `on_submit`) and `()` for the
-/// bare focus / blur events.
-#[derive(Clone)]
-pub struct InputCallback<A>(Rc<dyn Fn(A) + 'static>);
-
-impl<A> InputCallback<A> {
-    /// Invoke the wrapped callback.
-    pub fn call(&self, arg: A) {
-        (self.0)(arg)
-    }
-}
-
-impl<A, F: Fn(A) + 'static> From<F> for InputCallback<A> {
-    fn from(f: F) -> Self {
-        InputCallback(Rc::new(f))
-    }
-}
-
-/// A cloneable no-argument user callback for an [`Input`] event prop
-/// (`on_focus` / `on_blur`). Same rationale as [`InputCallback`] — a
-/// `Clone`, `Into`-from-closure wrapper around `Rc<dyn Fn()>`.
-#[derive(Clone)]
-pub struct InputAction(Rc<dyn Fn() + 'static>);
-
-impl InputAction {
-    /// Invoke the wrapped callback.
-    pub fn call(&self) {
-        (self.0)()
-    }
-}
-
-impl<F: Fn() + 'static> From<F> for InputAction {
-    fn from(f: F) -> Self {
-        InputAction(Rc::new(f))
     }
 }
 
@@ -353,7 +313,7 @@ impl AutoCapitalize {
 ///
 /// `Clone` produces a shared handle (same backing arena slot), so the
 /// same handle can drive multiple event closures.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct InputRef {
     r: ElementRef,
 }
@@ -417,15 +377,11 @@ impl Default for InputRef {
     }
 }
 
-// Bool / number / enum props reach the native side pre-stringified ("true" /
-// "false", a decimal string, the enum's `as_attr`), so it reads one stable
-// string form per attr. Attr names are the kebab-cased field names
-// (`placeholder-color`, `caret-color`, `selection-color`).
-
 #[doc(hidden)]
 #[whisker::module_element(
     name = "whisker-input:Input",
     measurement = None,
+    text_style = true,
     commands = [
         ("focus", Null),
         ("blur", Null),
@@ -439,17 +395,17 @@ pub fn native_input(
     placeholder_color: Signal<String>,
     caret_color: Signal<String>,
     selection_color: Signal<String>,
-    multiline: Signal<String>,
-    lines: Signal<String>,
-    secure: Signal<String>,
-    editable: Signal<String>,
-    auto_focus: Signal<String>,
-    max_length: Signal<String>,
+    multiline: Signal<bool>,
+    lines: Signal<i32>,
+    secure: Signal<bool>,
+    editable: Signal<bool>,
+    auto_focus: Signal<bool>,
+    max_length: Signal<i32>,
     keyboard_type: Signal<String>,
     return_key: Signal<String>,
     auto_capitalize: Signal<String>,
-    autocorrect: Signal<String>,
-    spell_check: Signal<String>,
+    autocorrect: Signal<bool>,
+    spell_check: Signal<bool>,
     style: Style,
     on_input: InputEvent,
     on_change: InputEvent,
@@ -457,6 +413,15 @@ pub fn native_input(
     on_blur: InputEvent,
     on_submit: InputEvent,
 ) {
+}
+
+/// Element schema exported for generated Host bootstrap.
+#[doc(hidden)]
+pub fn __whisker_element_module_definition() -> whisker::ElementModuleDefinition {
+    whisker::ElementModuleDefinition::new(
+        env!("CARGO_PKG_NAME"),
+        [native_input_schema::element_provider()],
+    )
 }
 
 /// `whisker-input:Input` — a native text field with Leptos-style
@@ -472,15 +437,15 @@ pub fn input(
     /// Controlled read (escape hatch). Ignored when `text` is set.
     value: Option<Signal<String>>,
     /// Fires every keystroke with the new full text.
-    on_input: Option<InputCallback<String>>,
+    on_input: Option<Callback<String>>,
     /// Fires when editing ends / the value is committed.
-    on_change: Option<InputCallback<String>>,
+    on_change: Option<Callback<String>>,
     /// Field gained focus.
-    on_focus: Option<InputAction>,
+    on_focus: Option<Callback<()>>,
     /// Field lost focus.
-    on_blur: Option<InputAction>,
+    on_blur: Option<Callback<()>>,
     /// Return / done key pressed; carries the current text.
-    on_submit: Option<InputCallback<String>>,
+    on_submit: Option<Callback<String>>,
     /// Placeholder text shown when the field is empty.
     placeholder: Option<Signal<String>>,
     /// Multiline area vs single-line field.
@@ -534,9 +499,7 @@ pub fn input(
     placeholder_color: Option<Signal<String>>,
     /// Selection-highlight color (CSS color string).
     selection_color: Option<Signal<String>>,
-    /// Standard Whisker style. Accepts a `Css` builder, a raw string,
-    /// or a reactive signal of either — same as a built-in element's
-    /// `style:`.
+    /// Standard structured Whisker style.
     style: Option<Style>,
     /// Imperative handle ([`InputRef`]).
     input_ref: Option<InputRef>,
@@ -560,22 +523,20 @@ pub fn input(
     // Update the bound `text` signal BEFORE calling the user's `on_input`, so
     // reads inside that callback already see the new value.
     let on_input_cb = {
-        let on_input = on_input.clone();
         move |ev: InputEvent| {
             let new = ev.into_value();
             if let Some(t) = text {
                 t.set(new.clone());
             }
-            if let Some(cb) = &on_input {
-                cb.call(new);
+            if let Some(cb) = on_input {
+                cb.run(new);
             }
         }
     };
     let on_change_cb = {
-        let on_change = on_change.clone();
         move |ev: InputEvent| {
-            if let Some(cb) = &on_change {
-                cb.call(ev.into_value());
+            if let Some(cb) = on_change {
+                cb.run(ev.into_value());
             }
         }
     };
@@ -587,30 +548,27 @@ pub fn input(
         .unwrap_or_else(ElementRef::new);
 
     let on_focus_cb = {
-        let on_focus = on_focus.clone();
         move |_ev: InputEvent| {
             // `whisker-router` reads this registry to blur/restore this exact
             // input across a navigation.
             whisker::focus::note_focused(element_ref);
-            if let Some(cb) = &on_focus {
+            if let Some(cb) = on_focus {
                 cb.call();
             }
         }
     };
     let on_blur_cb = {
-        let on_blur = on_blur.clone();
         move |_ev: InputEvent| {
             whisker::focus::note_blurred(element_ref);
-            if let Some(cb) = &on_blur {
+            if let Some(cb) = on_blur {
                 cb.call();
             }
         }
     };
     let on_submit_cb = {
-        let on_submit = on_submit.clone();
         move |ev: InputEvent| {
-            if let Some(cb) = &on_submit {
-                cb.call(ev.into_value());
+            if let Some(cb) = on_submit {
+                cb.run(ev.into_value());
             }
         }
     };
@@ -621,36 +579,29 @@ pub fn input(
     let selection_color_prop: Signal<String> = selection_color.unwrap_or_default();
     let style_prop: Style = style.clone().unwrap_or_default();
 
-    let multiline_attr = bool_attr(multiline);
-    let secure_attr = bool_attr(secure);
-    let editable_attr = bool_attr(editable);
-    let auto_focus_attr = bool_attr(auto_focus);
     // `0` is the "unset" sentinel for `lines` / `max_length`.
-    let lines_attr = lines.unwrap_or(0).to_string();
-    let max_length_attr = max_length.unwrap_or(0).to_string();
+    let lines_attr = i32::try_from(lines.unwrap_or(0)).unwrap_or(i32::MAX);
+    let max_length_attr = i32::try_from(max_length.unwrap_or(0)).unwrap_or(i32::MAX);
     let keyboard_type_attr = keyboard_type.as_attr().to_string();
     let return_key_attr = return_key.as_attr().to_string();
     let auto_capitalize_attr = auto_capitalize.as_attr().to_string();
-    let autocorrect_attr = bool_attr(autocorrect);
-    let spell_check_attr = bool_attr(spell_check);
-
     let mut builder = NativeInput::builder()
         .value(value_prop)
         .placeholder(placeholder_prop)
         .placeholder_color(placeholder_color_prop)
         .caret_color(caret_color_prop)
         .selection_color(selection_color_prop)
-        .multiline(multiline_attr)
+        .multiline(multiline)
         .lines(lines_attr)
-        .secure(secure_attr)
-        .editable(editable_attr)
-        .auto_focus(auto_focus_attr)
+        .secure(secure)
+        .editable(editable)
+        .auto_focus(auto_focus)
         .max_length(max_length_attr)
         .keyboard_type(keyboard_type_attr)
         .return_key(return_key_attr)
         .auto_capitalize(auto_capitalize_attr)
-        .autocorrect(autocorrect_attr)
-        .spell_check(spell_check_attr)
+        .autocorrect(autocorrect)
+        .spell_check(spell_check)
         .style(style_prop)
         .on_input(on_input_cb)
         .on_change(on_change_cb)
@@ -661,11 +612,6 @@ pub fn input(
     builder = builder.element_ref(element_ref);
 
     builder.build()
-}
-
-/// `true` / `false` wire string for a bool attr.
-fn bool_attr(b: bool) -> String {
-    if b { "true" } else { "false" }.to_string()
 }
 
 #[cfg(test)]
@@ -719,12 +665,6 @@ mod tests {
         assert_eq!(KeyboardType::default(), KeyboardType::Default);
         assert_eq!(ReturnKey::default(), ReturnKey::Default);
         assert_eq!(AutoCapitalize::default(), AutoCapitalize::Sentences);
-    }
-
-    #[test]
-    fn bool_attr_strings() {
-        assert_eq!(bool_attr(true), "true");
-        assert_eq!(bool_attr(false), "false");
     }
 
     #[test]

--- a/packages/whisker-input/web/Cargo.toml
+++ b/packages/whisker-input/web/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "whisker-input-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web Host implementation for whisker-input."
+
+[dependencies]
+whisker-protocol = { workspace = true }
+whisker-web = { workspace = true }
+web-sys = { version = "0.3", features = [
+    "CssStyleDeclaration",
+    "Document",
+    "Element",
+    "Event",
+    "EventTarget",
+    "HtmlElement",
+    "HtmlInputElement",
+    "HtmlTextAreaElement",
+    "KeyboardEvent",
+] }

--- a/packages/whisker-input/web/src/lib.rs
+++ b/packages/whisker-input/web/src/lib.rs
@@ -1,0 +1,635 @@
+//! Browser Host implementation for `whisker-input`.
+
+use std::rc::Rc;
+
+use whisker_protocol::{
+    MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextAlignment, PaintColor,
+};
+use whisker_web::wasm_bindgen::JsCast;
+use whisker_web::wasm_bindgen::closure::Closure;
+use whisker_web::{
+    ModuleDefinition, WebEventEmitter, WebNativeEvent, WebViewDefinition, WhiskerModule,
+    WhiskerTextStyle, WhiskerValue, wasm_bindgen, web_sys,
+};
+
+const MODULE_NAME: &str = "whisker-input:Input";
+
+struct Listener {
+    target: web_sys::EventTarget,
+    name: &'static str,
+    callback: Closure<dyn FnMut(web_sys::Event)>,
+}
+
+impl Listener {
+    fn new(
+        target: &web_sys::EventTarget,
+        name: &'static str,
+        callback: impl FnMut(web_sys::Event) + 'static,
+    ) -> Result<Self, wasm_bindgen::JsValue> {
+        let callback = Closure::new(callback);
+        target.add_event_listener_with_callback(name, callback.as_ref().unchecked_ref())?;
+        Ok(Self {
+            target: target.clone(),
+            name,
+            callback,
+        })
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        let _ = self
+            .target
+            .remove_event_listener_with_callback(self.name, self.callback.as_ref().unchecked_ref());
+    }
+}
+
+struct InputWebView {
+    root: web_sys::HtmlElement,
+    input: web_sys::HtmlInputElement,
+    textarea: web_sys::HtmlTextAreaElement,
+    emitter: WebEventEmitter,
+    _listeners: Vec<Listener>,
+    multiline: bool,
+    secure: bool,
+    editable: bool,
+    value: String,
+}
+
+impl InputWebView {
+    fn active_element(&self) -> web_sys::HtmlElement {
+        if self.multiline && !self.secure {
+            self.textarea.clone().unchecked_into()
+        } else {
+            self.input.clone().unchecked_into()
+        }
+    }
+
+    fn set_value(&mut self, value: &str) {
+        self.value.clear();
+        self.value.push_str(value);
+        if self.input.value() != value {
+            self.input.set_value(value);
+        }
+        if self.textarea.value() != value {
+            self.textarea.set_value(value);
+        }
+    }
+
+    fn update_mode(&self) -> Result<(), wasm_bindgen::JsValue> {
+        let use_textarea = self.multiline && !self.secure;
+        self.input
+            .style()
+            .set_property("display", if use_textarea { "none" } else { "block" })?;
+        self.textarea
+            .style()
+            .set_property("display", if use_textarea { "block" } else { "none" })?;
+        self.input
+            .set_type(if self.secure { "password" } else { "text" });
+        Ok(())
+    }
+
+    fn focus(&self) -> Result<(), wasm_bindgen::JsValue> {
+        self.active_element().focus()
+    }
+
+    fn blur(&self) -> Result<(), wasm_bindgen::JsValue> {
+        self.active_element().blur()
+    }
+
+    fn apply_text_style(&self, style: &WhiskerTextStyle) -> Result<(), wasm_bindgen::JsValue> {
+        for element in [
+            &self.input.clone().unchecked_into::<web_sys::HtmlElement>(),
+            &self
+                .textarea
+                .clone()
+                .unchecked_into::<web_sys::HtmlElement>(),
+        ] {
+            let css = element.style();
+            let families = style
+                .style
+                .font_families
+                .iter()
+                .map(|family| match family {
+                    MeasureFontFamily::System => "system-ui".to_owned(),
+                    MeasureFontFamily::Named(name) => format!("{name:?}"),
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            css.set_property("font-family", &families)?;
+            css.set_property("font-size", &format!("{}px", style.style.font_size))?;
+            css.set_property("font-weight", &style.style.font_weight.to_string())?;
+            css.set_property(
+                "font-style",
+                match style.style.font_style {
+                    MeasureFontStyle::Normal => "normal",
+                    MeasureFontStyle::Italic => "italic",
+                    MeasureFontStyle::Oblique => "oblique",
+                },
+            )?;
+            css.set_property(
+                "line-height",
+                &match style.style.line_height {
+                    MeasureLineHeight::Normal => "normal".to_owned(),
+                    MeasureLineHeight::LogicalPixels(value) => format!("{value}px"),
+                },
+            )?;
+            css.set_property(
+                "letter-spacing",
+                &format!("{}px", style.style.letter_spacing),
+            )?;
+            css.set_property(
+                "text-align",
+                match style.alignment {
+                    MeasureTextAlignment::Start => "start",
+                    MeasureTextAlignment::End => "end",
+                    MeasureTextAlignment::Left => "left",
+                    MeasureTextAlignment::Right => "right",
+                    MeasureTextAlignment::Center => "center",
+                },
+            )?;
+            css.set_property("color", &css_color(&style.paint.foreground))?;
+        }
+        Ok(())
+    }
+}
+
+struct InputModule;
+
+#[whisker_web::WhiskerModule]
+impl WhiskerModule for InputModule {
+    type Definition = ModuleDefinition;
+
+    fn definition() -> Self::Definition {
+        ModuleDefinition::new()
+            .name(MODULE_NAME)
+            .view(input_definition())
+    }
+}
+
+fn input_definition() -> WebViewDefinition<InputWebView> {
+    WebViewDefinition::new(
+        MODULE_NAME,
+        |document, emitter| {
+            let root = document
+                .create_element("div")?
+                .dyn_into::<web_sys::HtmlElement>()?;
+            let input = document
+                .create_element("input")?
+                .dyn_into::<web_sys::HtmlInputElement>()?;
+            let textarea = document
+                .create_element("textarea")?
+                .dyn_into::<web_sys::HtmlTextAreaElement>()?;
+            input.set_class_name("whisker-input-control");
+            textarea.set_class_name("whisker-input-control");
+            configure_control(&input.clone().unchecked_into())?;
+            configure_control(&textarea.clone().unchecked_into())?;
+            textarea.style().set_property("resize", "none")?;
+            textarea.style().set_property("display", "none")?;
+            let style = document.create_element("style")?;
+            style.set_text_content(Some(
+                ".whisker-input-control::placeholder{color:var(--whisker-placeholder-color)}\
+                 .whisker-input-control::selection{background:var(--whisker-selection-color)}",
+            ));
+            root.append_child(&style)?;
+            root.append_child(&input)?;
+            root.append_child(&textarea)?;
+
+            let mut listeners = Vec::new();
+            let input_value = {
+                let input = input.clone();
+                Rc::new(move || input.value()) as Rc<dyn Fn() -> String>
+            };
+            let textarea_value = {
+                let textarea = textarea.clone();
+                Rc::new(move || textarea.value()) as Rc<dyn Fn() -> String>
+            };
+            install_control_listeners(
+                &mut listeners,
+                input.as_ref(),
+                &emitter,
+                input_value,
+                false,
+            )?;
+            install_control_listeners(
+                &mut listeners,
+                textarea.as_ref(),
+                &emitter,
+                textarea_value,
+                true,
+            )?;
+            Ok(InputWebView {
+                root,
+                input,
+                textarea,
+                emitter,
+                _listeners: listeners,
+                multiline: false,
+                secure: false,
+                editable: true,
+                value: String::new(),
+            })
+        },
+        |view| view.root.clone().unchecked_into(),
+    )
+    .prop("value", string_prop(InputWebView::set_value), |view| {
+        view.set_value("");
+        Ok(())
+    })
+    .prop(
+        "placeholder",
+        |view, value| {
+            let value = expect_string(value, "placeholder")?;
+            view.input.set_placeholder(value);
+            view.textarea.set_placeholder(value);
+            Ok(())
+        },
+        |view| {
+            view.input.set_placeholder("");
+            view.textarea.set_placeholder("");
+            Ok(())
+        },
+    )
+    .prop(
+        "placeholder-color",
+        color_prop("--whisker-placeholder-color"),
+        clear_css_var("--whisker-placeholder-color"),
+    )
+    .prop(
+        "caret-color",
+        color_style_prop("caret-color"),
+        clear_control_style("caret-color"),
+    )
+    .prop(
+        "selection-color",
+        color_prop("--whisker-selection-color"),
+        clear_css_var("--whisker-selection-color"),
+    )
+    .prop(
+        "multiline",
+        |view, value| {
+            view.multiline = expect_bool(value, "multiline")?;
+            view.update_mode()
+        },
+        |view| {
+            view.multiline = false;
+            view.update_mode()
+        },
+    )
+    .prop(
+        "lines",
+        |view, value| {
+            let rows = match expect_int(value, "lines")? {
+                value if value <= 0 => 2,
+                value => value.min(u32::MAX as i64) as u32,
+            };
+            view.textarea.set_rows(rows);
+            Ok(())
+        },
+        |view| {
+            view.textarea.set_rows(2);
+            Ok(())
+        },
+    )
+    .prop(
+        "secure",
+        |view, value| {
+            view.secure = expect_bool(value, "secure")?;
+            view.update_mode()
+        },
+        |view| {
+            view.secure = false;
+            view.update_mode()
+        },
+    )
+    .prop(
+        "editable",
+        |view, value| set_editable(view, expect_bool(value, "editable")?),
+        |view| set_editable(view, true),
+    )
+    .prop(
+        "auto-focus",
+        |view, value| {
+            if expect_bool(value, "auto-focus")? {
+                view.focus()?;
+            }
+            Ok(())
+        },
+        |_| Ok(()),
+    )
+    .prop(
+        "max-length",
+        |view, value| {
+            let value = match expect_int(value, "max-length")? {
+                value if value <= 0 => -1,
+                value => value.min(i32::MAX as i64) as i32,
+            };
+            view.input.set_max_length(value);
+            view.textarea.set_max_length(value);
+            Ok(())
+        },
+        |view| {
+            view.input.set_max_length(-1);
+            view.textarea.set_max_length(-1);
+            Ok(())
+        },
+    )
+    .prop(
+        "keyboard-type",
+        input_mode_prop,
+        clear_attribute("inputmode"),
+    )
+    .prop(
+        "return-key",
+        enter_key_hint_prop,
+        clear_attribute("enterkeyhint"),
+    )
+    .prop(
+        "auto-capitalize",
+        attribute_prop("autocapitalize"),
+        clear_attribute("autocapitalize"),
+    )
+    .prop(
+        "autocorrect",
+        autocorrect_prop,
+        clear_attribute("autocorrect"),
+    )
+    .prop(
+        "spell-check",
+        bool_attribute_prop("spellcheck"),
+        clear_attribute("spellcheck"),
+    )
+    .event("input")
+    .event("change")
+    .event("focus")
+    .event("blur")
+    .event("submit")
+    .command("focus", |view, _| view.focus())
+    .command("blur", |view, _| view.blur())
+    .command("clear", |view, _| {
+        view.set_value("");
+        emit_value(&view.emitter, "input", "");
+        Ok(())
+    })
+    .command("setValue", |view, arguments| {
+        let WhiskerValue::Map(arguments) = arguments else {
+            return Err(js_error("setValue arguments must be a map"));
+        };
+        let Some(WhiskerValue::String(value)) = arguments.get("value") else {
+            return Err(js_error("setValue.value must be a string"));
+        };
+        view.set_value(value);
+        Ok(())
+    })
+    .text_style(|view, style| view.apply_text_style(style))
+}
+
+fn configure_control(element: &web_sys::HtmlElement) -> Result<(), wasm_bindgen::JsValue> {
+    let style = element.style();
+    for (name, value) in [
+        ("position", "absolute"),
+        ("inset", "0"),
+        ("width", "100%"),
+        ("height", "100%"),
+        ("box-sizing", "border-box"),
+        ("border", "0"),
+        ("outline", "0"),
+        ("margin", "0"),
+        ("padding", "0"),
+        ("background", "transparent"),
+    ] {
+        style.set_property(name, value)?;
+    }
+    Ok(())
+}
+
+fn install_control_listeners(
+    listeners: &mut Vec<Listener>,
+    target: &web_sys::EventTarget,
+    emitter: &WebEventEmitter,
+    value: Rc<dyn Fn() -> String>,
+    multiline: bool,
+) -> Result<(), wasm_bindgen::JsValue> {
+    for name in ["input", "change"] {
+        let emitter = emitter.clone();
+        let value = Rc::clone(&value);
+        listeners.push(Listener::new(target, name, move |_| {
+            emit_value(&emitter, name, &value());
+        })?);
+    }
+    for name in ["focus", "blur"] {
+        let emitter = emitter.clone();
+        listeners.push(Listener::new(target, name, move |_| {
+            emitter.emit(WebNativeEvent {
+                event: name.into(),
+                detail: WhiskerValue::Null,
+            });
+        })?);
+    }
+    if !multiline {
+        let emitter = emitter.clone();
+        let value = Rc::clone(&value);
+        listeners.push(Listener::new(target, "keydown", move |event| {
+            let Some(event) = event.dyn_ref::<web_sys::KeyboardEvent>() else {
+                return;
+            };
+            if event.key() == "Enter" && !event.is_composing() {
+                emit_value(&emitter, "submit", &value());
+            }
+        })?);
+    }
+    Ok(())
+}
+
+fn emit_value(emitter: &WebEventEmitter, event: &str, value: &str) {
+    emitter.emit(WebNativeEvent {
+        event: event.into(),
+        detail: WhiskerValue::map([("value", WhiskerValue::String(value.to_owned()))]),
+    });
+}
+
+fn string_prop(
+    setter: fn(&mut InputWebView, &str),
+) -> impl Fn(&mut InputWebView, &WhiskerValue) -> Result<(), wasm_bindgen::JsValue> {
+    move |view, value| {
+        setter(view, expect_string(value, "string property")?);
+        Ok(())
+    }
+}
+
+fn set_editable(view: &mut InputWebView, editable: bool) -> Result<(), wasm_bindgen::JsValue> {
+    view.editable = editable;
+    view.input.set_disabled(!editable);
+    view.textarea.set_disabled(!editable);
+    Ok(())
+}
+
+fn attribute_prop(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView, &WhiskerValue) -> Result<(), wasm_bindgen::JsValue> {
+    move |view, value| {
+        let value = expect_string(value, name)?;
+        view.input.set_attribute(name, value)?;
+        view.textarea.set_attribute(name, value)
+    }
+}
+
+fn input_mode_prop(
+    view: &mut InputWebView,
+    value: &WhiskerValue,
+) -> Result<(), wasm_bindgen::JsValue> {
+    let value = match expect_string(value, "keyboard-type")? {
+        "number" => "numeric",
+        "phone" => "tel",
+        "default" => "text",
+        value => value,
+    };
+    view.input.set_attribute("inputmode", value)?;
+    view.textarea.set_attribute("inputmode", value)
+}
+
+fn enter_key_hint_prop(
+    view: &mut InputWebView,
+    value: &WhiskerValue,
+) -> Result<(), wasm_bindgen::JsValue> {
+    let value = expect_string(value, "return-key")?;
+    if value == "default" {
+        view.input.remove_attribute("enterkeyhint")?;
+        view.textarea.remove_attribute("enterkeyhint")
+    } else {
+        view.input.set_attribute("enterkeyhint", value)?;
+        view.textarea.set_attribute("enterkeyhint", value)
+    }
+}
+
+fn bool_attribute_prop(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView, &WhiskerValue) -> Result<(), wasm_bindgen::JsValue> {
+    move |view, value| {
+        let value = expect_bool(value, name)?.to_string();
+        view.input.set_attribute(name, &value)?;
+        view.textarea.set_attribute(name, &value)
+    }
+}
+
+fn autocorrect_prop(
+    view: &mut InputWebView,
+    value: &WhiskerValue,
+) -> Result<(), wasm_bindgen::JsValue> {
+    let value = if expect_bool(value, "autocorrect")? {
+        "on"
+    } else {
+        "off"
+    };
+    view.input.set_attribute("autocorrect", value)?;
+    view.textarea.set_attribute("autocorrect", value)
+}
+
+fn clear_attribute(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView) -> Result<(), wasm_bindgen::JsValue> {
+    move |view| {
+        view.input.remove_attribute(name)?;
+        view.textarea.remove_attribute(name)
+    }
+}
+
+fn color_prop(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView, &WhiskerValue) -> Result<(), wasm_bindgen::JsValue> {
+    move |view, value| {
+        view.root
+            .style()
+            .set_property(name, expect_string(value, name)?)
+    }
+}
+
+fn clear_css_var(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView) -> Result<(), wasm_bindgen::JsValue> {
+    move |view| view.root.style().remove_property(name).map(|_| ())
+}
+
+fn color_style_prop(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView, &WhiskerValue) -> Result<(), wasm_bindgen::JsValue> {
+    move |view, value| {
+        let value = expect_string(value, name)?;
+        view.input.style().set_property(name, value)?;
+        view.textarea.style().set_property(name, value)
+    }
+}
+
+fn clear_control_style(
+    name: &'static str,
+) -> impl Fn(&mut InputWebView) -> Result<(), wasm_bindgen::JsValue> {
+    move |view| {
+        view.input.style().remove_property(name)?;
+        view.textarea.style().remove_property(name).map(|_| ())
+    }
+}
+
+fn expect_string<'a>(
+    value: &'a WhiskerValue,
+    name: &str,
+) -> Result<&'a str, wasm_bindgen::JsValue> {
+    let WhiskerValue::String(value) = value else {
+        return Err(js_error(&format!("Input {name} property must be a string")));
+    };
+    Ok(value)
+}
+
+fn expect_bool(value: &WhiskerValue, name: &str) -> Result<bool, wasm_bindgen::JsValue> {
+    let WhiskerValue::Bool(value) = value else {
+        return Err(js_error(&format!(
+            "Input {name} property must be a boolean"
+        )));
+    };
+    Ok(*value)
+}
+
+fn expect_int(value: &WhiskerValue, name: &str) -> Result<i64, wasm_bindgen::JsValue> {
+    let WhiskerValue::Int(value) = value else {
+        return Err(js_error(&format!(
+            "Input {name} property must be an integer"
+        )));
+    };
+    Ok(*value)
+}
+
+fn css_color(value: &PaintColor) -> String {
+    match value {
+        PaintColor::Named(value) => value.clone(),
+        PaintColor::Srgba {
+            red,
+            green,
+            blue,
+            alpha,
+        } => {
+            format!("rgba({red}, {green}, {blue}, {alpha})")
+        }
+        PaintColor::Hsla {
+            hue_degrees,
+            saturation,
+            lightness,
+            alpha,
+        } => {
+            format!("hsla({hue_degrees}, {saturation}%, {lightness}%, {alpha})")
+        }
+    }
+}
+
+fn js_error(message: &str) -> wasm_bindgen::JsValue {
+    wasm_bindgen::JsValue::from_str(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_exports_input_factory() {
+        let definition = InputModule::definition();
+        assert_eq!(definition.factories().len(), 1);
+    }
+}

--- a/platforms/desktop/Cargo.toml
+++ b/platforms/desktop/Cargo.toml
@@ -31,6 +31,7 @@ whisker-dev-runtime = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 accesskit = "0.25.0"
+arboard = { version = "3.6.1", default-features = false, features = ["wayland-data-control"] }
 base64 = { workspace = true }
 bytemuck = { version = "1", features = ["derive"] }
 csscolorparser = "0.7.2"

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -443,7 +443,7 @@ impl DesktopApplication {
         let (Some(window), Some(host)) = (&self.window, &self.host) else {
             return;
         };
-        let rect = host.focused_text_input_rect();
+        let rect = host.focused_text_input_caret_rect(window.scale_factor() as f32);
         window.set_ime_allowed(rect.is_some());
         if let Some(rect) = rect {
             let (position, size) = ime_cursor_area(rect);
@@ -800,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    fn ime_cursor_area_uses_the_focused_editor_bounds_once() {
+    fn ime_cursor_area_uses_the_focused_caret_bounds() {
         let (position, size) = ime_cursor_area(LayoutRect {
             x: 10.0,
             y: 20.0,

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 use crate::accessibility::{DesktopAccessibilityAction, DesktopAccessibilityBridge};
 use crate::{
     BuiltInElementModule, DesktopElementFactory, DesktopFrameContext, DesktopModuleDefinition,
-    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime, WhiskerModule,
+    DesktopMouseButton, DesktopPointerAdapter, DesktopPointerPhase, DesktopRuntime,
+    DesktopTextInputEvent, DesktopTextInputKey, WhiskerModule,
 };
 use whisker::runtime::RuntimeWakeHandle;
 use whisker::runtime::module::RustModuleDefinition;
@@ -15,8 +16,11 @@ use whisker_protocol::{CursorKeyword, InputEvent, InputEventKind, SurfaceId, Whi
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
-use winit::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
+use winit::event::{
+    ElementState, Ime, Modifiers, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent,
+};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProxy};
+use winit::keyboard::{Key, NamedKey};
 use winit::window::{CursorIcon, Window, WindowAttributes, WindowId};
 
 #[cfg(target_os = "macos")]
@@ -240,6 +244,8 @@ struct DesktopApplication {
     frame_failed: bool,
     pointer: DesktopPointerAdapter,
     pending_scroll_settle: Option<(Instant, [f32; 2])>,
+    modifiers: Modifiers,
+    clipboard: Option<arboard::Clipboard>,
 }
 
 impl DesktopApplication {
@@ -269,6 +275,8 @@ impl DesktopApplication {
             frame_failed: false,
             pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
             pending_scroll_settle: None,
+            modifiers: Modifiers::default(),
+            clipboard: arboard::Clipboard::new().ok(),
         }
     }
 
@@ -394,6 +402,7 @@ impl DesktopApplication {
         }
         if !self.frame_failed {
             self.update_accessibility(false);
+            self.sync_text_input();
         }
     }
 
@@ -425,6 +434,94 @@ impl DesktopApplication {
             eprintln!("dispatch {TARGET_NAME} input failed: {error}");
         } else {
             self.request_frame();
+        }
+    }
+
+    fn sync_text_input(&self) {
+        let (Some(window), Some(host)) = (&self.window, &self.host) else {
+            return;
+        };
+        let rect = host.focused_text_input_rect();
+        window.set_ime_allowed(rect.is_some());
+        if let Some(rect) = rect {
+            window.set_ime_cursor_area(
+                winit::dpi::LogicalPosition::new(rect.x as f64, (rect.y + rect.height) as f64),
+                winit::dpi::LogicalSize::new(
+                    rect.width.max(1.0) as f64,
+                    rect.height.max(1.0) as f64,
+                ),
+            );
+        }
+    }
+
+    fn dispatch_text_input(&mut self, event: DesktopTextInputEvent) {
+        if self
+            .host
+            .as_mut()
+            .is_some_and(|host| host.dispatch_text_input(&event))
+        {
+            self.request_frame();
+            self.sync_text_input();
+        }
+    }
+
+    fn handle_keyboard(&mut self, event: winit::event::KeyEvent) {
+        if event.state != ElementState::Pressed {
+            return;
+        }
+        let shift = self.modifiers.state().shift_key();
+        let command = if cfg!(target_os = "macos") {
+            self.modifiers.state().super_key()
+        } else {
+            self.modifiers.state().control_key()
+        };
+        if command {
+            if let Key::Character(character) = &event.logical_key {
+                match character.to_lowercase().as_str() {
+                    "a" => self.dispatch_text_input(DesktopTextInputEvent::SelectAll),
+                    "c" => {
+                        if let Some(text) =
+                            self.host.as_ref().and_then(DesktopRuntime::selected_text)
+                        {
+                            if let Some(clipboard) = &mut self.clipboard {
+                                let _ = clipboard.set_text(text);
+                            }
+                        }
+                    }
+                    "x" => {
+                        if let Some(text) =
+                            self.host.as_ref().and_then(DesktopRuntime::selected_text)
+                        {
+                            if let Some(clipboard) = &mut self.clipboard {
+                                let _ = clipboard.set_text(text);
+                            }
+                            self.dispatch_text_input(DesktopTextInputEvent::Cut);
+                        }
+                    }
+                    "v" => {
+                        if let Some(clipboard) = &mut self.clipboard
+                            && let Ok(text) = clipboard.get_text()
+                        {
+                            self.dispatch_text_input(DesktopTextInputEvent::Paste(text));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return;
+        }
+        let key = match event.logical_key {
+            Key::Named(NamedKey::Backspace) => Some(DesktopTextInputKey::Backspace),
+            Key::Named(NamedKey::Delete) => Some(DesktopTextInputKey::Delete),
+            Key::Named(NamedKey::ArrowLeft) => Some(DesktopTextInputKey::ArrowLeft),
+            Key::Named(NamedKey::ArrowRight) => Some(DesktopTextInputKey::ArrowRight),
+            Key::Named(NamedKey::Home) => Some(DesktopTextInputKey::Home),
+            Key::Named(NamedKey::End) => Some(DesktopTextInputKey::End),
+            Key::Named(NamedKey::Enter) => Some(DesktopTextInputKey::Enter),
+            _ => None,
+        };
+        if let Some(key) = key {
+            self.dispatch_text_input(DesktopTextInputEvent::Key { key, shift });
         }
     }
 
@@ -548,6 +645,17 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                 }
             }
             WindowEvent::RedrawRequested => self.drive_frame(),
+            WindowEvent::ModifiersChanged(modifiers) => self.modifiers = modifiers,
+            WindowEvent::KeyboardInput { event, .. } => self.handle_keyboard(event),
+            WindowEvent::Ime(Ime::Commit(text)) => {
+                if !text.is_empty() {
+                    self.dispatch_text_input(DesktopTextInputEvent::Commit(text));
+                }
+            }
+            WindowEvent::Ime(Ime::Preedit(text, cursor)) => {
+                self.dispatch_text_input(DesktopTextInputEvent::Preedit { text, cursor });
+            }
+            WindowEvent::Ime(Ime::Enabled | Ime::Disabled) => {}
             WindowEvent::CursorMoved { position, .. } => {
                 if let Some(window) = &self.window {
                     let logical = position.to_logical::<f32>(window.scale_factor());
@@ -574,6 +682,15 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                     state == ElementState::Pressed,
                 ) {
                     self.dispatch_input(input);
+                }
+                if button == MouseButton::Left
+                    && state == ElementState::Pressed
+                    && let (Some(position), Some(host)) =
+                        (self.pointer.mouse_position(), self.host.as_mut())
+                    && host.focus_text_input_at([position.x, position.y])
+                {
+                    self.request_frame();
+                    self.sync_text_input();
                 }
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -12,7 +12,9 @@ use crate::{
 use whisker::runtime::RuntimeWakeHandle;
 use whisker::runtime::module::RustModuleDefinition;
 use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
-use whisker_protocol::{CursorKeyword, InputEvent, InputEventKind, SurfaceId, WhiskerValue};
+use whisker_protocol::{
+    CursorKeyword, InputEvent, InputEventKind, LayoutRect, SurfaceId, WhiskerValue,
+};
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalSize};
@@ -444,13 +446,8 @@ impl DesktopApplication {
         let rect = host.focused_text_input_rect();
         window.set_ime_allowed(rect.is_some());
         if let Some(rect) = rect {
-            window.set_ime_cursor_area(
-                winit::dpi::LogicalPosition::new(rect.x as f64, (rect.y + rect.height) as f64),
-                winit::dpi::LogicalSize::new(
-                    rect.width.max(1.0) as f64,
-                    rect.height.max(1.0) as f64,
-                ),
-            );
+            let (position, size) = ime_cursor_area(rect);
+            window.set_ime_cursor_area(position, size);
         }
     }
 
@@ -764,9 +761,17 @@ fn printable_key_text(text: Option<&str>) -> Option<&str> {
     text.filter(|text| !text.is_empty() && text.chars().all(|character| !character.is_control()))
 }
 
+fn ime_cursor_area(rect: LayoutRect) -> (winit::dpi::LogicalPosition<f64>, LogicalSize<f64>) {
+    (
+        winit::dpi::LogicalPosition::new(rect.x as f64, rect.y as f64),
+        LogicalSize::new(rect.width.max(1.0) as f64, rect.height.max(1.0) as f64),
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DesktopAppConfig, printable_key_text};
+    use super::{DesktopAppConfig, ime_cursor_area, printable_key_text};
+    use whisker_protocol::LayoutRect;
 
     #[test]
     fn default_config_preserves_the_standalone_window_contract() {
@@ -792,5 +797,20 @@ mod tests {
         assert_eq!(printable_key_text(Some("hello")), Some("hello"));
         assert_eq!(printable_key_text(Some("\r")), None);
         assert_eq!(printable_key_text(None), None);
+    }
+
+    #[test]
+    fn ime_cursor_area_uses_the_focused_editor_bounds_once() {
+        let (position, size) = ime_cursor_area(LayoutRect {
+            x: 10.0,
+            y: 20.0,
+            width: 120.0,
+            height: 44.0,
+        });
+
+        assert_eq!(position.x, 10.0);
+        assert_eq!(position.y, 20.0);
+        assert_eq!(size.width, 120.0);
+        assert_eq!(size.height, 44.0);
     }
 }

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -522,6 +522,10 @@ impl DesktopApplication {
         };
         if let Some(key) = key {
             self.dispatch_text_input(DesktopTextInputEvent::Key { key, shift });
+            return;
+        }
+        if let Some(text) = printable_key_text(event.text.as_deref()) {
+            self.dispatch_text_input(DesktopTextInputEvent::Commit(text.to_owned()));
         }
     }
 
@@ -756,9 +760,13 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
     }
 }
 
+fn printable_key_text(text: Option<&str>) -> Option<&str> {
+    text.filter(|text| !text.is_empty() && text.chars().all(|character| !character.is_control()))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DesktopAppConfig;
+    use super::{DesktopAppConfig, printable_key_text};
 
     #[test]
     fn default_config_preserves_the_standalone_window_contract() {
@@ -777,5 +785,12 @@ mod tests {
     fn generated_host_can_set_static_background() {
         let config = DesktopAppConfig::new("Whisker").with_background_rgb(16, 16, 24);
         assert_eq!(config.background_rgb, [16, 16, 24]);
+    }
+
+    #[test]
+    fn printable_keyboard_text_is_forwarded_to_the_focused_editor() {
+        assert_eq!(printable_key_text(Some("hello")), Some("hello"));
+        assert_eq!(printable_key_text(Some("\r")), None);
+        assert_eq!(printable_key_text(None), None);
     }
 }

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -10,8 +10,9 @@ use whisker::WhiskerModule;
 use whisker::runtime::module::{ModuleEventEmitter, ModulePromise, RustModuleDefinition};
 use whisker_protocol::{
     ChildPolicy, CommandId, ElementMeasurement, ElementRegistration, ElementRegistrationError,
-    ElementTypeId, EventId, MeasurementMetrics, MeasurementRequest, MeasurementResponse, NodeId,
-    PropertyId, TextContent, UnsupportedMeasurementReason, WhiskerValue,
+    ElementTypeId, EventId, LayoutRect, MeasurementMetrics, MeasurementRequest,
+    MeasurementResponse, NodeId, PropertyId, TextContent, UnsupportedMeasurementReason,
+    WhiskerValue,
 };
 
 use crate::{WhiskerMeasureRequest, WhiskerMeasuredSize, WhiskerTextStyle};
@@ -439,6 +440,14 @@ pub trait DesktopNativeElement: fmt::Debug + 'static {
         None
     }
 
+    /// Returns the current caret rectangle in element-local logical pixels.
+    ///
+    /// The Host translates this into surface coordinates for the platform IME.
+    /// `None` falls back to the complete element bounds.
+    fn text_input_caret_rect(&self, _logical_size: [f32; 2], _scale: f32) -> Option<LayoutRect> {
+        None
+    }
+
     /// Whether this element owns transient vertical scroll state.
     fn is_scroll_container(&self) -> bool {
         false
@@ -662,6 +671,19 @@ impl DesktopElementContent {
     pub(crate) fn selected_text(&self) -> Option<String> {
         match self {
             Self::Native { implementation, .. } => implementation.selected_text(),
+            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+        }
+    }
+
+    pub(crate) fn text_input_caret_rect(
+        &self,
+        logical_size: [f32; 2],
+        scale: f32,
+    ) -> Option<LayoutRect> {
+        match self {
+            Self::Native { implementation, .. } => {
+                implementation.text_input_caret_rect(logical_size, scale)
+            }
             Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
         }
     }

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -318,6 +318,52 @@ pub enum DesktopRasterError {
     },
 }
 
+/// Editing keys normalized by the shared Desktop window shell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DesktopTextInputKey {
+    /// Delete the previous grapheme or selection.
+    Backspace,
+    /// Delete the next grapheme or selection.
+    Delete,
+    /// Move the caret one logical character left.
+    ArrowLeft,
+    /// Move the caret one logical character right.
+    ArrowRight,
+    /// Move the caret to the start of the value.
+    Home,
+    /// Move the caret to the end of the value.
+    End,
+    /// Insert a newline or submit a single-line field.
+    Enter,
+}
+
+/// OS text-service input delivered only to the focused Desktop native element.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DesktopTextInputEvent {
+    /// Replace the current selection or marked range with committed text.
+    Commit(String),
+    /// Update the current IME marked text. An empty string cancels composition.
+    Preedit {
+        /// Current marked text.
+        text: String,
+        /// Cursor range inside `text`, expressed as UTF-8 byte offsets.
+        cursor: Option<(usize, usize)>,
+    },
+    /// A non-text editing key.
+    Key {
+        /// Semantic key.
+        key: DesktopTextInputKey,
+        /// Whether movement extends the current selection.
+        shift: bool,
+    },
+    /// Select the complete value.
+    SelectAll,
+    /// Delete the selection after the Host copied it to the clipboard.
+    Cut,
+    /// Insert clipboard text at the current selection.
+    Paste(String),
+}
+
 impl fmt::Display for DesktopRasterError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -360,9 +406,37 @@ pub trait DesktopNativeElement: fmt::Debug + 'static {
         None
     }
 
+    /// Produces element-owned pixels with the current logical-to-physical
+    /// scale. Existing image-like elements can keep implementing
+    /// [`Self::rasterize`]; text controls use this hook for crisp glyphs.
+    fn rasterize_scaled(&self, width: u32, height: u32, _scale: f32) -> Option<DesktopRaster> {
+        self.rasterize(width, height)
+    }
+
     /// Whether this element contributes raster content at all.
     fn has_raster_content(&self) -> bool {
         false
+    }
+
+    /// Whether this native element participates in Desktop text editing.
+    fn accepts_text_input(&self) -> bool {
+        false
+    }
+
+    /// Whether this element currently owns keyboard and IME focus.
+    fn text_input_focused(&self) -> bool {
+        false
+    }
+
+    /// Changes keyboard and IME focus for this element.
+    fn set_text_input_focus(&mut self, _focused: bool) {}
+
+    /// Applies one normalized keyboard, clipboard, or IME edit.
+    fn handle_text_input(&mut self, _event: &DesktopTextInputEvent) {}
+
+    /// Returns selected text for the Host clipboard bridge.
+    fn selected_text(&self) -> Option<String> {
+        None
     }
 
     /// Whether this element owns transient vertical scroll state.
@@ -561,6 +635,33 @@ impl DesktopElementContent {
                 Some(implementation.as_ref())
             }
             Self::Native { .. } => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+        }
+    }
+
+    pub(crate) fn accepts_text_input(&self) -> bool {
+        matches!(self, Self::Native { implementation, .. } if implementation.accepts_text_input())
+    }
+
+    pub(crate) fn text_input_focused(&self) -> bool {
+        matches!(self, Self::Native { implementation, .. } if implementation.text_input_focused())
+    }
+
+    pub(crate) fn set_text_input_focus(&mut self, focused: bool) {
+        if let Self::Native { implementation, .. } = self {
+            implementation.set_text_input_focus(focused);
+        }
+    }
+
+    pub(crate) fn handle_text_input(&mut self, event: &DesktopTextInputEvent) {
+        if let Self::Native { implementation, .. } = self {
+            implementation.handle_text_input(event);
+        }
+    }
+
+    pub(crate) fn selected_text(&self) -> Option<String> {
+        match self {
+            Self::Native { implementation, .. } => implementation.selected_text(),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
         }
     }
@@ -836,6 +937,18 @@ impl DesktopElementRegistry {
             });
         }
         Ok(())
+    }
+
+    pub(crate) fn command_name(
+        &self,
+        element_type: ElementTypeId,
+        command: CommandId,
+    ) -> Option<String> {
+        self.binding(element_type)
+            .ok()?
+            .registration
+            .command(command)
+            .map(|schema| schema.name.clone())
     }
 
     pub(crate) fn event(

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -440,10 +440,10 @@ pub trait DesktopNativeElement: fmt::Debug + 'static {
         None
     }
 
-    /// Returns the current caret rectangle in element-local logical pixels.
+    /// Returns the current caret rectangle in content-local logical pixels.
     ///
     /// The Host translates this into surface coordinates for the platform IME.
-    /// `None` falls back to the complete element bounds.
+    /// `None` falls back to the complete content bounds.
     fn text_input_caret_rect(&self, _logical_size: [f32; 2], _scale: f32) -> Option<LayoutRect> {
         None
     }

--- a/platforms/desktop/src/element/module_definition.rs
+++ b/platforms/desktop/src/element/module_definition.rs
@@ -322,7 +322,7 @@ where
         self
     }
 
-    /// Supplies the current caret rectangle in element-local logical pixels.
+    /// Supplies the current caret rectangle in content-local logical pixels.
     /// Desktop uses this to anchor IME candidate UI to the edited text.
     pub fn text_input_caret_rect(
         mut self,

--- a/platforms/desktop/src/element/module_definition.rs
+++ b/platforms/desktop/src/element/module_definition.rs
@@ -108,11 +108,33 @@ type DesktopCommandHandler<T> = Arc<dyn Fn(&mut T, &WhiskerValue) + Send + Sync>
 type DesktopTextStyleUpdater<T> = Arc<dyn Fn(&mut T, &WhiskerTextStyle) + Send + Sync>;
 pub(super) type DesktopMeasurementHandler =
     Arc<dyn Fn(&WhiskerMeasureRequest) -> Option<WhiskerMeasuredSize> + Send + Sync>;
-type DesktopRasterizer<T> = Arc<dyn Fn(&T, u32, u32) -> Option<DesktopRaster> + Send + Sync>;
+type DesktopRasterizer<T> = Arc<dyn Fn(&T, u32, u32, f32) -> Option<DesktopRaster> + Send + Sync>;
 type DesktopScrollAxis<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
 type DesktopItemSnap<T> = Arc<dyn Fn(&T) -> Option<(f64, f64)> + Send + Sync>;
 type DesktopSnapStop<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
 type DesktopScrollEnabled<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+type DesktopInputFocused<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
+type DesktopSetInputFocus<T> = Arc<dyn Fn(&mut T, bool) + Send + Sync>;
+type DesktopInputHandler<T> = Arc<dyn Fn(&mut T, &DesktopTextInputEvent) + Send + Sync>;
+type DesktopSelectedText<T> = Arc<dyn Fn(&T) -> Option<String> + Send + Sync>;
+
+struct DesktopTextInputBinding<T> {
+    focused: DesktopInputFocused<T>,
+    set_focus: DesktopSetInputFocus<T>,
+    input: DesktopInputHandler<T>,
+    selected_text: DesktopSelectedText<T>,
+}
+
+impl<T> Clone for DesktopTextInputBinding<T> {
+    fn clone(&self) -> Self {
+        Self {
+            focused: Arc::clone(&self.focused),
+            set_focus: Arc::clone(&self.set_focus),
+            input: Arc::clone(&self.input),
+            selected_text: Arc::clone(&self.selected_text),
+        }
+    }
+}
 
 struct DesktopPropBinding<T> {
     set: DesktopPropSetter<T>,
@@ -144,6 +166,7 @@ pub struct DesktopViewDefinition<T> {
     item_snap: DesktopItemSnap<T>,
     snap_stop_always: DesktopSnapStop<T>,
     scroll_enabled: DesktopScrollEnabled<T>,
+    text_input: Option<DesktopTextInputBinding<T>>,
 }
 
 impl<T> DesktopViewDefinition<T>
@@ -170,6 +193,7 @@ where
             item_snap: Arc::new(|_| None),
             snap_stop_always: Arc::new(|_| false),
             scroll_enabled: Arc::new(|_| true),
+            text_input: None,
         }
     }
 
@@ -270,6 +294,30 @@ where
         self
     }
 
+    /// Declares a module-owned editable-text object. The package retains the
+    /// value, selection, and composition model; the shared Desktop Host only
+    /// routes OS focus, keyboard, clipboard, and IME messages.
+    pub fn text_input(
+        mut self,
+        focused: impl Fn(&T) -> bool + Send + Sync + 'static,
+        set_focus: impl Fn(&mut T, bool) + Send + Sync + 'static,
+        input: impl Fn(&mut T, &DesktopTextInputEvent) + Send + Sync + 'static,
+        selected_text: impl Fn(&T) -> Option<String> + Send + Sync + 'static,
+    ) -> Self {
+        assert!(
+            self.text_input.is_none(),
+            "duplicate Desktop text-input binding for {}",
+            self.name
+        );
+        self.text_input = Some(DesktopTextInputBinding {
+            focused: Arc::new(focused),
+            set_focus: Arc::new(set_focus),
+            input: Arc::new(input),
+            selected_text: Arc::new(selected_text),
+        });
+        self
+    }
+
     /// Supplies synchronous Host intrinsic measurement for Custom or
     /// ReplacedContent schemas. `None` means unsupported for this request.
     pub fn measurement(
@@ -289,6 +337,23 @@ where
     pub fn raster(
         mut self,
         rasterize: impl Fn(&T, u32, u32) -> Option<DesktopRaster> + Send + Sync + 'static,
+    ) -> Self {
+        assert!(
+            self.rasterizer
+                .replace(Arc::new(move |state, width, height, _scale| {
+                    rasterize(state, width, height)
+                }))
+                .is_none(),
+            "duplicate Desktop raster binding for {}",
+            self.name,
+        );
+        self
+    }
+
+    /// Declares scale-aware module-owned raster content.
+    pub fn raster_scaled(
+        mut self,
+        rasterize: impl Fn(&T, u32, u32, f32) -> Option<DesktopRaster> + Send + Sync + 'static,
     ) -> Self {
         assert!(
             self.rasterizer.replace(Arc::new(rasterize)).is_none(),
@@ -380,6 +445,7 @@ where
             item_snap: Arc::clone(&self.item_snap),
             snap_stop_always: Arc::clone(&self.snap_stop_always),
             scroll_enabled: Arc::clone(&self.scroll_enabled),
+            text_input: self.text_input.clone(),
         });
         Ok(Arc::new(move |events| {
             Box::new(DeclaredDesktopElement {
@@ -412,6 +478,7 @@ struct BoundDesktopViewDefinition<T> {
     item_snap: DesktopItemSnap<T>,
     snap_stop_always: DesktopSnapStop<T>,
     scroll_enabled: DesktopScrollEnabled<T>,
+    text_input: Option<DesktopTextInputBinding<T>>,
 }
 
 struct DeclaredDesktopElement<T> {
@@ -463,14 +530,48 @@ where
     }
 
     fn rasterize(&self, width: u32, height: u32) -> Option<DesktopRaster> {
+        self.rasterize_scaled(width, height, 1.0)
+    }
+
+    fn rasterize_scaled(&self, width: u32, height: u32, scale: f32) -> Option<DesktopRaster> {
         self.definition
             .rasterizer
             .as_ref()
-            .and_then(|rasterize| rasterize(&self.state, width, height))
+            .and_then(|rasterize| rasterize(&self.state, width, height, scale))
     }
 
     fn has_raster_content(&self) -> bool {
         self.definition.rasterizer.is_some()
+    }
+
+    fn accepts_text_input(&self) -> bool {
+        self.definition.text_input.is_some()
+    }
+
+    fn text_input_focused(&self) -> bool {
+        self.definition
+            .text_input
+            .as_ref()
+            .is_some_and(|binding| (binding.focused)(&self.state))
+    }
+
+    fn set_text_input_focus(&mut self, focused: bool) {
+        if let Some(binding) = &self.definition.text_input {
+            (binding.set_focus)(&mut self.state, focused);
+        }
+    }
+
+    fn handle_text_input(&mut self, event: &DesktopTextInputEvent) {
+        if let Some(binding) = &self.definition.text_input {
+            (binding.input)(&mut self.state, event);
+        }
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        self.definition
+            .text_input
+            .as_ref()
+            .and_then(|binding| (binding.selected_text)(&self.state))
     }
 
     fn is_scroll_container(&self) -> bool {

--- a/platforms/desktop/src/element/module_definition.rs
+++ b/platforms/desktop/src/element/module_definition.rs
@@ -117,12 +117,14 @@ type DesktopInputFocused<T> = Arc<dyn Fn(&T) -> bool + Send + Sync>;
 type DesktopSetInputFocus<T> = Arc<dyn Fn(&mut T, bool) + Send + Sync>;
 type DesktopInputHandler<T> = Arc<dyn Fn(&mut T, &DesktopTextInputEvent) + Send + Sync>;
 type DesktopSelectedText<T> = Arc<dyn Fn(&T) -> Option<String> + Send + Sync>;
+type DesktopInputCaretRect<T> = Arc<dyn Fn(&T, [f32; 2], f32) -> LayoutRect + Send + Sync>;
 
 struct DesktopTextInputBinding<T> {
     focused: DesktopInputFocused<T>,
     set_focus: DesktopSetInputFocus<T>,
     input: DesktopInputHandler<T>,
     selected_text: DesktopSelectedText<T>,
+    caret_rect: Option<DesktopInputCaretRect<T>>,
 }
 
 impl<T> Clone for DesktopTextInputBinding<T> {
@@ -132,6 +134,7 @@ impl<T> Clone for DesktopTextInputBinding<T> {
             set_focus: Arc::clone(&self.set_focus),
             input: Arc::clone(&self.input),
             selected_text: Arc::clone(&self.selected_text),
+            caret_rect: self.caret_rect.clone(),
         }
     }
 }
@@ -314,7 +317,26 @@ where
             set_focus: Arc::new(set_focus),
             input: Arc::new(input),
             selected_text: Arc::new(selected_text),
+            caret_rect: None,
         });
+        self
+    }
+
+    /// Supplies the current caret rectangle in element-local logical pixels.
+    /// Desktop uses this to anchor IME candidate UI to the edited text.
+    pub fn text_input_caret_rect(
+        mut self,
+        resolve: impl Fn(&T, [f32; 2], f32) -> LayoutRect + Send + Sync + 'static,
+    ) -> Self {
+        let binding = self
+            .text_input
+            .as_mut()
+            .expect("Desktop caret geometry requires a text-input binding");
+        assert!(
+            binding.caret_rect.replace(Arc::new(resolve)).is_none(),
+            "duplicate Desktop text-input caret binding for {}",
+            self.name
+        );
         self
     }
 
@@ -572,6 +594,14 @@ where
             .text_input
             .as_ref()
             .and_then(|binding| (binding.selected_text)(&self.state))
+    }
+
+    fn text_input_caret_rect(&self, logical_size: [f32; 2], scale: f32) -> Option<LayoutRect> {
+        self.definition
+            .text_input
+            .as_ref()
+            .and_then(|binding| binding.caret_rect.as_ref())
+            .map(|resolve| resolve(&self.state, logical_size, scale))
     }
 
     fn is_scroll_container(&self) -> bool {

--- a/platforms/desktop/src/gpu/renderer.rs
+++ b/platforms/desktop/src/gpu/renderer.rs
@@ -344,7 +344,7 @@ impl GpuRenderer {
                 } => {
                     let width = (rect.width * scale).ceil().max(1.0) as u32;
                     let height = (rect.height * scale).ceil().max(1.0) as u32;
-                    let Some(raster) = rasterizer.rasterize(width, height) else {
+                    let Some(raster) = rasterizer.rasterize_scaled(width, height, scale) else {
                         self.native_rasters.remove(node);
                         continue;
                     };

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -252,9 +252,12 @@ impl DesktopRuntime {
         self.surface.selected_text()
     }
 
-    /// Returns the focused editor bounds in logical surface coordinates.
-    pub fn focused_text_input_rect(&self) -> Option<whisker_protocol::LayoutRect> {
-        self.surface.focused_text_input_rect()
+    /// Returns the focused editor's caret bounds in logical surface coordinates.
+    pub fn focused_text_input_caret_rect(
+        &self,
+        scale: f32,
+    ) -> Option<whisker_protocol::LayoutRect> {
+        self.surface.focused_text_input_caret_rect(scale)
     }
 
     /// Registers one already-decoded RGBA8 raster for later `ResourceId`

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -53,7 +53,7 @@ use element::DesktopElementRegistry;
 pub use element::{
     BuiltInElementModule, DesktopElementFactory, DesktopEventEmitter, DesktopModuleDefinition,
     DesktopNativeElement, DesktopNativeEvent, DesktopRaster, DesktopRasterError,
-    DesktopViewDefinition, DesktopViewImplementation,
+    DesktopTextInputEvent, DesktopTextInputKey, DesktopViewDefinition, DesktopViewImplementation,
 };
 pub use input::{
     DesktopMouseButton, DesktopPointerAdapter, DesktopPointerEvent, DesktopPointerPhase,
@@ -234,6 +234,27 @@ impl DesktopRuntime {
     /// Settles the nearest snapping ScrollView after wheel/trackpad input ends.
     pub fn settle_scroll_at(&mut self, logical_position: [f32; 2]) -> bool {
         self.surface.settle_scroll_at(logical_position)
+    }
+
+    /// Focuses the editable native element under a pointer, blurring any
+    /// previous editor. Clicking outside an editor clears text focus.
+    pub fn focus_text_input_at(&mut self, logical_position: [f32; 2]) -> bool {
+        self.surface.focus_text_input_at(logical_position)
+    }
+
+    /// Routes one normalized OS edit to the focused native element.
+    pub fn dispatch_text_input(&mut self, event: &DesktopTextInputEvent) -> bool {
+        self.surface.dispatch_text_input(event)
+    }
+
+    /// Returns the focused element's selected text for clipboard integration.
+    pub fn selected_text(&self) -> Option<String> {
+        self.surface.selected_text()
+    }
+
+    /// Returns the focused editor bounds in logical surface coordinates.
+    pub fn focused_text_input_rect(&self) -> Option<whisker_protocol::LayoutRect> {
+        self.surface.focused_text_input_rect()
     }
 
     /// Registers one already-decoded RGBA8 raster for later `ResourceId`

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -14,6 +14,7 @@ use whisker_protocol::{
     ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
 
+use crate::DesktopTextInputEvent;
 use crate::element::{
     DesktopElementContent, DesktopElementError, DesktopElementRegistry, DesktopEventEmitter,
 };

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -262,6 +262,125 @@ fn toggle_scene() -> (DesktopScene, ElementTypeId) {
     toggle_scene_with_wake(RuntimeWakeHandle::new(|| {}))
 }
 
+#[derive(Debug, Default)]
+struct TextInputProbe {
+    focused: bool,
+    value: String,
+}
+
+#[derive(Debug)]
+struct TextInputNative {
+    probe: Arc<Mutex<TextInputProbe>>,
+}
+
+impl DesktopNativeElement for TextInputNative {
+    fn set_property(&mut self, _property: PropertyId, _value: &WhiskerValue) {
+        unreachable!("test input has no properties")
+    }
+
+    fn clear_property(&mut self, _property: PropertyId) {
+        unreachable!("test input has no properties")
+    }
+
+    fn invoke_command(&mut self, _command: CommandId, _arguments: &WhiskerValue) {
+        unreachable!("test input has no commands")
+    }
+
+    fn accepts_text_input(&self) -> bool {
+        true
+    }
+
+    fn text_input_focused(&self) -> bool {
+        self.probe.lock().unwrap().focused
+    }
+
+    fn set_text_input_focus(&mut self, focused: bool) {
+        self.probe.lock().unwrap().focused = focused;
+    }
+
+    fn handle_text_input(&mut self, event: &DesktopTextInputEvent) {
+        if let DesktopTextInputEvent::Commit(text) = event {
+            self.probe.lock().unwrap().value.push_str(text);
+        }
+    }
+
+    fn selected_text(&self) -> Option<String> {
+        Some(self.probe.lock().unwrap().value.clone())
+    }
+}
+
+fn text_input_scene() -> (DesktopScene, ElementTypeId, Arc<Mutex<TextInputProbe>>) {
+    let element_type = ElementTypeId::new(21).unwrap();
+    let mut registrations = standard_element_registrations();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/Input".into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![],
+        events: vec![],
+        commands: vec![],
+    });
+    let probe = Arc::new(Mutex::new(TextInputProbe::default()));
+    let input_probe = Arc::clone(&probe);
+    let mut factories = built_in_element_factories();
+    factories.push(DesktopElementFactory::native(
+        "whisker.test/Input",
+        move |_| {
+            Box::new(TextInputNative {
+                probe: Arc::clone(&input_probe),
+            })
+        },
+    ));
+    (
+        DesktopScene::new(
+            SurfaceId::new(1).unwrap(),
+            DesktopElementRegistry::bind(&registrations, &factories).unwrap(),
+        ),
+        element_type,
+        probe,
+    )
+}
+
+#[test]
+fn text_input_focus_and_edits_are_routed_to_the_hit_native_element() {
+    let node = id(1);
+    let (mut scene, element_type, probe) = text_input_scene();
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(10.0, 20.0, 120.0, 44.0),
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert!(scene.focus_text_input_at([20.0, 30.0]));
+    assert_eq!(
+        scene.focused_text_input_rect(),
+        Some(LayoutRect {
+            x: 10.0,
+            y: 20.0,
+            width: 120.0,
+            height: 44.0,
+        })
+    );
+    assert!(scene.dispatch_text_input(&DesktopTextInputEvent::Commit("hi".into())));
+    assert_eq!(scene.selected_text().as_deref(), Some("hi"));
+    assert_eq!(probe.lock().unwrap().value, "hi");
+
+    assert!(scene.focus_text_input_at([500.0, 500.0]));
+    assert!(!probe.lock().unwrap().focused);
+    assert!(!scene.dispatch_text_input(&DesktopTextInputEvent::Commit("!".into())));
+}
+
 #[test]
 fn accessibility_semantics_are_retained_with_the_common_presentation() {
     let node = id(1);

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -307,6 +307,15 @@ impl DesktopNativeElement for TextInputNative {
     fn selected_text(&self) -> Option<String> {
         Some(self.probe.lock().unwrap().value.clone())
     }
+
+    fn text_input_caret_rect(&self, _logical_size: [f32; 2], _scale: f32) -> Option<LayoutRect> {
+        Some(LayoutRect {
+            x: 32.0,
+            y: 4.0,
+            width: 1.0,
+            height: 18.0,
+        })
+    }
 }
 
 fn text_input_scene() -> (DesktopScene, ElementTypeId, Arc<Mutex<TextInputProbe>>) {
@@ -364,12 +373,12 @@ fn text_input_focus_and_edits_are_routed_to_the_hit_native_element() {
 
     assert!(scene.focus_text_input_at([20.0, 30.0]));
     assert_eq!(
-        scene.focused_text_input_rect(),
+        scene.focused_text_input_caret_rect(2.0),
         Some(LayoutRect {
-            x: 10.0,
-            y: 20.0,
-            width: 120.0,
-            height: 44.0,
+            x: 42.0,
+            y: 24.0,
+            width: 1.0,
+            height: 18.0,
         })
     );
     assert!(scene.dispatch_text_input(&DesktopTextInputEvent::Commit("hi".into())));

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -266,6 +266,7 @@ fn toggle_scene() -> (DesktopScene, ElementTypeId) {
 struct TextInputProbe {
     focused: bool,
     value: String,
+    caret_request: Option<([f32; 2], f32)>,
 }
 
 #[derive(Debug)]
@@ -308,7 +309,8 @@ impl DesktopNativeElement for TextInputNative {
         Some(self.probe.lock().unwrap().value.clone())
     }
 
-    fn text_input_caret_rect(&self, _logical_size: [f32; 2], _scale: f32) -> Option<LayoutRect> {
+    fn text_input_caret_rect(&self, logical_size: [f32; 2], scale: f32) -> Option<LayoutRect> {
+        self.probe.lock().unwrap().caret_request = Some((logical_size, scale));
         Some(LayoutRect {
             x: 32.0,
             y: 4.0,
@@ -375,11 +377,15 @@ fn text_input_focus_and_edits_are_routed_to_the_hit_native_element() {
     assert_eq!(
         scene.focused_text_input_caret_rect(2.0),
         Some(LayoutRect {
-            x: 42.0,
-            y: 24.0,
+            x: 43.0,
+            y: 26.0,
             width: 1.0,
             height: 18.0,
         })
+    );
+    assert_eq!(
+        probe.lock().unwrap().caret_request,
+        Some(([118.0, 40.0], 2.0))
     );
     assert!(scene.dispatch_text_input(&DesktopTextInputEvent::Commit("hi".into())));
     assert_eq!(scene.selected_text().as_deref(), Some("hi"));

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -143,7 +143,7 @@ impl DesktopScene {
             .nodes
             .iter()
             .find_map(|(node, state)| state.content.text_input_focused().then_some(*node))?;
-        let bounds = self.absolute_border_box(node)?;
+        let bounds = self.absolute_content_box(node)?;
         let local = self
             .nodes
             .get(&node)?
@@ -185,6 +185,17 @@ impl DesktopScene {
             y: parent_rect.y + local.y - scroll[1],
             width: local.width,
             height: local.height,
+        })
+    }
+
+    fn absolute_content_box(&self, node: NodeId) -> Option<LayoutRect> {
+        let border = self.absolute_border_box(node)?;
+        let content = self.nodes.get(&node)?.presentation.layout.content_box;
+        Some(LayoutRect {
+            x: border.x + content.x,
+            y: border.y + content.y,
+            width: content.width,
+            height: content.height,
         })
     }
 

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -86,6 +86,87 @@ impl DesktopScene {
             .find_map(|(node, _)| self.hit_test_node(node, point, [0.0, 0.0]))
     }
 
+    pub(crate) fn focus_text_input_at(&mut self, point: [f32; 2]) -> bool {
+        let mut target = self.hit_test(point);
+        while let Some(node) = target {
+            let state = self
+                .nodes
+                .get(&node)
+                .expect("hit-tested Desktop node remains live");
+            if state.content.accepts_text_input() {
+                break;
+            }
+            target = state.presentation.parent;
+        }
+        let mut changed = false;
+        for (node, state) in &mut self.nodes {
+            if !state.content.accepts_text_input() {
+                continue;
+            }
+            let focused = Some(*node) == target;
+            if state.content.text_input_focused() != focused {
+                state.content.set_text_input_focus(focused);
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    pub(crate) fn dispatch_text_input(&mut self, event: &DesktopTextInputEvent) -> bool {
+        let Some(node) = self
+            .nodes
+            .iter()
+            .find_map(|(node, state)| state.content.text_input_focused().then_some(*node))
+        else {
+            return false;
+        };
+        self.nodes
+            .get_mut(&node)
+            .expect("focused Desktop editor remains live")
+            .content
+            .handle_text_input(event);
+        true
+    }
+
+    pub(crate) fn selected_text(&self) -> Option<String> {
+        self.nodes.values().find_map(|state| {
+            state
+                .content
+                .text_input_focused()
+                .then(|| state.content.selected_text())
+                .flatten()
+        })
+    }
+
+    pub(crate) fn focused_text_input_rect(&self) -> Option<LayoutRect> {
+        let node = self
+            .nodes
+            .iter()
+            .find_map(|(node, state)| state.content.text_input_focused().then_some(*node))?;
+        self.absolute_border_box(node)
+    }
+
+    fn absolute_border_box(&self, node: NodeId) -> Option<LayoutRect> {
+        let state = self.nodes.get(&node)?;
+        let local = state.presentation.layout.border_box;
+        let Some(parent) = state.presentation.parent else {
+            return Some(local);
+        };
+        let parent_state = self.nodes.get(&parent)?;
+        let parent_rect = self.absolute_border_box(parent)?;
+        let scroll = if parent_state.content.is_scroll_container() {
+            parent_state.scroll_offset
+        } else {
+            [0.0, 0.0]
+        };
+        Some(LayoutRect {
+            x: parent_rect.x + local.x - scroll[0],
+            y: parent_rect.y + local.y - scroll[1],
+            width: local.width,
+            height: local.height,
+        })
+    }
+
     fn hit_test_node(
         &self,
         node: NodeId,
@@ -1008,6 +1089,21 @@ impl DesktopScene {
                     ..
                 } => {
                     if !self.apply_scroll_command(*node, *command, arguments) {
+                        let is_focus = self
+                            .nodes
+                            .get(node)
+                            .and_then(|state| {
+                                self.elements.command_name(state.element_type, *command)
+                            })
+                            .as_deref()
+                            == Some("focus");
+                        if is_focus {
+                            for (candidate, state) in &mut self.nodes {
+                                if candidate != node && state.content.text_input_focused() {
+                                    state.content.set_text_input_focus(false);
+                                }
+                            }
+                        }
                         let state = self.nodes.get_mut(node).expect("validated node");
                         state
                             .content

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -138,12 +138,33 @@ impl DesktopScene {
         })
     }
 
-    pub(crate) fn focused_text_input_rect(&self) -> Option<LayoutRect> {
+    pub(crate) fn focused_text_input_caret_rect(&self, scale: f32) -> Option<LayoutRect> {
         let node = self
             .nodes
             .iter()
             .find_map(|(node, state)| state.content.text_input_focused().then_some(*node))?;
-        self.absolute_border_box(node)
+        let bounds = self.absolute_border_box(node)?;
+        let local = self
+            .nodes
+            .get(&node)?
+            .content
+            .text_input_caret_rect([bounds.width, bounds.height], scale);
+        let Some(local) = local.filter(|rect| {
+            rect.x.is_finite()
+                && rect.y.is_finite()
+                && rect.width.is_finite()
+                && rect.height.is_finite()
+                && rect.width > 0.0
+                && rect.height > 0.0
+        }) else {
+            return Some(bounds);
+        };
+        Some(LayoutRect {
+            x: bounds.x + local.x.clamp(0.0, bounds.width),
+            y: bounds.y + local.y.clamp(0.0, bounds.height),
+            width: local.width,
+            height: local.height,
+        })
     }
 
     fn absolute_border_box(&self, node: NodeId) -> Option<LayoutRect> {

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -94,8 +94,11 @@ impl DesktopSurface {
         self.scene.selected_text()
     }
 
-    pub(crate) fn focused_text_input_rect(&self) -> Option<whisker_protocol::LayoutRect> {
-        self.scene.focused_text_input_rect()
+    pub(crate) fn focused_text_input_caret_rect(
+        &self,
+        scale: f32,
+    ) -> Option<whisker_protocol::LayoutRect> {
+        self.scene.focused_text_input_caret_rect(scale)
     }
 
     pub(crate) fn advance_scroll_animations(&mut self, delta_ms: f32) -> bool {

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -82,6 +82,22 @@ impl DesktopSurface {
         self.scene.settle_scroll_at(logical_position)
     }
 
+    pub(crate) fn focus_text_input_at(&mut self, logical_position: [f32; 2]) -> bool {
+        self.scene.focus_text_input_at(logical_position)
+    }
+
+    pub(crate) fn dispatch_text_input(&mut self, event: &crate::DesktopTextInputEvent) -> bool {
+        self.scene.dispatch_text_input(event)
+    }
+
+    pub(crate) fn selected_text(&self) -> Option<String> {
+        self.scene.selected_text()
+    }
+
+    pub(crate) fn focused_text_input_rect(&self) -> Option<whisker_protocol::LayoutRect> {
+        self.scene.focused_text_input_rect()
+    }
+
     pub(crate) fn advance_scroll_animations(&mut self, delta_ms: f32) -> bool {
         self.scene.advance_scroll_animations(delta_ms)
     }


### PR DESCRIPTION
## Summary
- add explicit Android, iOS, Web, and Desktop Host manifests for `whisker-input`
- keep mobile native controls while adding a browser-native input/textarea Host implementation
- add a GPUI-style Desktop editable-text seam: package-owned value/selection/composition state, GPU text rendering, and Host-routed keyboard/IME/clipboard/focus events
- transfer boolean and integer props as typed `WhiskerValue` values on every Host instead of stringifying them
- export the package element schema for generated Host bootstrap and document the GPUI input-system research behind the Desktop design

## Desktop model
- `whisker-input-desktop` owns editing state, grapheme-safe mutations, secure text, selection/caret rendering, and raster caching
- `whisker-desktop` only owns the cross-module OS seam and winit integration
- the font system and glyph cache are shared across fields; rasters are cached by generation, physical size, and scale
- X11 and Wayland clipboard paths are enabled on Linux

## Validation
- `cargo test --workspace --all-targets`
- `cargo clippy -p whisker-input -p whisker-input-web -p whisker-input-desktop -p whisker-desktop --all-targets -- -D warnings`
- `cargo check -p whisker-input-web --target wasm32-unknown-unknown`
- `cargo package -p whisker-input --allow-dirty --no-verify`
- Android Gradle/KSP: `:whisker-input:compileDebugKotlin --warning-mode all`
- iOS simulator build/install/launch through `whisker run ios`
- Web and Desktop build/launch through `whisker run web` / `whisker run desktop`
