### PR TITLE
fix(runtime): recover from Host transaction failures

### DIFF
--- a/crates/whisker-driver/src/ffi_runtime.rs
+++ b/crates/whisker-driver/src/ffi_runtime.rs
@@ -74,6 +74,7 @@ struct MobileRuntime {
     environment_epoch: u64,
     viewport_epoch: u32,
     viewport: Viewport,
+    retrying_failed_frame: bool,
 }
 
 #[cfg(feature = "hot-reload")]
@@ -265,12 +266,9 @@ pub unsafe fn create(
         environment_epoch: 1,
         viewport_epoch: 1,
         viewport,
+        retrying_failed_frame: false,
     });
-    if !mobile.drain_resource_commands() {
-        let modules = std::rc::Rc::clone(&mobile.modules);
-        let _ = with_module_host(&modules, || mobile.runtime.unmount());
-        return std::ptr::null_mut();
-    }
+    mobile.drain_resource_commands();
     request_frame(request_data);
     Box::into_raw(mobile).cast()
 }
@@ -311,15 +309,20 @@ pub unsafe fn tick(
             LayoutOptions::default(),
         )
     });
-    if !mobile.drain_resource_commands() {
-        mobile_error("Whisker mobile Host rejected a resource command");
-        return true;
-    }
+    mobile.drain_resource_commands();
     match frame_result {
-        Ok(drive) => !drive.needs_frame,
+        Ok(drive) => {
+            mobile.retrying_failed_frame = false;
+            !drive.needs_frame
+        }
         Err(error) => {
             mobile_error(format_args!("Whisker mobile frame failed: {error}"));
-            true
+            if mobile.retrying_failed_frame {
+                true
+            } else {
+                mobile.retrying_failed_frame = true;
+                false
+            }
         }
     }
 }
@@ -518,12 +521,27 @@ pub unsafe fn dispatch_resource_event(
 }
 
 impl MobileRuntime {
-    fn drain_resource_commands(&mut self) -> bool {
-        self.runtime
-            .surface()
-            .take_resource_commands()
-            .iter()
-            .all(|command| self.resources.send(command))
+    fn drain_resource_commands(&mut self) {
+        for command in self.runtime.surface().take_resource_commands() {
+            if self.resources.send(&command) {
+                continue;
+            }
+            let ResourceCommand::Load(request) = command else {
+                mobile_error("Whisker mobile Host rejected a resource release");
+                continue;
+            };
+            let event = ResourceEvent::Failed {
+                resource: request.resource,
+                generation: request.generation,
+                code: ResourceFailureCode::Unsupported,
+                diagnostic: Some("Host rejected the resource command".to_owned()),
+            };
+            if let Err(error) = self.runtime.dispatch_resource_event(&event) {
+                mobile_error(format_args!(
+                    "Whisker mobile resource rejection could not be applied: {error}"
+                ));
+            }
+        }
     }
 }
 

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -88,13 +88,16 @@ pub enum DeferredMeasurementApply {
     },
     /// The request, key, or environment generation was no longer current.
     IgnoredStale,
+    /// A re-entrant Host callback was accepted for ordered delivery at the
+    /// next safe runtime boundary.
+    Queued,
 }
 
 impl DeferredMeasurementApply {
     pub(crate) fn invalidated_nodes(&self) -> &[NodeId] {
         match self {
             Self::Applied { invalidated_nodes } => invalidated_nodes,
-            Self::IgnoredStale => &[],
+            Self::IgnoredStale | Self::Queued => &[],
         }
     }
 }

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -840,9 +840,9 @@ impl SurfaceEngine {
 
     /// Presents the next transaction and applies the Host acknowledgement.
     ///
-    /// `NeedSnapshot` rotates the scene epoch and leaves a complete snapshot
-    /// ready for the next call. A sink error discards only the prepared packet;
-    /// retained semantic changes remain dirty and can be retried.
+    /// `NeedSnapshot`, a sink error, or an invalid acknowledgement rotates the
+    /// scene epoch and leaves a complete snapshot ready for the next call.
+    /// This repairs Hosts that may have applied part of a rejected packet.
     pub fn present<Sink: FrameSink>(
         &mut self,
         viewport_epoch: u32,
@@ -858,15 +858,24 @@ impl SurfaceEngine {
         let result = match sink.present(&packet) {
             Ok(result) => result,
             Err(error) => {
-                self.discard_pending()
-                    .expect("a sink error always follows successful frame preparation");
+                self.require_snapshot()
+                    .expect("a prepared frame can always be replaced by a snapshot");
                 return Err(SurfacePresentError::Sink(error));
             }
         };
         match result {
-            ApplyResult::Accepted { revision } => self
-                .accept_pending(revision)
-                .map_err(SurfacePresentError::Surface)?,
+            ApplyResult::Accepted { revision } => {
+                if let Err(error) = self.accept_pending(revision) {
+                    // An acknowledgement that does not match the prepared
+                    // frame means sender and receiver no longer agree on the
+                    // retained revision. Do not leave the rejected packet
+                    // pending: the next frame must repair the receiver from a
+                    // complete snapshot.
+                    self.require_snapshot()
+                        .expect("a prepared frame can always be replaced by a snapshot");
+                    return Err(SurfacePresentError::Surface(error));
+                }
+            }
             ApplyResult::NeedSnapshot { .. } => self
                 .require_snapshot()
                 .map_err(SurfacePresentError::Surface)?,
@@ -2572,6 +2581,10 @@ mod tests {
             surface.present(1, &mut sink),
             Ok(Some(ApplyResult::Accepted { revision: 3 }))
         );
+        assert_eq!(
+            sink.renderer.frames().last().unwrap().packet.header.mode,
+            FrameMode::Snapshot
+        );
         assert_eq!(surface.present(1, &mut sink), Ok(None));
 
         surface.scene.set_opacity(root, 0.4).unwrap();
@@ -2585,7 +2598,16 @@ mod tests {
                 }
             )))
         );
