### PR TITLE
fix(paint): canonicalize radial gradients in Rust

### DIFF
--- a/crates/whisker-engine/src/lib.rs
+++ b/crates/whisker-engine/src/lib.rs
@@ -21,6 +21,7 @@ mod color;
 mod layout;
 mod measurement;
 mod paint;
+mod radial_gradient;
 mod recording;
 mod scene;
 mod surface;

--- a/crates/whisker-engine/src/radial_gradient.rs
+++ b/crates/whisker-engine/src/radial_gradient.rs
@@ -230,3 +230,320 @@ pub(super) const fn absolute_length(length: f32) -> PaintLengthPercentage {
         fraction: 0.0,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use whisker_protocol::{
+        BackgroundAttachment, BlendMode, GradientStop, LayoutRect, PaintColor, PaintEdges,
+        PaintPosition, ResourceId,
+    };
+
+    use super::*;
+
+    fn coordinate(length: f32, fraction: f32) -> PaintCoordinate {
+        PaintCoordinate { length, fraction }
+    }
+
+    fn length(length: f32, fraction: f32) -> PaintLengthPercentage {
+        PaintLengthPercentage { length, fraction }
+    }
+
+    fn radial(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        stop: PaintCoordinate,
+    ) -> BackgroundLayer {
+        radial_with_first_stop(shape, extent, radii, Some(coordinate(0.0, 0.0)), stop)
+    }
+
+    fn radial_with_first_stop(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        first_stop: Option<PaintCoordinate>,
+        stop: PaintCoordinate,
+    ) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::RadialGradient {
+                shape,
+                extent,
+                center: PaintPosition {
+                    x: coordinate(0.0, 0.25),
+                    y: coordinate(0.0, 0.75),
+                },
+                radii,
+                repeating: false,
+                stops: vec![
+                    GradientStop {
+                        color: PaintColor::default(),
+                        position: first_stop,
+                    },
+                    GradientStop {
+                        color: PaintColor::default(),
+                        position: Some(stop),
+                    },
+                ],
+            },
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Border,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
+    fn resource() -> BackgroundLayer {
+        let mut layer = radial(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+            None,
+            coordinate(0.0, 1.0),
+        );
+        layer.image = PaintImage::Resource(ResourceId::new(1).expect("resource"));
+        layer
+    }
+
+    fn source(shape: RadialGradientShape, extent: RadialGradientExtent) -> RadialBackgroundSource {
+        RadialBackgroundSource {
+            layer: 0,
+            shape,
+            extent,
+            radii: None,
+            original_stop_positions: None,
+        }
+    }
+
+    #[test]
+    fn source_discovery_skips_non_radial_and_already_canonical_layers() {
+        let absolute = coordinate(0.0, 0.5);
+        let layers = vec![
+            resource(),
+            radial(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::ClosestSide,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                None,
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                coordinate(4.0, 0.5),
+            ),
+        ];
+        let found = sources(&layers);
+        assert_eq!(found.len(), 4);
+        assert_eq!(found[0].layer, 1);
+        assert_eq!(found[3].layer, 5);
+        assert!(found[3].original_stop_positions.is_some());
+    }
+
+    #[test]
+    fn canonicalization_tolerates_stale_sources_and_unresolved_explicit_radii() {
+        let geometry = LayoutGeometry::from(LayoutRect {
+            width: 100.0,
+            height: 80.0,
+            ..LayoutRect::default()
+        });
+        let stale = RadialBackgroundSource {
+            layer: 1,
+            ..source(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::ClosestSide,
+            )
+        };
+        let mut no_layer = vec![resource()];
+        canonicalize(&mut no_layer, &[stale], geometry, None);
+
+        let wrong_kind = source(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+        );
+        canonicalize(&mut no_layer, &[wrong_kind], geometry, None);
+
+        let missing_radii = source(RadialGradientShape::Ellipse, RadialGradientExtent::Explicit);
+        let mut layers = vec![radial(
+            RadialGradientShape::Ellipse,
+            RadialGradientExtent::Explicit,
+            None,
+            coordinate(0.0, 0.5),
+        )];
+        let unchanged = layers.clone();
+        canonicalize(&mut layers, &[missing_radii], geometry, None);
+        assert_eq!(layers, unchanged);
+
+        let mut resolved = vec![radial_with_first_stop(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+            None,
+            None,
+            coordinate(0.0, 0.5),
+        )];
+        canonicalize(
+            &mut resolved,
+            &[source(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::ClosestSide,
+            )],
+            geometry,
+            None,
+        );
+        let expected = radial_with_first_stop(
+            RadialGradientShape::Ellipse,
+            RadialGradientExtent::Explicit,
+            Some((absolute_length(20.0), absolute_length(20.0))),
+            None,
+            coordinate(0.0, 0.5),
+        );
+        assert_eq!(resolved[0].image, expected.image);
+    }
+
+    #[test]
+    fn positioning_and_tile_geometry_cover_every_supported_mode() {
+        let geometry = LayoutGeometry {
+            border_box: LayoutRect {
+                width: 100.0,
+                height: 80.0,
+                ..LayoutRect::default()
+            },
+            content_box: LayoutRect {
+                width: 70.0,
+                height: 50.0,
+                ..LayoutRect::default()
+            },
+        };
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Content),
+            [70.0, 50.0]
+        );
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Padding),
+            [100.0, 80.0]
+        );
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Margin),
+            [100.0, 80.0]
+        );
+
+        let paint = BoxPaint {
+            border_widths: PaintEdges {
+                top: length(2.0, 0.1),
+                right: length(3.0, 0.1),
+                bottom: length(4.0, 0.1),
+                left: length(5.0, 0.1),
+            },
+            ..BoxPaint::default()
+        };
+        assert_eq!(
+            background_positioning_size(geometry, Some(&paint), PaintBox::Padding),
+            [72.0, 58.0]
+        );
+
+        let mut layer = resource();
+        for size in [
+            BackgroundSize::Auto,
+            BackgroundSize::Cover,
+            BackgroundSize::Contain,
+        ] {
+            layer.size = size;
+            assert_eq!(gradient_tile_size(100.0, 80.0, &layer), [100.0, 80.0]);
+        }
+        layer.size = BackgroundSize::Explicit {
+            width: Some(length(10.0, 0.5)),
+            height: None,
+        };
+        layer.repeat_x = ImageRepeat::Round;
+        layer.repeat_y = ImageRepeat::Round;
+        assert_eq!(gradient_tile_size(100.0, 80.0, &layer), [50.0, 80.0]);
+        layer.size = BackgroundSize::Explicit {
+            width: None,
+            height: Some(length(10.0, 0.5)),
+        };
+        assert_eq!(gradient_tile_size(-1.0, -2.0, &layer), [0.0, 9.0]);
+        assert_eq!(rounded_tile_size(0.0, 2.0), 2.0);
+        assert_eq!(rounded_tile_size(2.0, -1.0), 0.0);
+        assert!((rounded_tile_size(100.0, 40.0) - 100.0 / 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn radius_resolution_covers_all_circle_and_ellipse_extents() {
+        let expected = [
+            (RadialGradientExtent::ClosestSide, (20.0, 20.0)),
+            (RadialGradientExtent::FarthestSide, (75.0, 75.0)),
+            (
+                RadialGradientExtent::ClosestCorner,
+                (25.0_f32.hypot(20.0), 25.0_f32.hypot(20.0)),
+            ),
+            (
+                RadialGradientExtent::FarthestCorner,
+                (75.0_f32.hypot(60.0), 75.0_f32.hypot(60.0)),
+            ),
+        ];
+        for (extent, circle_expected) in expected {
+            assert_eq!(
+                resolved_radii(
+                    &source(RadialGradientShape::Circle, extent),
+                    100.0,
+                    80.0,
+                    25.0,
+                    20.0,
+                ),
+                Some(circle_expected)
+            );
+            assert!(
+                resolved_radii(
+                    &source(RadialGradientShape::Ellipse, extent),
+                    100.0,
+                    80.0,
+                    25.0,
+                    20.0,
+                )
+                .is_some()
+            );
+        }
+
+        let explicit_ellipse = RadialBackgroundSource {
+            radii: Some((length(10.0, 0.5), length(4.0, 0.25))),
+            ..source(RadialGradientShape::Ellipse, RadialGradientExtent::Explicit)
+        };
+        assert_eq!(
+            resolved_radii(&explicit_ellipse, 100.0, 80.0, 25.0, 20.0),
+            Some((60.0, 24.0))
+        );
+        let explicit_circle = RadialBackgroundSource {
+            radii: explicit_ellipse.radii,
+            ..source(RadialGradientShape::Circle, RadialGradientExtent::Explicit)
+        };
+        let circle = resolved_radii(&explicit_circle, 100.0, 80.0, 25.0, 20.0).unwrap();
+        assert_eq!(circle.0, circle.1);
+
+        let invalid = RadialBackgroundSource {
+            radii: Some((absolute_length(f32::NAN), absolute_length(1.0))),
+            ..explicit_ellipse
+        };
+        assert_eq!(resolved_radii(&invalid, 100.0, 80.0, 25.0, 20.0), None);
+        assert_eq!(ellipse_corner_scale(0.0, 0.0, 4.0, 3.0), 0.0);
+    }
+}

--- a/crates/whisker-engine/src/radial_gradient.rs
+++ b/crates/whisker-engine/src/radial_gradient.rs
@@ -1,0 +1,232 @@
+//! Layout-dependent canonicalization for the radial-gradient wire subset.
+
+use std::sync::Arc;
+
+use whisker_protocol::{
+    BackgroundLayer, BackgroundSize, BoxPaint, ImageRepeat, LayoutGeometry, PaintBox,
+    PaintCoordinate, PaintImage, PaintLengthPercentage, RadialGradientExtent, RadialGradientShape,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct RadialBackgroundSource {
+    layer: usize,
+    shape: RadialGradientShape,
+    extent: RadialGradientExtent,
+    radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+    original_stop_positions: Option<Arc<[Option<PaintCoordinate>]>>,
+}
+
+pub(super) fn sources(layers: &[BackgroundLayer]) -> Vec<RadialBackgroundSource> {
+    layers
+        .iter()
+        .enumerate()
+        .filter_map(|(layer, background)| {
+            let PaintImage::RadialGradient {
+                shape,
+                extent,
+                radii,
+                stops,
+                ..
+            } = &background.image
+            else {
+                return None;
+            };
+            let already_canonical = *shape == RadialGradientShape::Ellipse
+                && *extent == RadialGradientExtent::Explicit
+                && radii.is_some()
+                && stops
+                    .iter()
+                    .all(|stop| stop.position.is_some_and(|position| position.length == 0.0));
+            (!already_canonical).then_some(RadialBackgroundSource {
+                layer,
+                shape: *shape,
+                extent: *extent,
+                radii: *radii,
+                original_stop_positions: stops
+                    .iter()
+                    .any(|stop| stop.position.is_some_and(|position| position.length != 0.0))
+                    .then(|| stops.iter().map(|stop| stop.position).collect::<Arc<[_]>>()),
+            })
+        })
+        .collect()
+}
+
+pub(super) fn canonicalize(
+    layers: &mut [BackgroundLayer],
+    sources: &[RadialBackgroundSource],
+    geometry: LayoutGeometry,
+    paint: Option<&BoxPaint>,
+) {
+    for source in sources {
+        let Some(layer) = layers.get_mut(source.layer) else {
+            continue;
+        };
+        let [positioning_width, positioning_height] =
+            background_positioning_size(geometry, paint, layer.origin);
+        let [tile_width, tile_height] =
+            gradient_tile_size(positioning_width, positioning_height, layer);
+        let PaintImage::RadialGradient {
+            shape,
+            extent,
+            center,
+            radii,
+            stops,
+            ..
+        } = &mut layer.image
+        else {
+            continue;
+        };
+        let center_x = center.x.length + center.x.fraction * tile_width;
+        let center_y = center.y.length + center.y.fraction * tile_height;
+        let Some((radius_x, radius_y)) =
+            resolved_radii(source, tile_width, tile_height, center_x, center_y)
+        else {
+            continue;
+        };
+        if let Some(originals) = &source.original_stop_positions {
+            for (stop, original) in stops.iter_mut().zip(originals.iter()) {
+                stop.position = *original;
+            }
+        }
+        let gradient_line = radius_x.max(f32::EPSILON);
+        for stop in stops {
+            if let Some(position) = &mut stop.position {
+                position.fraction += position.length / gradient_line;
+                position.length = 0.0;
+            }
+        }
+        *shape = RadialGradientShape::Ellipse;
+        *extent = RadialGradientExtent::Explicit;
+        *radii = Some((absolute_length(radius_x), absolute_length(radius_y)));
+    }
+}
+
+fn background_positioning_size(
+    geometry: LayoutGeometry,
+    paint: Option<&BoxPaint>,
+    origin: PaintBox,
+) -> [f32; 2] {
+    let border = geometry.border_box;
+    match origin {
+        PaintBox::Content => [geometry.content_box.width, geometry.content_box.height],
+        PaintBox::Padding => {
+            let Some(paint) = paint else {
+                return [border.width, border.height];
+            };
+            let horizontal = resolve_length(paint.border_widths.left, border.width)
+                + resolve_length(paint.border_widths.right, border.width);
+            let vertical = resolve_length(paint.border_widths.top, border.height)
+                + resolve_length(paint.border_widths.bottom, border.height);
+            [
+                (border.width - horizontal).max(0.0),
+                (border.height - vertical).max(0.0),
+            ]
+        }
+        _ => [border.width, border.height],
+    }
+}
+
+fn gradient_tile_size(width: f32, height: f32, layer: &BackgroundLayer) -> [f32; 2] {
+    let [mut tile_width, mut tile_height] = match layer.size {
+        BackgroundSize::Auto | BackgroundSize::Cover | BackgroundSize::Contain => [width, height],
+        BackgroundSize::Explicit {
+            width: explicit_width,
+            height: explicit_height,
+        } => [
+            explicit_width.map_or(width, |value| resolve_length(value, width)),
+            explicit_height.map_or(height, |value| resolve_length(value, height)),
+        ],
+    };
+    if layer.repeat_x == ImageRepeat::Round {
+        tile_width = rounded_tile_size(width, tile_width);
+    }
+    if layer.repeat_y == ImageRepeat::Round {
+        tile_height = rounded_tile_size(height, tile_height);
+    }
+    [tile_width.max(0.0), tile_height.max(0.0)]
+}
+
+fn rounded_tile_size(area: f32, tile: f32) -> f32 {
+    if area <= 0.0 || tile <= 0.0 {
+        return tile.max(0.0);
+    }
+    let count = (area / tile).round().max(1.0);
+    area / count
+}
+
+fn resolved_radii(
+    source: &RadialBackgroundSource,
+    width: f32,
+    height: f32,
+    center_x: f32,
+    center_y: f32,
+) -> Option<(f32, f32)> {
+    let left = center_x.abs();
+    let right = (width - center_x).abs();
+    let top = center_y.abs();
+    let bottom = (height - center_y).abs();
+    let closest_x = left.min(right);
+    let farthest_x = left.max(right);
+    let closest_y = top.min(bottom);
+    let farthest_y = top.max(bottom);
+    let circle = source.shape == RadialGradientShape::Circle;
+    let radii = match source.extent {
+        RadialGradientExtent::Explicit => {
+            let (radius_x, radius_y) = source.radii?;
+            if circle {
+                let basis = width.hypot(height) / 2.0_f32.sqrt();
+                let radius = resolve_length(radius_x, basis);
+                (radius, radius)
+            } else {
+                (
+                    resolve_length(radius_x, width),
+                    resolve_length(radius_y, height),
+                )
+            }
+        }
+        RadialGradientExtent::ClosestSide if circle => {
+            let radius = closest_x.min(closest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::FarthestSide if circle => {
+            let radius = farthest_x.max(farthest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::ClosestCorner if circle => {
+            let radius = closest_x.hypot(closest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::FarthestCorner if circle => {
+            let radius = farthest_x.hypot(farthest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::ClosestSide => (closest_x, closest_y),
+        RadialGradientExtent::FarthestSide => (farthest_x, farthest_y),
+        RadialGradientExtent::ClosestCorner => {
+            let scale = ellipse_corner_scale(closest_x, closest_y, closest_x, closest_y);
+            (closest_x * scale, closest_y * scale)
+        }
+        RadialGradientExtent::FarthestCorner => {
+            let scale = ellipse_corner_scale(farthest_x, farthest_y, farthest_x, farthest_y);
+            (farthest_x * scale, farthest_y * scale)
+        }
+    };
+    (radii.0.is_finite() && radii.1.is_finite()).then_some(radii)
+}
+
+fn ellipse_corner_scale(radius_x: f32, radius_y: f32, x: f32, y: f32) -> f32 {
+    let normalized_x = if radius_x > 0.0 { x / radius_x } else { 0.0 };
+    let normalized_y = if radius_y > 0.0 { y / radius_y } else { 0.0 };
+    normalized_x.hypot(normalized_y)
+}
+
+fn resolve_length(value: PaintLengthPercentage, extent: f32) -> f32 {
+    value.length + value.fraction * extent
+}
+
+pub(super) const fn absolute_length(length: f32) -> PaintLengthPercentage {
+    PaintLengthPercentage {
+        length,
+        fraction: 0.0,
+    }
+}

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -4,16 +4,22 @@ use std::{collections::HashMap, error::Error, fmt};
 
 use whisker_layout::{IntrinsicMeasurer, LayoutError, LayoutSize, LayoutSnapshot, LayoutTree};
 use whisker_protocol::{
-    Accessibility, ApplyResult, BoxPaint, CommandId, Cursor, CursorKeyword, ElementTypeId,
-    FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, MeasurementMetrics, MeasurementReady,
-    MeasurementResponse, MeasurementSpec, NodeId, PointerId, PropertyId, SurfaceId, TextContent,
-    WhiskerValue,
+    Accessibility, ApplyResult, BackgroundLayer, BoxPaint, CommandId, Cursor, CursorKeyword,
+    ElementTypeId, FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, MeasurementMetrics,
+    MeasurementReady, MeasurementResponse, MeasurementSpec, NodeId, PointerId, PropertyId,
+    SurfaceId, TextContent, WhiskerValue,
 };
 use whisker_style::{
     ComputedLayoutStyle, ComputedStyle, ComputedTransformStyle, CursorValue, PointerEventsValue,
     PropertyImpactSet,
 };
 
+#[cfg(test)]
+use crate::radial_gradient::absolute_length;
+use crate::radial_gradient::{
+    RadialBackgroundSource, canonicalize as canonicalize_radial_backgrounds,
+    sources as radial_background_sources,
+};
 use crate::{
     DeferredMeasurementApply, FrameSink, LayoutProgress, MeasurementApply, MeasurementError,
     PlainTextInput, Scene, SceneError, SceneNode, lower_paint, lower_plain_text, lower_text_style,
@@ -204,6 +210,7 @@ pub struct SurfaceEngine {
     layout_dirty: bool,
     layout_provisional: bool,
     transforms: HashMap<NodeId, ComputedTransformStyle>,
+    radial_backgrounds: HashMap<NodeId, Vec<RadialBackgroundSource>>,
     measurements: MeasurementCoordinator,
 }
 
@@ -223,6 +230,7 @@ impl SurfaceEngine {
             layout_dirty: false,
             layout_provisional: false,
             transforms: HashMap::new(),
+            radial_backgrounds: HashMap::new(),
             measurements: MeasurementCoordinator::default(),
         }
     }
@@ -439,6 +447,7 @@ impl SurfaceEngine {
             .expect("scene and layout trees remain structurally synchronized");
         for removed in removed {
             self.transforms.remove(&removed);
+            self.radial_backgrounds.remove(&removed);
             self.measurements.remove_node(removed);
         }
         self.layout_dirty = true;
@@ -595,10 +604,25 @@ impl SurfaceEngine {
     pub fn set_background_layers(
         &mut self,
         node: NodeId,
-        layers: Vec<whisker_protocol::BackgroundLayer>,
+        mut layers: Vec<BackgroundLayer>,
     ) -> Result<(), SurfaceError> {
         self.ensure_mutable()?;
+        let sources = radial_background_sources(&layers);
+        if let Some(geometry) = self
+            .last_layout
+            .as_ref()
+            .and_then(|layout| layout.get(node))
+            .copied()
+        {
+            let paint = self.scene.node(node).and_then(SceneNode::box_paint);
+            canonicalize_radial_backgrounds(&mut layers, &sources, geometry, paint);
+        }
         self.scene.set_background_layers(node, layers)?;
+        if sources.is_empty() {
+            self.radial_backgrounds.remove(&node);
+        } else {
+            self.radial_backgrounds.insert(node, sources);
+        }
         Ok(())
     }
 
@@ -934,6 +958,24 @@ impl SurfaceEngine {
                     .map(Option::flatten)
             })
             .collect::<Result<Vec<_>, SurfaceError>>()?;
+        let radial_backgrounds = if self.radial_backgrounds.is_empty() {
+            Vec::new()
+        } else {
+            changed
+                .iter()
+                .filter_map(|(node, geometry)| {
+                    let sources = self.radial_backgrounds.get(node)?;
+                    let mut layers = self.scene.node(*node)?.background_layers().to_vec();
+                    canonicalize_radial_backgrounds(
+                        &mut layers,
+                        sources,
+                        *geometry,
+                        self.scene.node(*node).and_then(SceneNode::box_paint),
+                    );
+                    Some((*node, layers))
+                })
+                .collect::<Vec<_>>()
+        };
         for ((node, rect), transform) in changed.iter().zip(transforms) {
             self.scene
                 .set_layout(*node, *rect)
@@ -943,6 +985,11 @@ impl SurfaceEngine {
                     .set_transform(*node, transform)
                     .expect("the transform was validated before layout projection");
             }
+        }
+        for (node, layers) in radial_backgrounds {
+            self.scene
+                .set_background_layers(node, layers)
+                .expect("canonical radial backgrounds preserve protocol validity");
         }
         self.last_layout = Some(snapshot);
         self.last_inputs = Some(inputs);
@@ -1038,7 +1085,8 @@ mod tests {
         MeasuredSize, MeasurementKey, MeasurementKind, MeasurementMetrics, MeasurementPayload,
         MeasurementReady, MeasurementRequestId, MeasurementResponse, MeasurementSpec,
         NativeControlMeasurePayload, NodeId, Operation, PaintBox, PaintCoordinate, PaintImage,
-        PaintPosition, PendingMeasurePolicy, PointerId, ReplacedContentMeasurePayload, ResourceId,
+        PaintLengthPercentage, PaintPosition, PendingMeasurePolicy, PointerId,
+        RadialGradientExtent, RadialGradientShape, ReplacedContentMeasurePayload, ResourceId,
         SurfaceId, TextMeasurePayload, TextMeasureStyle, UnsupportedMeasurementReason,
     };
     use whisker_style::{
@@ -1085,6 +1133,159 @@ mod tests {
             attachment: BackgroundAttachment::Scroll,
             blend_mode: BlendMode::Normal,
         }
+    }
+
+    fn radial_background(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+    ) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::RadialGradient {
+                shape,
+                extent,
+                center: PaintPosition {
+                    x: PaintCoordinate {
+                        length: 0.0,
+                        fraction: 0.5,
+                    },
+                    y: PaintCoordinate {
+                        length: 0.0,
+                        fraction: 0.5,
+                    },
+                },
+                radii,
+                repeating: false,
+                stops: vec![
+                    whisker_protocol::GradientStop {
+                        color: Default::default(),
+                        position: Some(PaintCoordinate {
+                            length: 0.0,
+                            fraction: 0.0,
+                        }),
+                    },
+                    whisker_protocol::GradientStop {
+                        color: Default::default(),
+                        position: Some(PaintCoordinate {
+                            length: 25.0,
+                            fraction: 0.0,
+                        }),
+                    },
+                ],
+            },
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Border,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
+    #[test]
+    fn layout_canonicalizes_radial_keyword_geometry_and_absolute_stops() {
+        let mut surface = SurfaceEngine::new(surface_id());
+        let root = surface
+            .create_node(element_type(), sized(200.0, 100.0))
+            .expect("root");
+        surface
+            .set_background_layers(
+                root,
+                vec![radial_background(
+                    RadialGradientShape::Circle,
+                    RadialGradientExtent::FarthestCorner,
+                    None,
+                )],
+            )
+            .expect("background");
+        surface
+            .compute_layout(root, LayoutSize::new(200.0, 100.0), &mut zero_measure)
+            .expect("layout");
+
+        let PaintImage::RadialGradient {
+            shape,
+            extent,
+            radii: Some((radius_x, radius_y)),
+            stops,
+            ..
+        } = &surface.node(root).unwrap().background_layers()[0].image
+        else {
+            panic!("expected canonical radial gradient")
+        };
+        let expected_radius = 100.0_f32.hypot(50.0);
+        assert_eq!(*shape, RadialGradientShape::Ellipse);
+        assert_eq!(*extent, RadialGradientExtent::Explicit);
+        assert!((radius_x.length - expected_radius).abs() < 0.001);
+        assert_eq!(*radius_x, *radius_y);
+        assert_eq!(radius_x.fraction, 0.0);
+        assert_eq!(stops[1].position.unwrap().length, 0.0);
+        assert!((stops[1].position.unwrap().fraction - 25.0 / expected_radius).abs() < 0.0001);
+
+        surface
+            .update_layout_style(root, sized(100.0, 100.0))
+            .expect("resize style");
+        surface
+            .compute_layout(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
+            .expect("resized layout");
+        let PaintImage::RadialGradient {
+            radii: Some((resized_radius, _)),
+            stops: resized_stops,
+            ..
+        } = &surface.node(root).unwrap().background_layers()[0].image
+        else {
+            panic!("expected resized radial gradient")
+        };
+        let resized_expected = 50.0_f32.hypot(50.0);
+        assert!((resized_radius.length - resized_expected).abs() < 0.001);
+        assert!(
+            (resized_stops[1].position.unwrap().fraction - 25.0 / resized_expected).abs() < 0.0001
+        );
+    }
+
+    #[test]
+    fn radial_canonicalization_preserves_ellipse_aspect_ratio_and_circle_radius() {
+        let geometry = LayoutGeometry::from(LayoutRect {
+            width: 200.0,
+            height: 100.0,
+            ..LayoutRect::default()
+        });
+        let mut layers = vec![
+            radial_background(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::FarthestCorner,
+                None,
+            ),
+            radial_background(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(20.0), absolute_length(20.0))),
+            ),
+        ];
+        let sources = radial_background_sources(&layers);
+        canonicalize_radial_backgrounds(&mut layers, &sources, geometry, None);
+
+        let PaintImage::RadialGradient {
+            radii: Some((ellipse_x, ellipse_y)),
+            ..
+        } = layers[0].image
+        else {
+            panic!("expected ellipse")
+        };
+        assert!((ellipse_x.length - 100.0 * 2.0_f32.sqrt()).abs() < 0.001);
+        assert!((ellipse_y.length - 50.0 * 2.0_f32.sqrt()).abs() < 0.001);
+        let PaintImage::RadialGradient {
+            shape,
+            radii: Some((circle_x, circle_y)),
+            ..
+        } = layers[1].image
+        else {
+            panic!("expected circle")
+        };
+        assert_eq!(shape, RadialGradientShape::Ellipse);
+        assert_eq!(circle_x, absolute_length(20.0));
+        assert_eq!(circle_y, absolute_length(20.0));
     }
 
     fn zero_measure(_: NodeId, _: MeasureRequest) -> LayoutSize {

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -965,7 +965,12 @@ impl SurfaceEngine {
                 .iter()
                 .filter_map(|(node, geometry)| {
                     let sources = self.radial_backgrounds.get(node)?;
-                    let mut layers = self.scene.node(*node)?.background_layers().to_vec();
+                    let mut layers = self
+                        .scene
+                        .node(*node)
+                        .expect("radial background owners remain live")
+                        .background_layers()
+                        .to_vec();
                     canonicalize_radial_backgrounds(
                         &mut layers,
                         sources,
@@ -1184,12 +1189,37 @@ mod tests {
         }
     }
 
+    type RadialParts<'a> = (
+        RadialGradientShape,
+        RadialGradientExtent,
+        Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        &'a [whisker_protocol::GradientStop],
+    );
+
+    fn radial_parts(image: &PaintImage) -> Option<RadialParts<'_>> {
+        match image {
+            PaintImage::RadialGradient {
+                shape,
+                extent,
+                radii,
+                stops,
+                ..
+            } => Some((*shape, *extent, *radii, stops)),
+            _ => None,
+        }
+    }
+
     #[test]
     fn layout_canonicalizes_radial_keyword_geometry_and_absolute_stops() {
+        assert!(radial_parts(&PaintImage::None).is_none());
         let mut surface = SurfaceEngine::new(surface_id());
         let root = surface
             .create_node(element_type(), sized(200.0, 100.0))
             .expect("root");
+        let plain_child = surface
+            .create_node(element_type(), sized(10.0, 10.0))
+            .expect("plain child");
+        surface.insert_child(root, plain_child, 0).expect("insert");
         surface
             .set_background_layers(
                 root,
@@ -1203,22 +1233,26 @@ mod tests {
         surface
             .compute_layout(root, LayoutSize::new(200.0, 100.0), &mut zero_measure)
             .expect("layout");
+        surface
+            .set_background_layers(
+                root,
+                vec![radial_background(
+                    RadialGradientShape::Circle,
+                    RadialGradientExtent::FarthestCorner,
+                    None,
+                )],
+            )
+            .expect("post-layout background");
 
-        let PaintImage::RadialGradient {
-            shape,
-            extent,
-            radii: Some((radius_x, radius_y)),
-            stops,
-            ..
-        } = &surface.node(root).unwrap().background_layers()[0].image
-        else {
-            panic!("expected canonical radial gradient")
-        };
+        let (shape, extent, radii, stops) =
+            radial_parts(&surface.node(root).unwrap().background_layers()[0].image)
+                .expect("canonical radial gradient");
+        let (radius_x, radius_y) = radii.expect("canonical radii");
         let expected_radius = 100.0_f32.hypot(50.0);
-        assert_eq!(*shape, RadialGradientShape::Ellipse);
-        assert_eq!(*extent, RadialGradientExtent::Explicit);
+        assert_eq!(shape, RadialGradientShape::Ellipse);
+        assert_eq!(extent, RadialGradientExtent::Explicit);
         assert!((radius_x.length - expected_radius).abs() < 0.001);
-        assert_eq!(*radius_x, *radius_y);
+        assert_eq!(radius_x, radius_y);
         assert_eq!(radius_x.fraction, 0.0);
         assert_eq!(stops[1].position.unwrap().length, 0.0);
         assert!((stops[1].position.unwrap().fraction - 25.0 / expected_radius).abs() < 0.0001);
@@ -1229,14 +1263,10 @@ mod tests {
         surface
             .compute_layout(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
             .expect("resized layout");
-        let PaintImage::RadialGradient {
-            radii: Some((resized_radius, _)),
-            stops: resized_stops,
-            ..
-        } = &surface.node(root).unwrap().background_layers()[0].image
-        else {
-            panic!("expected resized radial gradient")
-        };
+        let (_, _, resized_radii, resized_stops) =
+            radial_parts(&surface.node(root).unwrap().background_layers()[0].image)
+                .expect("resized radial gradient");
+        let (resized_radius, _) = resized_radii.expect("resized radii");
         let resized_expected = 50.0_f32.hypot(50.0);
         assert!((resized_radius.length - resized_expected).abs() < 0.001);
         assert!(
@@ -1266,23 +1296,12 @@ mod tests {
         let sources = radial_background_sources(&layers);
         canonicalize_radial_backgrounds(&mut layers, &sources, geometry, None);
 
-        let PaintImage::RadialGradient {
-            radii: Some((ellipse_x, ellipse_y)),
-            ..
-        } = layers[0].image
-        else {
-            panic!("expected ellipse")
-        };
+        let (_, _, ellipse_radii, _) = radial_parts(&layers[0].image).expect("ellipse");
+        let (ellipse_x, ellipse_y) = ellipse_radii.expect("ellipse radii");
         assert!((ellipse_x.length - 100.0 * 2.0_f32.sqrt()).abs() < 0.001);
         assert!((ellipse_y.length - 50.0 * 2.0_f32.sqrt()).abs() < 0.001);
-        let PaintImage::RadialGradient {
-            shape,
-            radii: Some((circle_x, circle_y)),
-            ..
-        } = layers[1].image
-        else {
-            panic!("expected circle")
-        };
+        let (shape, _, circle_radii, _) = radial_parts(&layers[1].image).expect("circle");
+        let (circle_x, circle_y) = circle_radii.expect("circle radii");
         assert_eq!(shape, RadialGradientShape::Ellipse);
         assert_eq!(circle_x, absolute_length(20.0));
         assert_eq!(circle_y, absolute_length(20.0));

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -27,8 +27,8 @@ pub enum RenderCapability {
     /// One resolved, non-repeating linear-gradient background image using the
     /// initial layer geometry and explicit color-stop positions.
     LinearGradients = 8,
-    /// One resolved, non-repeating explicit radial-gradient background image
-    /// using the initial layer geometry and explicit color-stop positions.
+    /// One resolved, non-repeating elliptical radial-gradient background image
+    /// with explicit radii and explicit fractional color-stop positions.
     RadialGradients = 9,
     /// One resolved, non-repeating conic-gradient background image using the
     /// initial layer geometry and explicit fractional color-stop positions.

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -785,6 +785,39 @@ fn background_gradients_lower_without_host_resources() {
     assert_eq!(radius_x.length, 40.0);
     assert_eq!(radius_y.fraction, 0.25);
 
+    let radial_circle = render_gradient(
+        50,
+        Gradient::Radial {
+            shape: RadialShape::Circle,
+            stops: stops(),
+        },
+    );
+    let PaintImage::RadialGradient {
+        shape,
+        extent,
+        radii: Some((radius_x, radius_y)),
+        stops: circle_stops,
+        ..
+    } = radial_circle
+    else {
+        panic!("expected canonical radial circle")
+    };
+    assert_eq!(
+        shape,
+        whisker_engine::whisker_protocol::RadialGradientShape::Ellipse
+    );
+    assert_eq!(
+        extent,
+        whisker_engine::whisker_protocol::RadialGradientExtent::Explicit
+    );
+    assert!((radius_x.length - 50.0_f32.hypot(50.0)).abs() < 0.001);
+    assert_eq!(radius_x, radius_y);
+    assert!(
+        circle_stops
+            .iter()
+            .all(|stop| stop.position.is_some_and(|position| position.length == 0.0))
+    );
+
     let conic = render_gradient(
         49,
         Gradient::Conic {


### PR DESCRIPTION
## Summary

- canonicalize circle/ellipse keyword radial gradients after Taffy layout into the explicit elliptical wire form accepted by every Host
- resolve absolute radial color stops into fractional positions before crossing the Host boundary
- recompute layout-dependent radii and stops after resize while retaining only compact metadata for non-canonical radial layers
- account for background origin, explicit background size, and `round` tile sizing in the shared engine
- align the radial capability documentation with its actual fractional-stop contract

## Performance

- nodes without non-canonical radial gradients pay one empty-map branch per layout pass
- only affected radial layers are copied during a geometry change
- original absolute stop positions use shared `Arc` storage, making speculative `SurfaceEngine` clones cheap
- no Host-specific branches or additional FFI fields are introduced

## Tests

- `cargo check --workspace --all-targets`
- `cargo clippy -p whisker-protocol -p whisker-engine -p whisker-runtime -p whisker-driver -p whisker-desktop -p whisker-web -p whisker --all-targets -- -D warnings`
- `cargo test -p whisker-protocol -p whisker-engine -p whisker-runtime -p whisker-driver -p whisker-desktop -p whisker-web -p whisker`
- `cargo fmt --all --check`
- `git diff --check`

The geometry follows CSS Images Level 3: corner ellipses preserve the corresponding side-derived aspect ratio and scale to pass through the selected corner.