-        surface.discard_pending().unwrap();
+        assert!(surface.has_pending_work());
+        sink.behavior = SinkBehavior::Record;
+        assert_eq!(
+            surface.present(1, &mut sink),
+            Ok(Some(ApplyResult::Accepted { revision: 4 }))
+        );
+        assert_eq!(
+            sink.renderer.frames().last().unwrap().packet.header.mode,
+            FrameMode::Snapshot
+        );
 
         surface.scene.set_scene_epoch_for_tests(u32::MAX);
         surface.scene.set_opacity(root, 0.6).unwrap();

--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -51,7 +51,10 @@ mod tests {
         BindType, append_child, create_element, remove_child, set_attribute, set_event_listener,
         set_specified_style,
     };
-    use whisker_engine::whisker_protocol::{InputEventKind, SurfaceId};
+    use whisker_engine::whisker_protocol::{
+        InputEventKind, MeasuredSize, MeasurementKey, MeasurementMetrics, MeasurementRequestId,
+        ResourceFailureCode, ResourceId, SurfaceId,
+    };
     use whisker_style::{SpecifiedStyle, StyleEnvironment, StyleNumber, StyleProperty, StyleValue};
 
     #[test]
@@ -101,6 +104,36 @@ mod tests {
                 pointer: None,
                 target: surface.root(),
                 detail: WhiskerValue::Null,
+            })
+            .unwrap();
+
+        assert_eq!(surface.surface_snapshot_count(), 1);
+    }
+
+    #[test]
+    fn mounting_many_styled_elements_takes_one_surface_snapshot() {
+        __reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(83).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        surface.reset_surface_snapshot_count();
+        let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+        runtime
+            .mount(|| {
+                let root = create_element(ElementTag::View);
+                for index in 0..256 {
+                    let child = create_element(ElementTag::View);
+                    set_specified_style(
+                        child,
+                        &SpecifiedStyle::new().push(
+                            StyleProperty::Opacity,
+                            StyleValue::Number(StyleNumber::new(index as f32 / 256.0)),
+                        ),
+                    );
+                    append_child(root, child);
+                }
+                root
             })
             .unwrap();
 
@@ -237,6 +270,149 @@ mod tests {
     }
 
     #[test]
+    fn reentrant_host_events_are_queued_and_drained_in_fifo_order() {
+        __reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(80).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        let wakes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let wake_count = Arc::clone(&wakes);
+        let mut runtime = RuntimeInstance::new(
+            surface.clone(),
+            RuntimeWakeHandle::new(move || {
+                wake_count.fetch_add(1, Ordering::Relaxed);
+            }),
+        );
+        let modules = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        let order = Rc::new(RefCell::new(Vec::new()));
+        let subscription = Rc::new(RefCell::new(None::<ModuleSubscription>));
+        with_module_host(&modules, || {
+            runtime
+                .mount({
+                    let order = Rc::clone(&order);
+                    let subscription = Rc::clone(&subscription);
+                    move || {
+                        let root = create_element(ElementTag::View);
+                        let input_order = Rc::clone(&order);
+                        set_event_listener(
+                            root,
+                            "queued-input",
+                            BindType::Bind,
+                            Box::new(move |_| input_order.borrow_mut().push("input")),
+                        );
+                        let module_order = Rc::clone(&order);
+                        *subscription.borrow_mut() = Some(PlatformModule::named("demo").on_event(
+                            "queued-module",
+                            move |_| {
+                                module_order.borrow_mut().push("module");
+                            },
+                        ));
+                        root
+                    }
+                })
+                .unwrap();
+        });
+
+        let queued_input = InputEvent {
+            surface: surface.surface(),
+            timestamp_ms: 1.0,
+            kind: InputEventKind::Named("queued-input".to_owned()),
+            pointer: None,
+            target: surface.root(),
+            detail: WhiskerValue::Null,
+        };
+        runtime.context.enter(|| {
+            assert!(runtime.dispatch_input(&queued_input).unwrap().queued);
+            assert!(
+                runtime
+                    .dispatch_module_event(&modules, "demo", "queued-module", WhiskerValue::Null,)
+                    .unwrap()
+            );
+            assert!(order.borrow().is_empty());
+            assert_eq!(runtime.pending_host_events.borrow().len(), 2);
+        });
+
+        runtime
+            .dispatch_input(&InputEvent {
+                kind: InputEventKind::Named("drain".to_owned()),
+                timestamp_ms: 2.0,
+                ..queued_input
+            })
+            .unwrap();
+        assert_eq!(*order.borrow(), ["input", "module"]);
+        assert!(runtime.pending_host_events.borrow().is_empty());
+        assert!(wakes.load(Ordering::Relaxed) >= 3);
+
+        runtime.context.enter(|| subscription.borrow_mut().take());
+    }
+
+    #[test]
+    fn reentrant_measurement_and_resource_completions_report_queued() {
+        __reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(81).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        let mut runtime = RuntimeInstance::new(surface, RuntimeWakeHandle::new(|| {}));
+        runtime.mount(|| create_element(ElementTag::View)).unwrap();
+        let ready = MeasurementReady {
+            key: MeasurementKey::new(1).unwrap(),
+            request_id: MeasurementRequestId::new(1).unwrap(),
+            environment_epoch: 1,
+            metrics: MeasurementMetrics {
+                size: MeasuredSize::new(10.0, 10.0),
+                first_baseline: None,
+                last_baseline: None,
+                overflow: None,
+                prepared_content: None,
+            },
+        };
+        let resource = ResourceEvent::Failed {
+            resource: ResourceId::new(1).unwrap(),
+            generation: 1,
+            code: ResourceFailureCode::Decode,
+            diagnostic: Some("failed".to_owned()),
+        };
+
+        runtime.context.enter(|| {
+            assert_eq!(
+                runtime.measurement_ready(&ready).unwrap(),
+                DeferredMeasurementApply::Queued
+            );
+            assert_eq!(
+                runtime.dispatch_resource_event(&resource).unwrap(),
+                ResourceEventApply::Queued
+            );
+            assert_eq!(runtime.pending_host_events.borrow().len(), 2);
+        });
+        runtime.pending_host_events.borrow_mut().clear();
+    }
+
+    #[test]
+    fn stale_explicit_input_target_is_an_unhandled_event() {
+        __reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(82).unwrap(),
+            StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+        );
+        let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+        runtime.mount(|| create_element(ElementTag::View)).unwrap();
+
+        let dispatch = runtime
+            .dispatch_input(&InputEvent {
+                surface: surface.surface(),
+                timestamp_ms: 1.0,
+                kind: InputEventKind::Click,
+                pointer: None,
+                target: Some(NodeId::new(u64::MAX).unwrap()),
+                detail: WhiskerValue::Null,
+            })
+            .unwrap();
+        assert_eq!(dispatch, InputDispatch::default());
+    }
+
+    #[test]
     fn root_remount_replaces_only_the_instance_application_tree() {
         __reset_for_tests();
         let surface = SurfaceRuntime::new(
@@ -293,6 +469,12 @@ pub enum RuntimeEventError {
     Input(RuntimeInputError),
     /// Resource completion validation or generation matching failed.
     Resource(RuntimeResourceError),
+    /// Re-entrant Host callbacks exceeded the bounded per-instance queue.
+    HostEventQueueFull {
+        /// Maximum number of callbacks retained until the current runtime
+        /// turn reaches a safe drain point.
+        limit: usize,
+    },
 }
 
 impl fmt::Display for RuntimeEventError {
@@ -319,12 +501,14 @@ pub enum RuntimeDriveError<MeasurementError, SinkError> {
     Lifecycle(RuntimeLifecycleError),
     /// Measurement, layout, or presentation failed.
     Frame(RuntimeFrameError<MeasurementError, SinkError>),
-    /// A queued Host event failed validation or routing.
-    Input(RuntimeInputError),
+    /// An ordered Host callback failed while being drained at a safe point.
+    HostEvent(RuntimeEventError),
     /// Host viewport values could not be applied to the retained style environment.
     Environment(crate::RuntimeBindingError),
     /// Rust-owned transition sampling could not update the retained scene.
     Motion(crate::RuntimeBindingError),
+    /// Reactive rendering could not commit its retained-scene transaction.
+    Binding(crate::RuntimeBindingError),
 }
 
 impl<MeasurementError: fmt::Debug, SinkError: fmt::Debug> fmt::Display
@@ -354,10 +538,24 @@ pub struct RuntimeInstance {
     wake: RuntimeWakeHandle,
     owner: Option<Owner>,
     lifecycle: RuntimeLifecycle,
-    pending_input: RefCell<VecDeque<InputEvent>>,
+    pending_host_events: RefCell<VecDeque<PendingHostEvent>>,
     activations: RefCell<ActivationRecognizer>,
     wake_enabled: Arc<AtomicBool>,
 }
+
+enum PendingHostEvent {
+    Input(InputEvent),
+    Module {
+        modules: Rc<ModuleHost>,
+        module: String,
+        event: String,
+        payload: WhiskerValue,
+    },
+    Measurement(MeasurementReady),
+    Resource(ResourceEvent),
+}
+
+const HOST_EVENT_QUEUE_CAP: usize = 4096;
 
 #[derive(Clone, Copy, Debug)]
 struct ActivationCandidate {
@@ -471,7 +669,7 @@ impl RuntimeInstance {
             wake,
             owner: None,
             lifecycle: RuntimeLifecycle::Created,
-            pending_input: RefCell::new(VecDeque::new()),
+            pending_host_events: RefCell::new(VecDeque::new()),
             activations: RefCell::new(ActivationRecognizer::default()),
             wake_enabled,
         }
@@ -496,12 +694,16 @@ impl RuntimeInstance {
         let surface = self.surface.clone();
         let (owner, root) = self.context.enter(|| {
             view::with_installed_renderer(surface.renderer(), || {
+                surface.begin_mutation_batch();
                 crate::drain_runtime_dispatches();
                 let owner = Owner::new(None);
                 let root = owner.with(application);
                 view::set_root(root);
                 reactive::flush();
                 reactive::flush_mounts();
+                if let Err(error) = surface.finish_mutation_batch() {
+                    surface.defer_binding_error(error);
+                }
                 (owner, root)
             })
         });
@@ -517,6 +719,7 @@ impl RuntimeInstance {
         self.require(RuntimeLifecycle::Running, "pause")?;
         self.wake_enabled.store(false, Ordering::Release);
         self.activations.borrow_mut().clear();
+        self.pending_host_events.borrow_mut().clear();
         let owner = self.owner.expect("a running runtime has a root owner");
         let surface = self.surface.clone();
         self.context.enter(|| {
@@ -560,7 +763,7 @@ impl RuntimeInstance {
         self.context.enter(|| {
             view::with_installed_renderer(surface.renderer(), || owner.dispose());
         });
-        self.pending_input.borrow_mut().clear();
+        self.pending_host_events.borrow_mut().clear();
         self.activations.borrow_mut().clear();
         self.context.shutdown();
         self.lifecycle = RuntimeLifecycle::Unmounted;
@@ -664,14 +867,7 @@ impl RuntimeInstance {
                 .validate()
                 .map_err(RuntimeInputError::InvalidInput)
                 .map_err(RuntimeEventError::Input)?;
-            const INPUT_CAP: usize = 4096;
-            let mut pending = self.pending_input.borrow_mut();
-            if pending.len() >= INPUT_CAP {
-                return Err(RuntimeEventError::Input(
-                    RuntimeInputError::InputQueueFull { limit: INPUT_CAP },
-                ));
-            }
-            pending.push_back(event.clone());
+            self.enqueue_host_event(PendingHostEvent::Input(event.clone()))?;
             return Ok(InputDispatch {
                 queued: true,
                 ..InputDispatch::default()
@@ -684,8 +880,7 @@ impl RuntimeInstance {
                 let dispatch = self
                     .dispatch_input_active(event)
                     .map_err(RuntimeEventError::Input)?;
-                self.drain_pending_input()
-                    .map_err(RuntimeEventError::Input)?;
+                self.drain_pending_host_events()?;
                 Ok(dispatch)
             })
         })
@@ -713,23 +908,25 @@ impl RuntimeInstance {
                 operation: "dispatch a module event",
             }));
         }
+        if self.context.is_entered() {
+            self.enqueue_host_event(PendingHostEvent::Module {
+                modules: Rc::clone(modules),
+                module: module.to_owned(),
+                event: event.to_owned(),
+                payload,
+            })?;
+            return Ok(true);
+        }
         let surface = self.surface.clone();
         self.context.enter(|| {
             view::with_installed_renderer(surface.renderer(), || {
-                with_module_host(modules, || {
-                    if self.lifecycle == RuntimeLifecycle::Running {
-                        crate::drain_runtime_dispatches();
-                    }
-                    surface.begin_mutation_batch();
-                    let dispatched = modules.dispatch_event(module, event, payload);
-                    reactive::flush();
-                    reactive::flush_mounts();
-                    surface
-                        .finish_mutation_batch()
-                        .map_err(RuntimeInputError::Binding)
-                        .map_err(RuntimeEventError::Input)?;
-                    Ok(dispatched)
-                })
+                if self.lifecycle == RuntimeLifecycle::Running {
+                    crate::drain_runtime_dispatches();
+                }
+                let dispatched =
+                    self.dispatch_module_event_active(modules, module, event, payload)?;
+                self.drain_pending_host_events()?;
+                Ok(dispatched)
             })
         })
     }
@@ -751,16 +948,19 @@ impl RuntimeInstance {
                 operation: "apply deferred measurement",
             }));
         }
+        if self.context.is_entered() {
+            self.enqueue_host_event(PendingHostEvent::Measurement(ready.clone()))?;
+            return Ok(DeferredMeasurementApply::Queued);
+        }
         let surface = self.surface.clone();
         let apply = self.context.enter(|| {
             view::with_installed_renderer(surface.renderer(), || {
                 if self.lifecycle == RuntimeLifecycle::Running {
                     crate::drain_runtime_dispatches();
                 }
-                surface
-                    .apply_measurement_ready(ready)
-                    .map_err(RuntimeInputError::Binding)
-                    .map_err(RuntimeEventError::Input)
+                let apply = self.measurement_ready_active(ready)?;
+                self.drain_pending_host_events()?;
+                Ok(apply)
             })
         })?;
         if self.lifecycle == RuntimeLifecycle::Running
@@ -789,10 +989,22 @@ impl RuntimeInstance {
                 operation: "apply resource completion",
             }));
         }
-        let apply = self
-            .surface
-            .apply_resource_event(event)
+        event
+            .validate()
+            .map_err(RuntimeResourceError::InvalidMessage)
             .map_err(RuntimeEventError::Resource)?;
+        if self.context.is_entered() {
+            self.enqueue_host_event(PendingHostEvent::Resource(event.clone()))?;
+            return Ok(ResourceEventApply::Queued);
+        }
+        let surface = self.surface.clone();
+        let apply = self.context.enter(|| {
+            view::with_installed_renderer(surface.renderer(), || {
+                let apply = self.resource_event_active(event)?;
+                self.drain_pending_host_events()?;
+                Ok(apply)
+            })
+        })?;
         if self.lifecycle == RuntimeLifecycle::Running && apply == ResourceEventApply::Applied {
             self.wake.wake();
         }
@@ -825,13 +1037,17 @@ impl RuntimeInstance {
                     .update_environment(environment)
                     .map_err(RuntimeDriveError::Environment)?;
                 crate::drain_runtime_dispatches();
-                self.drain_pending_input()
-                    .map_err(RuntimeDriveError::Input)?;
+                self.drain_pending_host_events()
+                    .map_err(RuntimeDriveError::HostEvent)?;
+                surface.begin_mutation_batch();
                 crate::anim_hook::step(timestamp_ms);
                 reactive::flush();
                 crate::tasks::run_until_stalled();
                 reactive::flush();
                 reactive::flush_mounts();
+                surface
+                    .finish_mutation_batch()
+                    .map_err(RuntimeDriveError::Binding)?;
                 surface
                     .step_motion(timestamp_ms)
                     .map_err(RuntimeDriveError::Motion)?;
@@ -850,14 +1066,16 @@ impl RuntimeInstance {
                     )
                     .map_err(RuntimeDriveError::Frame)?;
                 let recovery = matches!(frame.presentation, Some(ApplyResult::NeedSnapshot { .. }));
-                self.drain_pending_input()
-                    .map_err(RuntimeDriveError::Input)?;
+                let drained_events = self
+                    .drain_pending_host_events()
+                    .map_err(RuntimeDriveError::HostEvent)?;
                 Ok(RuntimeDrive {
                     frame,
                     needs_frame: recovery
+                        || drained_events > 0
                         || reactive::has_pending_work()
                         || surface.has_active_motion()
-                        || !self.pending_input.borrow().is_empty(),
+                        || !self.pending_host_events.borrow().is_empty(),
                 })
             })
         })
@@ -910,16 +1128,110 @@ impl RuntimeInstance {
         }
     }
 
-    fn drain_pending_input(&self) -> Result<(), RuntimeInputError> {
-        const INPUT_CAP: usize = 4096;
-        for _ in 0..INPUT_CAP {
-            let Some(event) = self.pending_input.borrow_mut().pop_front() else {
-                return Ok(());
-            };
-            self.dispatch_input_active(&event)?;
+    fn dispatch_module_event_active(
+        &self,
+        modules: &Rc<ModuleHost>,
+        module: &str,
+        event: &str,
+        payload: WhiskerValue,
+    ) -> Result<bool, RuntimeEventError> {
+        with_module_host(modules, || {
+            self.surface.begin_mutation_batch();
+            let dispatched = modules.dispatch_event(module, event, payload);
+            reactive::flush();
+            reactive::flush_mounts();
+            self.surface
+                .finish_mutation_batch()
+                .map_err(RuntimeInputError::Binding)
+                .map_err(RuntimeEventError::Input)?;
+            Ok(dispatched)
+        })
+    }
+
+    fn measurement_ready_active(
+        &self,
+        ready: &MeasurementReady,
+    ) -> Result<DeferredMeasurementApply, RuntimeEventError> {
+        self.surface
+            .apply_measurement_ready(ready)
+            .map_err(RuntimeInputError::Binding)
+            .map_err(RuntimeEventError::Input)
+    }
+
+    fn resource_event_active(
+        &self,
+        event: &ResourceEvent,
+    ) -> Result<ResourceEventApply, RuntimeEventError> {
+        self.surface
+            .apply_resource_event(event)
+            .map_err(RuntimeEventError::Resource)
+    }
+
+    fn enqueue_host_event(&self, event: PendingHostEvent) -> Result<(), RuntimeEventError> {
+        let mut pending = self.pending_host_events.borrow_mut();
+        if pending.len() >= HOST_EVENT_QUEUE_CAP {
+            return Err(RuntimeEventError::HostEventQueueFull {
+                limit: HOST_EVENT_QUEUE_CAP,
+            });
         }
-        crate::runtime_wake::wake_runtime();
+        pending.push_back(event);
+        drop(pending);
+        self.wake.wake();
         Ok(())
+    }
+
+    fn drain_pending_host_events(&self) -> Result<usize, RuntimeEventError> {
+        if self.pending_host_events.borrow().is_empty() {
+            return Ok(0);
+        }
+        // One re-entrant burst is one retained-scene transaction. Individual
+        // handlers nest into this batch, avoiding one speculative Surface
+        // snapshot per queued callback.
+        self.surface.begin_mutation_batch();
+        let mut drained = 0;
+        let result = (|| {
+            while drained < HOST_EVENT_QUEUE_CAP {
+                let Some(event) = self.pending_host_events.borrow_mut().pop_front() else {
+                    return Ok(());
+                };
+                match event {
+                    PendingHostEvent::Input(event) => self
+                        .dispatch_input_active(&event)
+                        .map_err(RuntimeEventError::Input)
+                        .map(|_| ())?,
+                    PendingHostEvent::Module {
+                        modules,
+                        module,
+                        event,
+                        payload,
+                    } => self
+                        .dispatch_module_event_active(&modules, &module, &event, payload)
+                        .map(|_| ())?,
+                    PendingHostEvent::Measurement(ready) => {
+                        self.measurement_ready_active(&ready).map(|_| ())?
+                    }
+                    PendingHostEvent::Resource(event) => {
+                        self.resource_event_active(&event).map(|_| ())?
+                    }
+                }
+                drained += 1;
+            }
+            self.wake.wake();
+            Ok(())
+        })();
+        let finish = self
+            .surface
+            .finish_mutation_batch()
+            .map_err(RuntimeInputError::Binding)
+            .map_err(RuntimeEventError::Input);
+        match result {
+            Ok(()) => finish?,
+            Err(error) => {
+                let _ = finish;
+                return Err(error);
+            }
+        }
+        Ok(drained)
     }
 
     fn require(

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -183,11 +183,6 @@ pub enum RuntimeInputError {
         /// Current mounted root.
         root: NodeId,
     },
-    /// Re-entrant Host delivery exceeded the bounded event queue.
-    InputQueueFull {
-        /// Maximum number of retained events.
-        limit: usize,
-    },
     /// No root has been mounted.
     MissingRoot,
     /// Retained scene hit testing failed.
@@ -259,6 +254,9 @@ pub enum ResourceEventApply {
     Applied,
     /// A replacement or release made the completion stale before it arrived.
     Stale,
+    /// A re-entrant Host callback was accepted for ordered delivery at the
+    /// next safe runtime boundary.
+    Queued,
 }
 
 /// Failure while driving layout for a surface populated through `render!`.
@@ -434,7 +432,8 @@ impl SurfaceRuntime {
         self.state.borrow().root
     }
 
-    /// Returns the first rejected runtime mutation without clearing it.
+    /// Returns the first rejected runtime mutation that has not yet been
+    /// reported at a runtime boundary.
     pub fn binding_error(&self) -> Option<RuntimeBindingError> {
         self.state.borrow().error.clone()
     }
@@ -462,6 +461,10 @@ impl SurfaceRuntime {
         self.state.borrow_mut().finish_mutation_batch()
     }
 
+    pub(crate) fn defer_binding_error(&self, error: RuntimeBindingError) {
+        self.state.borrow_mut().defer_binding_error(error);
+    }
+
     /// Re-resolves every retained style against current Host viewport metrics.
     ///
     /// The update is prepared against a cloned surface and committed only after
@@ -478,8 +481,10 @@ impl SurfaceRuntime {
     /// Hit-tests and routes one Host-normalized event through Rust listeners.
     pub fn dispatch_input(&self, event: &InputEvent) -> Result<InputDispatch, RuntimeInputError> {
         let (target, firings, body) = {
-            let state = self.state.borrow();
-            state.ensure_valid().map_err(RuntimeInputError::Binding)?;
+            let mut state = self.state.borrow_mut();
+            state
+                .take_binding_error()
+                .map_err(RuntimeInputError::Binding)?;
             if event.surface != state.surface.surface() {
                 return Err(RuntimeInputError::SurfaceMismatch {
                     expected: state.surface.surface(),
@@ -495,7 +500,10 @@ impl SurfaceRuntime {
                 Some(captured)
             } else if let Some(target) = event.target {
                 if state.surface.node(target).is_none() {
-                    return Err(RuntimeInputError::UnknownTarget { node: target });
+                    // A Host may have queued this event while the preceding
+                    // frame removed its target. Treat that normal race as an
+                    // unhandled event rather than poisoning the surface.
+                    return Ok(InputDispatch::default());
                 }
                 Some(target)
             } else if let Some(pointer) = event.pointer {
@@ -541,7 +549,7 @@ impl SurfaceRuntime {
         ready: &MeasurementReady,
     ) -> Result<DeferredMeasurementApply, RuntimeBindingError> {
         let mut state = self.state.borrow_mut();
-        state.ensure_valid()?;
+        state.take_binding_error()?;
         state
             .surface
             .apply_measurement_ready(ready)
@@ -637,9 +645,9 @@ impl SurfaceRuntime {
     ) -> Result<LayoutProgress, RuntimeLayoutError<Provider::Error>> {
         let (layout, notifications) = {
             let mut state = self.state.borrow_mut();
-            if let Some(error) = state.error.clone() {
-                return Err(RuntimeLayoutError::Binding(error));
-            }
+            state
+                .take_binding_error()
+                .map_err(RuntimeLayoutError::Binding)?;
             state
                 .flush_background_projections()
                 .map_err(RuntimeLayoutError::Binding)?;
@@ -693,7 +701,9 @@ impl SurfaceRuntime {
         RuntimePresentError<Sink::Error>,
     > {
         let mut state = self.state.borrow_mut();
-        state.ensure_valid().map_err(RuntimePresentError::Binding)?;
+        state
+            .take_binding_error()
+            .map_err(RuntimePresentError::Binding)?;
         state
             .flush_background_projections()
             .map_err(RuntimePresentError::Binding)?;
@@ -928,14 +938,10 @@ impl BindingState {
             .mutation_batch
             .take()
             .expect("the outermost mutation batch remains installed");
+        let recorded_error = self.error.take();
         let roots = self.minimal_dirty_roots(batch.dirty_elements);
         if let Err(error) = self.apply_subtrees_now(&roots) {
-            for (element, change) in batch.style_changes {
-                if let Some(entry) = self.elements.get_mut(&element) {
-                    entry.specified = change.previous;
-                }
-            }
-            self.record(Err(error.clone()));
+            Self::restore_style_changes(&mut self.elements, batch.style_changes);
             return Err(error);
         }
         let snapshots = batch
@@ -955,10 +961,20 @@ impl BindingState {
         if !snapshots.is_empty()
             && let Err(error) = self.configure_style_motion(snapshots)
         {
-            self.record(Err(error.clone()));
             return Err(error);
         }
-        Ok(())
+        recorded_error.map_or(Ok(()), Err)
+    }
+
+    fn restore_style_changes(
+        elements: &mut HashMap<Element, BoundElement>,
+        changes: Vec<(Element, PendingStyleChange)>,
+    ) {
+        for (element, change) in changes {
+            if let Some(entry) = elements.get_mut(&element) {
+                entry.specified = change.previous;
+            }
+        }
     }
 
     fn mark_subtree_dirty(&mut self, element: Element) {
@@ -991,9 +1007,9 @@ impl BindingState {
             .collect()
     }
 
-    fn ensure_valid(&self) -> Result<(), RuntimeBindingError> {
-        match &self.error {
-            Some(error) => Err(error.clone()),
+    fn take_binding_error(&mut self) -> Result<(), RuntimeBindingError> {
+        match self.error.take() {
+            Some(error) => Err(error),
             None => Ok(()),
         }
     }
@@ -1003,6 +1019,12 @@ impl BindingState {
             Ok(()) => crate::runtime_wake::wake_runtime(),
             Err(error) if self.error.is_none() => self.error = Some(error),
             Err(_) => {}
+        }
+    }
+
+    fn defer_binding_error(&mut self, error: RuntimeBindingError) {
+        if self.error.is_none() {
+            self.error = Some(error);
         }
     }
 
@@ -1093,7 +1115,7 @@ impl BindingState {
         &mut self,
         environment: StyleEnvironment,
     ) -> Result<bool, RuntimeBindingError> {
-        self.ensure_valid()?;
+        self.take_binding_error()?;
         // Validate even an empty surface before accepting Host-owned metrics.
         resolve_style(&SpecifiedStyle::new(), None, environment)?;
         if environment == self.environment {

--- a/crates/whisker-runtime/src/surface_runtime/motion.rs
+++ b/crates/whisker-runtime/src/surface_runtime/motion.rs
@@ -9,7 +9,7 @@ impl SurfaceRuntime {
             return Err(RuntimeBindingError::InvalidMotionTimestamp);
         }
         let mut state = self.state.borrow_mut();
-        state.ensure_valid()?;
+        state.take_binding_error()?;
         let mut motion_events = state
             .elements
             .values_mut()

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -17,7 +17,7 @@ use whisker::runtime::view::{
 };
 use whisker::{
     ElementModuleDefinition, ElementProviderMetadata, ElementRegistry, ElementTag,
-    RuntimeBindingError, SurfaceRuntime,
+    RuntimeBindingError, RuntimeFrameError, RuntimeLayoutError, SurfaceRuntime,
 };
 use whisker_engine::RecordingRenderer;
 use whisker_engine::whisker_layout::LayoutSize;
@@ -1472,6 +1472,54 @@ fn surface_registry_rejects_a_schema_introduced_after_bootstrap() {
         })
     );
     assert_eq!(surface.element_registrations(), bootstrap_registrations);
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn rejected_binding_is_reported_once_without_poisoning_the_surface() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(18).unwrap(),
+        StyleEnvironment::new(100.0, 100.0, 1.0, 14.0),
+    );
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            let root = whisker_runtime::view::create_element(whisker::ElementTag::View);
+            let _ = whisker_runtime::view::create_element_by_name("missing:Element");
+            root
+        });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    assert!(matches!(
+        surface.render_frame(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        ),
+        Err(RuntimeFrameError::Layout(RuntimeLayoutError::Binding(
+            RuntimeBindingError::UnsupportedCustomElement { .. }
+        )))
+    ));
+    assert_eq!(surface.binding_error(), None);
+
+    surface
+        .render_frame(
+            LayoutSize::new(100.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .expect("a rejected element must not poison later valid frames");
+    assert_eq!(renderer.frames().len(), 1);
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }
 

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -243,7 +243,7 @@ struct DesktopApplication {
     viewport_epoch: u32,
     environment_epoch: u64,
     started_at: Instant,
-    frame_failed: bool,
+    retrying_failed_frame: bool,
     pointer: DesktopPointerAdapter,
     pending_scroll_settle: Option<(Instant, [f32; 2])>,
     modifiers: Modifiers,
@@ -274,7 +274,7 @@ impl DesktopApplication {
             viewport_epoch: 1,
             environment_epoch: 1,
             started_at: Instant::now(),
-            frame_failed: false,
+            retrying_failed_frame: false,
             pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
             pending_scroll_settle: None,
             modifiers: Modifiers::default(),
@@ -350,22 +350,18 @@ impl DesktopApplication {
             .as_ref()
             .expect("mounted Desktop window")
             .set_visible(true);
-        if !self.frame_failed {
-            self.request_frame();
-        }
+        self.request_frame();
         Ok(())
     }
 
     fn request_frame(&self) {
-        if !self.frame_failed
-            && let Some(window) = &self.window
-        {
+        if let Some(window) = &self.window {
             window.request_redraw();
         }
     }
 
     fn drive_frame(&mut self) {
-        if self.frame_failed || self.viewport.width == 0 || self.viewport.height == 0 {
+        if self.viewport.width == 0 || self.viewport.height == 0 {
             return;
         }
         let (Some(window), Some(runtime), Some(host)) =
@@ -393,16 +389,20 @@ impl DesktopApplication {
         );
         match frame_result {
             Ok(result) => {
+                self.retrying_failed_frame = false;
                 if result.needs_frame {
                     window.request_redraw();
                 }
             }
             Err(error) => {
-                self.frame_failed = true;
                 eprintln!("whisker {TARGET_NAME} frame failed: {error}");
+                if !self.retrying_failed_frame {
+                    self.retrying_failed_frame = true;
+                    window.request_redraw();
+                }
             }
         }
-        if !self.frame_failed {
+        if !self.retrying_failed_frame {
             self.update_accessibility(false);
             self.sync_text_input();
         }
@@ -415,7 +415,7 @@ impl DesktopApplication {
         }
         self.viewport_epoch = self.viewport_epoch.wrapping_add(1).max(1);
         self.environment_epoch = self.environment_epoch.wrapping_add(1).max(1);
-        self.frame_failed = false;
+        self.retrying_failed_frame = false;
         self.request_frame();
     }
 
@@ -432,11 +432,12 @@ impl DesktopApplication {
             .expect("mounted Desktop runtime has a Host")
             .with_modules(|| runtime.dispatch_input(&event))
         {
-            self.frame_failed = true;
             eprintln!("dispatch {TARGET_NAME} input failed: {error}");
-        } else {
-            self.request_frame();
         }
+        // A failed transaction may still have committed independent valid
+        // mutations. Rendering also gives a transient binding failure its
+        // one-shot recovery boundary.
+        self.request_frame();
     }
 
     fn sync_text_input(&self) {

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -26,6 +26,7 @@ use crate::{
 thread_local! {
     static APPLICATION: RefCell<Option<WebApplication>> = const { RefCell::new(None) };
     static FRAME_SCHEDULED: Cell<bool> = const { Cell::new(false) };
+    static RETRYING_FAILED_FRAME: Cell<bool> = const { Cell::new(false) };
     static URGENT_FRAME_SCHEDULED: Cell<bool> = const { Cell::new(false) };
     #[cfg(feature = "hot-reload")]
     static MOUNTED_APPLICATION_HASH: Cell<u64> = const { Cell::new(0) };
@@ -46,6 +47,7 @@ pub fn run_with_application_hash(
     application: fn() -> Element,
     _application_hash: fn() -> u64,
 ) -> Result<(), WebError> {
+    RETRYING_FAILED_FRAME.set(false);
     #[cfg(feature = "hot-reload")]
     MOUNTED_APPLICATION_HASH.set(_application_hash());
     APPLICATION.with(|slot| {
@@ -461,9 +463,7 @@ pub(crate) fn request_frame() {
                     .ok_or_else(|| WebError("Web application is not mounted".into()))?
                     .drive_frame(timestamp_ms)
             });
-            if let Err(error) = result {
-                web_sys::console::error_1(&error.to_string().into());
-            }
+            finish_frame(result);
         });
         match web_sys::window().and_then(|window| {
             window
@@ -502,11 +502,23 @@ pub(crate) fn request_urgent_frame() {
                     None => Ok(()),
                 }
             });
-            if let Err(error) = result {
-                web_sys::console::error_1(&error.to_string().into());
-            }
+            finish_frame(result);
         });
     });
+}
+
+fn finish_frame(result: Result<(), WebError>) {
+    match result {
+        Ok(()) => RETRYING_FAILED_FRAME.set(false),
+        Err(error) => {
+            web_sys::console::error_1(&error.to_string().into());
+            RETRYING_FAILED_FRAME.with(|retrying| {
+                if !retrying.replace(true) {
+                    request_frame();
+                }
+            });
+        }
+    }
 }
 
 fn browser_window() -> Result<web_sys::Window, WebError> {


### PR DESCRIPTION
## Summary

- recover whole-frame transport and acknowledgement failures with a fresh snapshot instead of permanently wedging a surface
- serialize synchronous Host re-entry through one bounded FIFO queue while keeping the normal event path allocation-free
- batch mount, frame, and queued event mutations so large trees take one retained-scene snapshot per transaction
- report binding errors once, ignore stale removed input targets, and isolate rejected resource loads
- give mobile, Web, and Desktop one automatic recovery frame without creating a persistent retry loop

## Performance

- the common non-reentrant path only checks one `Cell<bool>` and continues directly
- owned event copies and queue allocations occur only during actual synchronous re-entry
- a queued burst shares one speculative Surface snapshot
- the retry policy is bounded to one automatic frame, so persistent failures cannot busy-loop

## Tests

- `cargo test --workspace --all-targets`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`