### PR TITLE
fix(input): make Rust authoritative for hit testing

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 29
+#define WHISKER_MOBILE_ABI_MINOR 30
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -797,7 +797,10 @@ extern bool whisker_view_dispatch_pointer(void *handle,
                                           float x,
                                           float y,
                                           uint32_t buttons,
-                                          int16_t changed_button);
+                                          int16_t changed_button,
+                                          const uint64_t *scroll_nodes,
+                                          const float *scroll_offsets,
+                                          size_t scroll_count);
 
 extern bool whisker_view_dispatch_module_event(void *handle,
                                                const uint8_t *module,

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -1076,11 +1076,21 @@ JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchEve
     release_raw(&raw);free(bytes);return consumed?JNI_TRUE:JNI_FALSE;
 }
 
-JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchPointer(JNIEnv* env,jobject self,jlong handle,jdouble timestamp,jint event,jlong pointer_id,jint pointer_kind,jfloat x,jfloat y,jint buttons,jint changed_button){
-    (void)env;(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;
+JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchPointer(JNIEnv* env,jobject self,jlong handle,jdouble timestamp,jint event,jlong pointer_id,jint pointer_kind,jfloat x,jfloat y,jint buttons,jint changed_button,jlongArray scroll_nodes,jfloatArray scroll_offsets){
+    (void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;
     if(!view||!view->runtime||pointer_id<=0||buttons<0||changed_button<INT16_MIN||changed_button>INT16_MAX)return JNI_FALSE;
-    return whisker_view_dispatch_pointer(view->runtime,timestamp,(uint32_t)event,(uint64_t)pointer_id,
-        (uint32_t)pointer_kind,x,y,(uint32_t)buttons,(int16_t)changed_button)?JNI_TRUE:JNI_FALSE;
+    if(!scroll_nodes||!scroll_offsets)return JNI_FALSE;
+    jsize scroll_count=(*env)->GetArrayLength(env,scroll_nodes);
+    if(scroll_count<0||(*env)->GetArrayLength(env,scroll_offsets)!=scroll_count*2)return JNI_FALSE;
+    jlong* nodes=scroll_count?(*env)->GetLongArrayElements(env,scroll_nodes,NULL):NULL;
+    jfloat* offsets=scroll_count?(*env)->GetFloatArrayElements(env,scroll_offsets,NULL):NULL;
+    if(scroll_count&&(!nodes||!offsets)){if(nodes)(*env)->ReleaseLongArrayElements(env,scroll_nodes,nodes,JNI_ABORT);if(offsets)(*env)->ReleaseFloatArrayElements(env,scroll_offsets,offsets,JNI_ABORT);return JNI_FALSE;}
+    bool consumed=whisker_view_dispatch_pointer(view->runtime,timestamp,(uint32_t)event,(uint64_t)pointer_id,
+        (uint32_t)pointer_kind,x,y,(uint32_t)buttons,(int16_t)changed_button,
+        (const uint64_t*)nodes,(const float*)offsets,(size_t)scroll_count);
+    if(nodes)(*env)->ReleaseLongArrayElements(env,scroll_nodes,nodes,JNI_ABORT);
+    if(offsets)(*env)->ReleaseFloatArrayElements(env,scroll_offsets,offsets,JNI_ABORT);
+    return consumed?JNI_TRUE:JNI_FALSE;
 }
 
 JNIEXPORT void JNICALL Java_rs_whisker_runtime_WhiskerView_nativeResolveModule(JNIEnv* env,jobject self,jlong callback_ptr,jlong data_ptr,jobject payload){

--- a/crates/whisker-driver-sys/src/mobile.rs
+++ b/crates/whisker-driver-sys/src/mobile.rs
@@ -8,7 +8,7 @@ use std::ffi::c_void;
 use crate::{WhiskerBytesRef, WhiskerStringRef, WhiskerValueRaw};
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 29;
+pub const MOBILE_ABI_MINOR: u16 = 30;
 pub const FRAME_PROTOCOL_MAJOR: u16 = 1;
 pub const FRAME_PROTOCOL_MINOR: u16 = 4;
 
@@ -633,6 +633,9 @@ unsafe extern "C" {
         y: f32,
         buttons: u32,
         changed_button: i16,
+        scroll_nodes: *const u64,
+        scroll_offsets: *const f32,
+        scroll_count: usize,
     ) -> bool;
     pub fn whisker_view_dispatch_module_event(
         handle: *mut c_void,

--- a/crates/whisker-driver/src/ffi_runtime.rs
+++ b/crates/whisker-driver/src/ffi_runtime.rs
@@ -395,6 +395,9 @@ pub unsafe fn dispatch_pointer(
     y: f32,
     buttons: u32,
     changed_button: i16,
+    scroll_nodes: *const u64,
+    scroll_offsets: *const f32,
+    scroll_count: usize,
 ) -> bool {
     let Some(mobile) = (unsafe { handle.cast::<MobileRuntime>().as_ref() }) else {
         return false;
@@ -411,13 +414,46 @@ pub unsafe fn dispatch_pointer(
     ) else {
         return false;
     };
+    if scroll_count != 0 && (scroll_nodes.is_null() || scroll_offsets.is_null()) {
+        return false;
+    }
+    let Some(offset_count) = scroll_count.checked_mul(2) else {
+        return false;
+    };
+    let (nodes, offsets) = if scroll_count == 0 {
+        (&[][..], &[][..])
+    } else {
+        (
+            unsafe { std::slice::from_raw_parts(scroll_nodes, scroll_count) },
+            unsafe { std::slice::from_raw_parts(scroll_offsets, offset_count) },
+        )
+    };
+    let mut presentation = Vec::with_capacity(scroll_count);
+    for (index, raw_node) in nodes.iter().copied().enumerate() {
+        let Some(node) = NodeId::new(raw_node) else {
+            return false;
+        };
+        presentation.push(
+            whisker_engine::whisker_protocol::HostPresentationUpdate::ScrollOffset {
+                node,
+                offset: InputPoint {
+                    x: offsets[index * 2],
+                    y: offsets[index * 2 + 1],
+                },
+            },
+        );
+    }
     let modules = std::rc::Rc::clone(&mobile.modules);
-    with_module_host(&modules, || mobile.runtime.dispatch_input(&event))
-        .map(|value| value.consumed)
-        .unwrap_or_else(|error| {
-            eprintln!("Whisker mobile pointer input failed: {error}");
-            false
-        })
+    with_module_host(&modules, || {
+        mobile
+            .runtime
+            .dispatch_input_with_presentation(&event, &presentation)
+    })
+    .map(|value| value.consumed)
+    .unwrap_or_else(|error| {
+        eprintln!("Whisker mobile pointer input failed: {error}");
+        false
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -1,15 +1,19 @@
 //! Retained scene state and coalescing frame journal.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::fmt;
 
 use whisker_protocol::{
     Accessibility, BackgroundLayer, BoxClip, BoxPaint, CommandId, Cursor, ElementTypeId,
-    FrameHeader, FrameMode, FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, NodeId,
-    Operation, OverflowClip, PointerId, PropertyId, ProtocolVersion, SurfaceId, TextContent,
-    TextContentError, TextStyleSnapshot, Transform, Visibility, VisualEffects, WhiskerValue,
+    FrameHeader, FrameMode, FramePacket, HitTestBehavior, LayoutGeometry, NodeId, Operation,
+    PointerId, PropertyId, ProtocolVersion, SurfaceId, TextContent, TextContentError,
+    TextStyleSnapshot, Transform, Visibility, VisualEffects, WhiskerValue,
 };
+#[cfg(test)]
+use whisker_protocol::{InputPoint, OverflowClip};
+
+mod hit_test;
 
 /// A retained logical node owned by a [`Scene`].
 #[derive(Clone, Debug, PartialEq)]
@@ -33,7 +37,7 @@ pub struct SceneNode {
     event_mask: Option<u64>,
     hit_test: Option<HitTestBehavior>,
     cursor: Option<Cursor>,
-    captured_pointers: BTreeSet<PointerId>,
+    host_scroll_offset: [f32; 2],
 }
 
 impl SceneNode {
@@ -58,7 +62,7 @@ impl SceneNode {
             event_mask: None,
             hit_test: None,
             cursor: None,
-            captured_pointers: BTreeSet::new(),
+            host_scroll_offset: [0.0; 2],
         }
     }
 
@@ -150,6 +154,11 @@ impl SceneNode {
     /// Returns the retained resolved pointing-device cursor.
     pub const fn cursor(&self) -> Option<&Cursor> {
         self.cursor.as_ref()
+    }
+
+    /// Returns the latest Host-owned native scroll position.
+    pub const fn host_scroll_offset(&self) -> [f32; 2] {
+        self.host_scroll_offset
     }
 }
 
@@ -303,6 +312,7 @@ pub struct Scene {
     next_frame_id: u64,
     needs_snapshot: bool,
     nodes: BTreeMap<NodeId, SceneNode>,
+    pointer_captures: BTreeMap<PointerId, NodeId>,
     journal: ChangeJournal,
     pending: Option<FramePacket>,
 }
@@ -324,6 +334,7 @@ impl Scene {
             next_frame_id: 1,
             needs_snapshot: true,
             nodes: BTreeMap::new(),
+            pointer_captures: BTreeMap::new(),
             journal: ChangeJournal::default(),
             pending: None,
         }
@@ -354,71 +365,14 @@ impl Scene {
         self.nodes.get(&node)
     }
 
-    /// Finds the visually topmost node at one surface-space point.
-    pub fn hit_test(&self, root: NodeId, point: InputPoint) -> Result<Option<NodeId>, SceneError> {
-        self.require_node(root)?;
-        Ok(self.hit_test_node(root, point, 0.0, 0.0))
-    }
-
     /// Returns the node currently retaining one pointer capture.
     pub fn pointer_capture_target(&self, pointer: PointerId) -> Option<NodeId> {
-        self.nodes
-            .iter()
-            .find_map(|(node, state)| state.captured_pointers.contains(&pointer).then_some(*node))
+        self.pointer_captures.get(&pointer).copied()
     }
 
     #[cfg(test)]
     pub(crate) fn set_scene_epoch_for_tests(&mut self, scene_epoch: u32) {
         self.scene_epoch = scene_epoch;
-    }
-
-    fn hit_test_node(
-        &self,
-        node: NodeId,
-        point: InputPoint,
-        parent_x: f32,
-        parent_y: f32,
-    ) -> Option<NodeId> {
-        let state = self
-            .nodes
-            .get(&node)
-            .expect("hit-test traversal only visits retained nodes");
-        if state.visibility == Some(Visibility::Hidden)
-            || state.hit_test == Some(HitTestBehavior::None)
-        {
-            return None;
-        }
-        let layout = state.layout?;
-        let x = parent_x + layout.border_box.x;
-        let y = parent_y + layout.border_box.y;
-        let contains_x = point.x >= x && point.x <= x + layout.border_box.width;
-        let contains_y = point.y >= y && point.y <= y + layout.border_box.height;
-        let contains = contains_x && contains_y;
-        let children_clipped = state.clip.is_some_and(|clip| {
-            (clip.horizontal == OverflowClip::Hidden && !contains_x)
-                || (clip.vertical == OverflowClip::Hidden && !contains_y)
-        });
-
-        if state.hit_test != Some(HitTestBehavior::BoxOnly) && !children_clipped {
-            let mut children: Vec<(usize, NodeId)> =
-                state.children.iter().copied().enumerate().collect();
-            children.sort_by_key(|(index, child)| {
-                (
-                    self.nodes
-                        .get(child)
-                        .and_then(|child| child.z_order)
-                        .unwrap_or(0),
-                    *index,
-                )
-            });
-            for (_, child) in children.into_iter().rev() {
-                if let Some(target) = self.hit_test_node(child, point, x, y) {
-                    return Some(target);
-                }
-            }
-        }
-
-        (contains && state.hit_test != Some(HitTestBehavior::DescendantsOnly)).then_some(node)
     }
 
     /// Returns whether a snapshot, mutation, command, or retry needs a frame.
@@ -461,6 +415,8 @@ impl Scene {
                 .expect("retained subtree is internally complete");
             pending.extend(removed.children);
         }
+        self.pointer_captures
+            .retain(|_, target| self.nodes.contains_key(target));
         self.journal.push_barrier(Operation::DeleteNode { node });
         Ok(())
     }
@@ -902,6 +858,27 @@ impl Scene {
         Ok(())
     }
 
+    /// Updates transient Host-owned scroll state without producing a frame operation.
+    ///
+    /// Native scrolling advances independently of frame delivery. Retaining its
+    /// latest logical offset keeps Rust input routing aligned with the pixels the
+    /// Host currently presents while leaving Rust-authored layout unchanged.
+    pub fn update_host_scroll_offset(
+        &mut self,
+        node: NodeId,
+        offset: [f32; 2],
+    ) -> Result<(), SceneError> {
+        if !offset.into_iter().all(f32::is_finite) {
+            return Err(SceneError::NonFiniteNumber);
+        }
+        self.require_node(node)?;
+        self.nodes
+            .get_mut(&node)
+            .expect("node checked above")
+            .host_scroll_offset = offset;
+        Ok(())
+    }
+
     /// Sets a node's resolved pointing-device cursor.
     pub fn set_cursor(&mut self, node: NodeId, cursor: Cursor) -> Result<(), SceneError> {
         self.ensure_mutable()?;
@@ -926,15 +903,11 @@ impl Scene {
         pointer: PointerId,
     ) -> Result<(), SceneError> {
         self.ensure_mutable()?;
-        if !self
-            .nodes
-            .get_mut(&node)
-            .ok_or(SceneError::UnknownNode { node })?
-            .captured_pointers
-            .insert(pointer)
-        {
+        self.require_node(node)?;
+        if self.pointer_captures.get(&pointer) == Some(&node) {
             return Ok(());
         }
+        self.pointer_captures.insert(pointer, node);
         self.journal.push_coalesced(
             DirtySlot::Pointer(node, pointer),
             Operation::SetPointerCapture { node, pointer },
@@ -949,15 +922,11 @@ impl Scene {
         pointer: PointerId,
     ) -> Result<(), SceneError> {
         self.ensure_mutable()?;
-        if !self
-            .nodes
-            .get_mut(&node)
-            .ok_or(SceneError::UnknownNode { node })?
-            .captured_pointers
-            .remove(&pointer)
-        {
+        self.require_node(node)?;
+        if self.pointer_captures.get(&pointer) != Some(&node) {
             return Ok(());
         }
+        self.pointer_captures.remove(&pointer);
         self.journal.push_coalesced(
             DirtySlot::Pointer(node, pointer),
             Operation::ReleasePointerCapture { node, pointer },
@@ -1228,12 +1197,12 @@ impl Scene {
                     cursor: cursor.clone(),
                 });
             }
-            for pointer in &state.captured_pointers {
-                operations.push(Operation::SetPointerCapture {
-                    node: *node,
-                    pointer: *pointer,
-                });
-            }
+        }
+        for (pointer, node) in &self.pointer_captures {
+            operations.push(Operation::SetPointerCapture {
+                node: *node,
+                pointer: *pointer,
+            });
         }
         operations.extend(self.journal.operations.iter().filter_map(|operation| {
             let Operation::InvokeCommand { node, .. } = operation else {

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -1689,11 +1689,24 @@ mod tests {
         scene
             .insert_child(child, grandchild, 0)
             .expect("insert grandchild");
+        let removed_pointer = pointer(41);
+        let retained_pointer = pointer(42);
+        scene
+            .set_pointer_capture(grandchild, removed_pointer)
+            .expect("capture removed descendant");
+        scene
+            .set_pointer_capture(sibling, retained_pointer)
+            .expect("capture retained sibling");
         scene.delete_node(child).expect("delete attached subtree");
         assert_eq!(scene.node_count(), 2);
         assert_eq!(scene.node(root).expect("root").children(), &[sibling]);
         assert!(scene.node(child).is_none());
         assert!(scene.node(grandchild).is_none());
+        assert_eq!(scene.pointer_capture_target(removed_pointer), None);
+        assert_eq!(
+            scene.pointer_capture_target(retained_pointer),
+            Some(sibling)
+        );
         present_and_accept(&mut scene, &mut renderer);
 
         scene.delete_node(root).expect("delete unattached root");
@@ -2112,6 +2125,9 @@ mod tests {
         scene.set_z_order(front, 2).unwrap();
         let point = InputPoint { x: 10.0, y: 10.0 };
         assert_eq!(scene.hit_test(root, point), Ok(Some(front)));
+        scene.set_z_order(back, 3).unwrap();
+        assert_eq!(scene.hit_test(root, point), Ok(Some(back)));
+        scene.set_z_order(back, 1).unwrap();
 
         scene.set_hit_test(root, HitTestBehavior::BoxOnly).unwrap();
         assert_eq!(scene.hit_test(root, point), Ok(Some(root)));

--- a/crates/whisker-engine/src/scene/hit_test.rs
+++ b/crates/whisker-engine/src/scene/hit_test.rs
@@ -522,7 +522,8 @@ fn path_contains(
 #[cfg(test)]
 mod tests {
     use whisker_protocol::{
-        BoxClip, ElementTypeId, LayoutRect, PaintColor, PaintEdges, SurfaceId, VisualEffects,
+        BorderLineStyle, BoxClip, BoxPaint, ElementTypeId, LayoutRect, PaintColor, PaintEdges,
+        SurfaceId, VisualEffects,
     };
 
     use super::*;
@@ -558,6 +559,62 @@ mod tests {
         (scene, root, child)
     }
 
+    fn length(value: f32) -> PaintLengthPercentage {
+        PaintLengthPercentage {
+            length: value,
+            fraction: 0.0,
+        }
+    }
+
+    fn coordinate(x: f32, y: f32) -> PaintPosition {
+        PaintPosition {
+            x: PaintCoordinate {
+                length: x,
+                fraction: 0.0,
+            },
+            y: PaintCoordinate {
+                length: y,
+                fraction: 0.0,
+            },
+        }
+    }
+
+    fn radii(value: f32) -> PaintCorners<PaintCornerRadius> {
+        let radius = PaintCornerRadius::circular(length(value));
+        PaintCorners {
+            top_left: radius,
+            top_right: radius,
+            bottom_right: radius,
+            bottom_left: radius,
+        }
+    }
+
+    fn bordered_paint(width: f32, radius: f32) -> BoxPaint {
+        let transparent = PaintColor::Named("transparent".into());
+        BoxPaint {
+            background_color: transparent.clone(),
+            border_widths: PaintEdges {
+                top: length(width),
+                right: length(width),
+                bottom: length(width),
+                left: length(width),
+            },
+            border_colors: PaintEdges {
+                top: transparent.clone(),
+                right: transparent.clone(),
+                bottom: transparent.clone(),
+                left: transparent,
+            },
+            border_styles: PaintEdges {
+                top: BorderLineStyle::None,
+                right: BorderLineStyle::None,
+                bottom: BorderLineStyle::None,
+                left: BorderLineStyle::None,
+            },
+            border_radii: radii(radius),
+        }
+    }
+
     #[test]
     fn transforms_hit_geometry_and_hidden_parents_keep_visible_descendants() {
         let (mut scene, root, child) = scene_with_child();
@@ -585,6 +642,10 @@ mod tests {
     #[test]
     fn host_scroll_offset_tracks_native_presentation_without_dirtying_a_frame() {
         let (mut scene, root, child) = scene_with_child();
+        assert_eq!(
+            scene.update_host_scroll_offset(root, [f32::NAN, 0.0]),
+            Err(SceneError::NonFiniteNumber)
+        );
         scene
             .set_layout(
                 child,
@@ -711,6 +772,256 @@ mod tests {
         assert_eq!(
             scene.hit_test(root, InputPoint { x: 10.0, y: 10.0 }),
             Ok(Some(root))
+        );
+    }
+
+    #[test]
+    fn inverse_mapping_rejects_singular_and_projective_horizon_matrices() {
+        let point = InputPoint { x: 1.0, y: 1.0 };
+        assert_eq!(
+            inverse_map_around(Some(Transform([0.0; 16])), point, [0.0; 2]),
+            None
+        );
+
+        let mut projective = Transform::IDENTITY;
+        projective.0[3] = 1.0;
+        assert_eq!(inverse_map_around(Some(projective), point, [0.0; 2]), None);
+        assert_eq!(inverse_map_around(None, point, [0.0; 2]), Some(point));
+        assert_eq!(
+            inverse_map_around(Some(Transform::IDENTITY), point, [0.0; 2]),
+            Some(point)
+        );
+
+        let (mut scene, root, _) = scene_with_child();
+        scene.set_transform(root, Transform([0.0; 16])).unwrap();
+        assert_eq!(scene.hit_test(root, point), Ok(None));
+    }
+
+    #[test]
+    fn clip_reference_boxes_and_shape_families_are_resolved_in_rust() {
+        let (mut scene, root, _) = scene_with_child();
+        let border = LayoutRect {
+            x: 10.0,
+            y: 20.0,
+            width: 100.0,
+            height: 80.0,
+        };
+        let content = LayoutRect {
+            x: 10.0,
+            y: 10.0,
+            width: 80.0,
+            height: 60.0,
+        };
+        assert_eq!(padding_box(scene.node(root).unwrap(), border), border);
+
+        scene
+            .set_box_paint(root, bordered_paint(5.0, 10.0))
+            .unwrap();
+        assert_eq!(
+            padding_box(scene.node(root).unwrap(), border),
+            LayoutRect {
+                x: 15.0,
+                y: 25.0,
+                width: 90.0,
+                height: 70.0,
+            }
+        );
+
+        for reference_box in [PaintBox::Content, PaintBox::Padding] {
+            scene
+                .set_visual_effects(
+                    root,
+                    VisualEffects {
+                        clip_path: Some((
+                            reference_box,
+                            ClipShape::Ellipse {
+                                radius_x: length(100.0),
+                                radius_y: length(100.0),
+                                center: coordinate(50.0, 40.0),
+                            },
+                        )),
+                        ..VisualEffects::default()
+                    },
+                )
+                .unwrap();
+            assert!(clip_path_contains(
+                scene.node(root).unwrap(),
+                content,
+                border,
+                InputPoint { x: 60.0, y: 60.0 },
+            ));
+        }
+
+        let reference = LayoutRect {
+            width: 100.0,
+            height: 100.0,
+            ..LayoutRect::default()
+        };
+        let point = InputPoint { x: 50.0, y: 50.0 };
+        assert!(shape_contains(
+            &ClipShape::Inset {
+                edges: PaintEdges {
+                    top: PaintCoordinate::default(),
+                    right: PaintCoordinate::default(),
+                    bottom: PaintCoordinate::default(),
+                    left: PaintCoordinate::default(),
+                },
+                radii: radii(0.0),
+            },
+            reference,
+            point,
+        ));
+        assert!(shape_contains(
+            &ClipShape::Ellipse {
+                radius_x: length(50.0),
+                radius_y: length(25.0),
+                center: coordinate(50.0, 50.0),
+            },
+            reference,
+            point,
+        ));
+        assert!(!shape_contains(
+            &ClipShape::Polygon {
+                fill_rule: FillRule::NonZero,
+                points: Vec::new(),
+            },
+            reference,
+            point,
+        ));
+        let square = vec![
+            coordinate(0.0, 0.0),
+            coordinate(100.0, 0.0),
+            coordinate(100.0, 100.0),
+            coordinate(0.0, 100.0),
+        ];
+        for fill_rule in [FillRule::NonZero, FillRule::EvenOdd] {
+            assert!(shape_contains(
+                &ClipShape::Polygon {
+                    fill_rule,
+                    points: square.clone(),
+                },
+                reference,
+                point,
+            ));
+        }
+        assert!(!ellipse_contains([0.0, 0.0], [0.0, 1.0], point));
+    }
+
+    #[test]
+    fn path_hit_testing_flattens_lines_and_curves() {
+        let reference = LayoutRect {
+            width: 100.0,
+            height: 100.0,
+            ..LayoutRect::default()
+        };
+        let inside = InputPoint { x: 50.0, y: 50.0 };
+        assert!(!path_contains(
+            FillRule::NonZero,
+            &[PathCommand::QuadraticTo {
+                control: coordinate(1.0, 1.0),
+                end: coordinate(2.0, 2.0),
+            }],
+            reference,
+            inside,
+        ));
+        assert!(!path_contains(
+            FillRule::NonZero,
+            &[PathCommand::CubicTo {
+                control_1: coordinate(1.0, 1.0),
+                control_2: coordinate(2.0, 2.0),
+                end: coordinate(3.0, 3.0),
+            }],
+            reference,
+            inside,
+        ));
+        assert!(!path_contains(
+            FillRule::NonZero,
+            &[PathCommand::LineTo(coordinate(1.0, 1.0))],
+            reference,
+            inside,
+        ));
+
+        let curved_box = ClipShape::Path {
+            fill_rule: FillRule::EvenOdd,
+            commands: vec![
+                PathCommand::MoveTo(coordinate(0.0, 0.0)),
+                PathCommand::MoveTo(coordinate(0.0, 0.0)),
+                PathCommand::LineTo(coordinate(100.0, 0.0)),
+                PathCommand::QuadraticTo {
+                    control: coordinate(100.0, 50.0),
+                    end: coordinate(100.0, 100.0),
+                },
+                PathCommand::CubicTo {
+                    control_1: coordinate(50.0, 100.0),
+                    control_2: coordinate(0.0, 100.0),
+                    end: coordinate(0.0, 0.0),
+                },
+                PathCommand::Close,
+            ],
+        };
+        assert!(shape_contains(&curved_box, reference, inside));
+    }
+
+    #[test]
+    fn winding_rounding_and_one_axis_overflow_cover_edge_geometry() {
+        let point = InputPoint { x: 0.0, y: 0.0 };
+        let mut winding = Winding::new(FillRule::NonZero, point);
+        winding.segment([-2.0, -2.0], [-2.0, 2.0]);
+        winding.segment([-2.0, 2.0], [2.0, 2.0]);
+        winding.segment([2.0, 2.0], [2.0, -2.0]);
+        assert!(winding.contains());
+        winding.segment([2.0, -2.0], [-2.0, -2.0]);
+        assert!(winding.contains());
+        let mut even_odd = Winding::new(FillRule::EvenOdd, point);
+        even_odd.segment([2.0, -2.0], [2.0, 2.0]);
+        assert!(even_odd.contains());
+
+        let rect = LayoutRect {
+            width: 100.0,
+            height: 100.0,
+            ..LayoutRect::default()
+        };
+        assert!(!rounded_rect_contains(
+            rect,
+            ([10.0; 4], [10.0; 4]),
+            InputPoint { x: -1.0, y: 50.0 },
+        ));
+        for point in [
+            InputPoint { x: 1.0, y: 1.0 },
+            InputPoint { x: 99.0, y: 1.0 },
+            InputPoint { x: 99.0, y: 99.0 },
+            InputPoint { x: 1.0, y: 99.0 },
+        ] {
+            assert!(!rounded_rect_contains(rect, ([10.0; 4], [10.0; 4]), point));
+        }
+        assert!(rounded_rect_contains(
+            rect,
+            ([10.0; 4], [10.0; 4]),
+            InputPoint { x: 50.0, y: 50.0 },
+        ));
+        let (horizontal, vertical) = resolve_radii(&radii(80.0), rect);
+        assert_eq!(horizontal, [50.0; 4]);
+        assert_eq!(vertical, [50.0; 4]);
+        assert_eq!(radius_scale(0.0, 0.0), 1.0);
+
+        let (mut scene, root, _) = scene_with_child();
+        scene.set_box_paint(root, bordered_paint(5.0, 0.0)).unwrap();
+        scene
+            .set_clip(
+                root,
+                BoxClip {
+                    horizontal: OverflowClip::Hidden,
+                    vertical: OverflowClip::Visible,
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            overflow_clip_contains(
+                scene.node(root).unwrap(),
+                rect,
+                InputPoint { x: 50.0, y: 50.0 },
+            ),
+            [true, true]
         );
     }
 }

--- a/crates/whisker-engine/src/scene/hit_test.rs
+++ b/crates/whisker-engine/src/scene/hit_test.rs
@@ -1,0 +1,716 @@
+use whisker_protocol::{
+    ClipShape, FillRule, HitTestBehavior, InputPoint, LayoutRect, NodeId, OverflowClip, PaintBox,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintLengthPercentage, PaintPosition,
+    PathCommand, Transform, Visibility,
+};
+
+use super::{Scene, SceneError, SceneNode};
+
+impl Scene {
+    /// Finds the visually topmost node at one surface-space point.
+    pub fn hit_test(&self, root: NodeId, point: InputPoint) -> Result<Option<NodeId>, SceneError> {
+        self.require_node(root)?;
+        Ok(self.hit_test_node(root, point, [0.0; 2]))
+    }
+
+    fn hit_test_node(
+        &self,
+        node: NodeId,
+        point: InputPoint,
+        parent_origin: [f32; 2],
+    ) -> Option<NodeId> {
+        let state = self
+            .nodes
+            .get(&node)
+            .expect("hit-test traversal only visits retained nodes");
+        if state.hit_test == Some(HitTestBehavior::None) {
+            return None;
+        }
+
+        let layout = state.layout?;
+        let border = LayoutRect {
+            x: parent_origin[0] + layout.border_box.x,
+            y: parent_origin[1] + layout.border_box.y,
+            width: layout.border_box.width,
+            height: layout.border_box.height,
+        };
+        let point = inverse_map_around(state.transform, point, [border.x, border.y])?;
+        let contains_x = contains_axis(point.x, border.x, border.width);
+        let contains_y = contains_axis(point.y, border.y, border.height);
+        let contains = contains_x && contains_y;
+
+        // clip-path applies to the element and its complete subtree. Test it
+        // before descending so no per-pointer clip stack needs allocating.
+        if !clip_path_contains(state, layout.content_box, border, point) {
+            return None;
+        }
+
+        let children_clipped = state.clip.is_some_and(|clip| {
+            let [clip_x, clip_y] = overflow_clip_contains(state, border, point);
+            (clip.horizontal == OverflowClip::Hidden && !clip_x)
+                || (clip.vertical == OverflowClip::Hidden && !clip_y)
+        });
+        if state.hit_test != Some(HitTestBehavior::BoxOnly) && !children_clipped {
+            let child_origin = [
+                border.x - state.host_scroll_offset[0],
+                border.y - state.host_scroll_offset[1],
+            ];
+            if let Some(target) = self.hit_test_children(state, point, child_origin) {
+                return Some(target);
+            }
+        }
+
+        (state.visibility != Some(Visibility::Hidden)
+            && contains
+            && state.hit_test != Some(HitTestBehavior::DescendantsOnly))
+        .then_some(node)
+    }
+
+    fn hit_test_children(
+        &self,
+        state: &SceneNode,
+        point: InputPoint,
+        child_origin: [f32; 2],
+    ) -> Option<NodeId> {
+        let first_z = state
+            .children
+            .first()
+            .and_then(|child| self.nodes.get(child))
+            .and_then(|child| child.z_order)
+            .unwrap_or(0);
+        let uniform_z = state.children.iter().all(|child| {
+            self.nodes
+                .get(child)
+                .and_then(|child| child.z_order)
+                .unwrap_or(0)
+                == first_z
+        });
+
+        // Normal UI trees have one stacking level. This path is allocation-free
+        // and returns as soon as the topmost matching child is found.
+        if uniform_z {
+            return state
+                .children
+                .iter()
+                .rev()
+                .find_map(|child| self.hit_test_node(*child, point, child_origin));
+        }
+
+        // z-index is uncommon. Traverse once and retain the highest matching
+        // sibling instead of allocating and sorting on every pointer move.
+        let mut best = None;
+        for (index, child) in state.children.iter().copied().enumerate() {
+            let Some(target) = self.hit_test_node(child, point, child_origin) else {
+                continue;
+            };
+            let z = self
+                .nodes
+                .get(&child)
+                .and_then(|child| child.z_order)
+                .unwrap_or(0);
+            if best.is_none_or(|((best_z, best_index), _)| (z, index) > (best_z, best_index)) {
+                best = Some(((z, index), target));
+            }
+        }
+        best.map(|(_, target)| target)
+    }
+}
+
+fn contains_axis(value: f32, start: f32, length: f32) -> bool {
+    value >= start && value <= start + length
+}
+
+fn inverse_map_around(
+    transform: Option<Transform>,
+    point: InputPoint,
+    origin: [f32; 2],
+) -> Option<InputPoint> {
+    let Some(transform) = transform.filter(|transform| *transform != Transform::IDENTITY) else {
+        return Some(point);
+    };
+    let [x, y] = [point.x - origin[0], point.y - origin[1]];
+    let matrix = transform.0;
+    let [a, c, tx] = [matrix[0], matrix[4], matrix[12]];
+    let [b, d, ty] = [matrix[1], matrix[5], matrix[13]];
+    let [p, q, r] = [matrix[3], matrix[7], matrix[15]];
+    let determinant = a * (d * r - ty * q) - c * (b * r - ty * p) + tx * (b * q - d * p);
+    if determinant.abs() <= f32::EPSILON {
+        return None;
+    }
+
+    // The common determinant divisor cancels during the homogeneous divide.
+    let inverse_x = (d * r - ty * q) * x + (tx * q - c * r) * y + (c * ty - tx * d);
+    let inverse_y = (ty * p - b * r) * x + (a * r - tx * p) * y + (tx * b - a * ty);
+    let inverse_w = (b * q - d * p) * x + (c * p - a * q) * y + (a * d - c * b);
+    if inverse_w.abs() <= f32::EPSILON {
+        return None;
+    }
+    let mapped = InputPoint {
+        x: origin[0] + inverse_x / inverse_w,
+        y: origin[1] + inverse_y / inverse_w,
+    };
+    mapped.is_valid().then_some(mapped)
+}
+
+fn overflow_clip_contains(state: &SceneNode, border: LayoutRect, point: InputPoint) -> [bool; 2] {
+    let clip = state
+        .clip
+        .expect("overflow geometry is queried only for a clip");
+    let Some(paint) = state.box_paint.as_ref() else {
+        return [
+            contains_axis(point.x, border.x, border.width),
+            contains_axis(point.y, border.y, border.height),
+        ];
+    };
+    let top = resolve_length(paint.border_widths.top, border.height).min(border.height);
+    let right = resolve_length(paint.border_widths.right, border.width).min(border.width);
+    let bottom = resolve_length(paint.border_widths.bottom, border.height).min(border.height);
+    let left = resolve_length(paint.border_widths.left, border.width).min(border.width);
+    let inner = LayoutRect {
+        x: border.x + left,
+        y: border.y + top,
+        width: (border.width - left - right).max(0.0),
+        height: (border.height - top - bottom).max(0.0),
+    };
+    if clip.horizontal == OverflowClip::Hidden && clip.vertical == OverflowClip::Hidden {
+        let (outer_x, outer_y) = resolve_radii(&paint.border_radii, border);
+        let inner_x = [
+            (outer_x[0] - left).max(0.0),
+            (outer_x[1] - right).max(0.0),
+            (outer_x[2] - right).max(0.0),
+            (outer_x[3] - left).max(0.0),
+        ];
+        let inner_y = [
+            (outer_y[0] - top).max(0.0),
+            (outer_y[1] - top).max(0.0),
+            (outer_y[2] - bottom).max(0.0),
+            (outer_y[3] - bottom).max(0.0),
+        ];
+        let contains = rounded_rect_contains(inner, (inner_x, inner_y), point);
+        return [contains; 2];
+    }
+    [
+        contains_axis(point.x, inner.x, inner.width),
+        contains_axis(point.y, inner.y, inner.height),
+    ]
+}
+
+fn clip_path_contains(
+    state: &SceneNode,
+    content: LayoutRect,
+    border: LayoutRect,
+    point: InputPoint,
+) -> bool {
+    let Some((reference_box, shape)) = state.visual_effects.clip_path.as_ref() else {
+        return true;
+    };
+    let reference = match reference_box {
+        PaintBox::Content => LayoutRect {
+            x: border.x + content.x,
+            y: border.y + content.y,
+            width: content.width,
+            height: content.height,
+        },
+        PaintBox::Padding => padding_box(state, border),
+        _ => border,
+    };
+    shape_contains(shape, reference, point)
+}
+
+fn padding_box(state: &SceneNode, border: LayoutRect) -> LayoutRect {
+    let Some(paint) = state.box_paint.as_ref() else {
+        return border;
+    };
+    let top = resolve_length(paint.border_widths.top, border.height).min(border.height);
+    let right = resolve_length(paint.border_widths.right, border.width).min(border.width);
+    let bottom = resolve_length(paint.border_widths.bottom, border.height).min(border.height);
+    let left = resolve_length(paint.border_widths.left, border.width).min(border.width);
+    LayoutRect {
+        x: border.x + left,
+        y: border.y + top,
+        width: (border.width - left - right).max(0.0),
+        height: (border.height - top - bottom).max(0.0),
+    }
+}
+
+fn shape_contains(shape: &ClipShape, reference: LayoutRect, point: InputPoint) -> bool {
+    match shape {
+        ClipShape::Inset { edges, radii } => {
+            let top = resolve_coordinate(edges.top, reference.height);
+            let right = resolve_coordinate(edges.right, reference.width);
+            let bottom = resolve_coordinate(edges.bottom, reference.height);
+            let left = resolve_coordinate(edges.left, reference.width);
+            let rect = LayoutRect {
+                x: reference.x + left,
+                y: reference.y + top,
+                width: (reference.width - left - right).max(0.0),
+                height: (reference.height - top - bottom).max(0.0),
+            };
+            rounded_rect_contains(rect, resolve_radii(radii, rect), point)
+        }
+        ClipShape::Circle { radius, center } => {
+            let center = resolve_position(*center, reference);
+            let diagonal = reference.width.hypot(reference.height) / 2.0_f32.sqrt();
+            ellipse_contains(center, [resolve_length(*radius, diagonal); 2], point)
+        }
+        ClipShape::Ellipse {
+            radius_x,
+            radius_y,
+            center,
+        } => ellipse_contains(
+            resolve_position(*center, reference),
+            [
+                resolve_length(*radius_x, reference.width),
+                resolve_length(*radius_y, reference.height),
+            ],
+            point,
+        ),
+        ClipShape::Polygon { fill_rule, points } => {
+            let mut winding = Winding::new(*fill_rule, point);
+            let Some(first) = points.first().copied() else {
+                return false;
+            };
+            let first = resolve_position(first, reference);
+            let mut previous = first;
+            for position in &points[1..] {
+                let current = resolve_position(*position, reference);
+                winding.segment(previous, current);
+                previous = current;
+            }
+            winding.segment(previous, first);
+            winding.contains()
+        }
+        ClipShape::Path {
+            fill_rule,
+            commands,
+        } => path_contains(*fill_rule, commands, reference, point),
+    }
+}
+
+fn ellipse_contains(center: [f32; 2], radii: [f32; 2], point: InputPoint) -> bool {
+    if radii[0] <= 0.0 || radii[1] <= 0.0 {
+        return false;
+    }
+    let x = (point.x - center[0]) / radii[0];
+    let y = (point.y - center[1]) / radii[1];
+    x * x + y * y <= 1.0
+}
+
+fn rounded_rect_contains(rect: LayoutRect, radii: ([f32; 4], [f32; 4]), point: InputPoint) -> bool {
+    if !contains_axis(point.x, rect.x, rect.width) || !contains_axis(point.y, rect.y, rect.height) {
+        return false;
+    }
+    let (horizontal, vertical) = radii;
+    let corners = [
+        (
+            0,
+            [rect.x + horizontal[0], rect.y + vertical[0]],
+            -1.0,
+            -1.0,
+        ),
+        (
+            1,
+            [rect.x + rect.width - horizontal[1], rect.y + vertical[1]],
+            1.0,
+            -1.0,
+        ),
+        (
+            2,
+            [
+                rect.x + rect.width - horizontal[2],
+                rect.y + rect.height - vertical[2],
+            ],
+            1.0,
+            1.0,
+        ),
+        (
+            3,
+            [rect.x + horizontal[3], rect.y + rect.height - vertical[3]],
+            -1.0,
+            1.0,
+        ),
+    ];
+    for (index, center, x_sign, y_sign) in corners {
+        let in_x_corner = (point.x - center[0]) * x_sign > 0.0;
+        let in_y_corner = (point.y - center[1]) * y_sign > 0.0;
+        if in_x_corner && in_y_corner {
+            return ellipse_contains(center, [horizontal[index], vertical[index]], point);
+        }
+    }
+    true
+}
+
+fn resolve_radii(
+    radii: &PaintCorners<PaintCornerRadius>,
+    rect: LayoutRect,
+) -> ([f32; 4], [f32; 4]) {
+    let values = [
+        radii.top_left,
+        radii.top_right,
+        radii.bottom_right,
+        radii.bottom_left,
+    ];
+    let mut horizontal = values.map(|radius| resolve_length(radius.horizontal, rect.width));
+    let mut vertical = values.map(|radius| resolve_length(radius.vertical, rect.height));
+    let scale = [
+        radius_scale(rect.width, horizontal[0] + horizontal[1]),
+        radius_scale(rect.width, horizontal[3] + horizontal[2]),
+        radius_scale(rect.height, vertical[0] + vertical[3]),
+        radius_scale(rect.height, vertical[1] + vertical[2]),
+    ]
+    .into_iter()
+    .fold(1.0_f32, f32::min);
+    for value in &mut horizontal {
+        *value *= scale;
+    }
+    for value in &mut vertical {
+        *value *= scale;
+    }
+    (horizontal, vertical)
+}
+
+fn radius_scale(available: f32, required: f32) -> f32 {
+    if required > available && required > 0.0 {
+        available / required
+    } else {
+        1.0
+    }
+}
+
+fn resolve_length(value: PaintLengthPercentage, available: f32) -> f32 {
+    value.length + value.fraction * available
+}
+
+fn resolve_coordinate(value: PaintCoordinate, available: f32) -> f32 {
+    value.length + value.fraction * available
+}
+
+fn resolve_position(position: PaintPosition, reference: LayoutRect) -> [f32; 2] {
+    [
+        reference.x + resolve_coordinate(position.x, reference.width),
+        reference.y + resolve_coordinate(position.y, reference.height),
+    ]
+}
+
+struct Winding {
+    rule: FillRule,
+    point: InputPoint,
+    winding: i32,
+    parity: bool,
+}
+
+impl Winding {
+    const fn new(rule: FillRule, point: InputPoint) -> Self {
+        Self {
+            rule,
+            point,
+            winding: 0,
+            parity: false,
+        }
+    }
+
+    fn segment(&mut self, from: [f32; 2], to: [f32; 2]) {
+        let crosses = (from[1] <= self.point.y && to[1] > self.point.y)
+            || (from[1] > self.point.y && to[1] <= self.point.y);
+        if !crosses {
+            return;
+        }
+        let intersection =
+            from[0] + (self.point.y - from[1]) * (to[0] - from[0]) / (to[1] - from[1]);
+        if intersection <= self.point.x {
+            return;
+        }
+        self.parity = !self.parity;
+        self.winding += if to[1] > from[1] { 1 } else { -1 };
+    }
+
+    const fn contains(&self) -> bool {
+        match self.rule {
+            FillRule::NonZero => self.winding != 0,
+            FillRule::EvenOdd => self.parity,
+        }
+    }
+}
+
+fn path_contains(
+    fill_rule: FillRule,
+    commands: &[PathCommand],
+    reference: LayoutRect,
+    point: InputPoint,
+) -> bool {
+    const CURVE_STEPS: usize = 16;
+    let mut winding = Winding::new(fill_rule, point);
+    let mut current = None;
+    let mut start = None;
+    let close = |winding: &mut Winding, current: &mut Option<[f32; 2]>, start| {
+        if let (Some(from), Some(to)) = (*current, start) {
+            winding.segment(from, to);
+            *current = Some(to);
+        }
+    };
+    for command in commands {
+        match command {
+            PathCommand::MoveTo(position) => {
+                close(&mut winding, &mut current, start);
+                let next = resolve_position(*position, reference);
+                current = Some(next);
+                start = Some(next);
+            }
+            PathCommand::LineTo(position) => {
+                let next = resolve_position(*position, reference);
+                if let Some(previous) = current {
+                    winding.segment(previous, next);
+                }
+                current = Some(next);
+            }
+            PathCommand::QuadraticTo { control, end } => {
+                let Some(from) = current else { continue };
+                let control = resolve_position(*control, reference);
+                let end = resolve_position(*end, reference);
+                let mut previous = from;
+                for step in 1..=CURVE_STEPS {
+                    let t = step as f32 / CURVE_STEPS as f32;
+                    let inverse = 1.0 - t;
+                    let next = [
+                        inverse * inverse * from[0]
+                            + 2.0 * inverse * t * control[0]
+                            + t * t * end[0],
+                        inverse * inverse * from[1]
+                            + 2.0 * inverse * t * control[1]
+                            + t * t * end[1],
+                    ];
+                    winding.segment(previous, next);
+                    previous = next;
+                }
+                current = Some(end);
+            }
+            PathCommand::CubicTo {
+                control_1,
+                control_2,
+                end,
+            } => {
+                let Some(from) = current else { continue };
+                let control_1 = resolve_position(*control_1, reference);
+                let control_2 = resolve_position(*control_2, reference);
+                let end = resolve_position(*end, reference);
+                let mut previous = from;
+                for step in 1..=CURVE_STEPS {
+                    let t = step as f32 / CURVE_STEPS as f32;
+                    let inverse = 1.0 - t;
+                    let next = [
+                        inverse.powi(3) * from[0]
+                            + 3.0 * inverse * inverse * t * control_1[0]
+                            + 3.0 * inverse * t * t * control_2[0]
+                            + t.powi(3) * end[0],
+                        inverse.powi(3) * from[1]
+                            + 3.0 * inverse * inverse * t * control_1[1]
+                            + 3.0 * inverse * t * t * control_2[1]
+                            + t.powi(3) * end[1],
+                    ];
+                    winding.segment(previous, next);
+                    previous = next;
+                }
+                current = Some(end);
+            }
+            PathCommand::Close => close(&mut winding, &mut current, start),
+        }
+    }
+    close(&mut winding, &mut current, start);
+    winding.contains()
+}
+
+#[cfg(test)]
+mod tests {
+    use whisker_protocol::{
+        BoxClip, ElementTypeId, LayoutRect, PaintColor, PaintEdges, SurfaceId, VisualEffects,
+    };
+
+    use super::*;
+
+    fn scene_with_child() -> (Scene, NodeId, NodeId) {
+        let mut scene = Scene::new(SurfaceId::new(1).unwrap());
+        let element = ElementTypeId::new(1).unwrap();
+        let root = scene.create_node(element).unwrap();
+        let child = scene.create_node(element).unwrap();
+        scene.insert_child(root, child, 0).unwrap();
+        scene
+            .set_layout(
+                root,
+                LayoutRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 300.0,
+                    height: 300.0,
+                },
+            )
+            .unwrap();
+        scene
+            .set_layout(
+                child,
+                LayoutRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 50.0,
+                    height: 50.0,
+                },
+            )
+            .unwrap();
+        (scene, root, child)
+    }
+
+    #[test]
+    fn transforms_hit_geometry_and_hidden_parents_keep_visible_descendants() {
+        let (mut scene, root, child) = scene_with_child();
+        let mut translated = Transform::IDENTITY;
+        translated.0[12] = 100.0;
+        scene.set_transform(child, translated).unwrap();
+
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 110.0, y: 10.0 }),
+            Ok(Some(child))
+        );
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 10.0, y: 10.0 }),
+            Ok(Some(root))
+        );
+
+        scene.set_visibility(root, Visibility::Hidden).unwrap();
+        scene.set_visibility(child, Visibility::Visible).unwrap();
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 110.0, y: 10.0 }),
+            Ok(Some(child))
+        );
+    }
+
+    #[test]
+    fn host_scroll_offset_tracks_native_presentation_without_dirtying_a_frame() {
+        let (mut scene, root, child) = scene_with_child();
+        scene
+            .set_layout(
+                child,
+                LayoutRect {
+                    x: 0.0,
+                    y: 120.0,
+                    width: 50.0,
+                    height: 50.0,
+                },
+            )
+            .unwrap();
+        scene
+            .set_clip(
+                root,
+                BoxClip {
+                    horizontal: OverflowClip::Hidden,
+                    vertical: OverflowClip::Hidden,
+                },
+            )
+            .unwrap();
+        scene.update_host_scroll_offset(root, [0.0, 100.0]).unwrap();
+
+        assert_eq!(scene.node(root).unwrap().host_scroll_offset(), [0.0, 100.0]);
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 10.0, y: 30.0 }),
+            Ok(Some(child))
+        );
+    }
+
+    #[test]
+    fn clip_paths_and_rounded_overflow_restrict_descendant_hits() {
+        let (mut scene, root, child) = scene_with_child();
+        scene
+            .set_layout(
+                child,
+                LayoutRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 300.0,
+                    height: 300.0,
+                },
+            )
+            .unwrap();
+        let effects = VisualEffects {
+            clip_path: Some((
+                PaintBox::Border,
+                ClipShape::Circle {
+                    radius: PaintLengthPercentage {
+                        length: 50.0,
+                        fraction: 0.0,
+                    },
+                    center: PaintPosition {
+                        x: PaintCoordinate {
+                            length: 0.0,
+                            fraction: 0.5,
+                        },
+                        y: PaintCoordinate {
+                            length: 0.0,
+                            fraction: 0.5,
+                        },
+                    },
+                },
+            )),
+            ..VisualEffects::default()
+        };
+        scene.set_visual_effects(root, effects).unwrap();
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 150.0, y: 150.0 }),
+            Ok(Some(child))
+        );
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 10.0, y: 10.0 }),
+            Ok(None)
+        );
+
+        scene
+            .set_visual_effects(root, VisualEffects::default())
+            .unwrap();
+        scene
+            .set_clip(
+                root,
+                BoxClip {
+                    horizontal: OverflowClip::Hidden,
+                    vertical: OverflowClip::Hidden,
+                },
+            )
+            .unwrap();
+        let radius = PaintCornerRadius::circular(PaintLengthPercentage {
+            length: 100.0,
+            fraction: 0.0,
+        });
+        scene
+            .set_box_paint(
+                root,
+                whisker_protocol::BoxPaint {
+                    background_color: PaintColor::Named("transparent".into()),
+                    border_widths: PaintEdges {
+                        top: PaintLengthPercentage::default(),
+                        right: PaintLengthPercentage::default(),
+                        bottom: PaintLengthPercentage::default(),
+                        left: PaintLengthPercentage::default(),
+                    },
+                    border_colors: PaintEdges {
+                        top: PaintColor::Named("transparent".into()),
+                        right: PaintColor::Named("transparent".into()),
+                        bottom: PaintColor::Named("transparent".into()),
+                        left: PaintColor::Named("transparent".into()),
+                    },
+                    border_styles: PaintEdges {
+                        top: whisker_protocol::BorderLineStyle::None,
+                        right: whisker_protocol::BorderLineStyle::None,
+                        bottom: whisker_protocol::BorderLineStyle::None,
+                        left: whisker_protocol::BorderLineStyle::None,
+                    },
+                    border_radii: PaintCorners {
+                        top_left: radius,
+                        top_right: radius,
+                        bottom_right: radius,
+                        bottom_left: radius,
+                    },
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            scene.hit_test(root, InputPoint { x: 10.0, y: 10.0 }),
+            Ok(Some(root))
+        );
+    }
+}

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -273,6 +273,20 @@ impl SurfaceEngine {
             .map_err(SurfaceError::Scene)
     }
 
+    /// Synchronizes one native scroll container's transient logical offset.
+    ///
+    /// This state participates only in Rust hit testing. It does not dirty
+    /// layout or echo a frame operation back to the Host.
+    pub fn update_host_scroll_offset(
+        &mut self,
+        node: NodeId,
+        offset: [f32; 2],
+    ) -> Result<(), SurfaceError> {
+        self.scene
+            .update_host_scroll_offset(node, offset)
+            .map_err(SurfaceError::Scene)
+    }
+
     /// Returns the node currently retaining one pointer capture.
     pub fn pointer_capture_target(&self, pointer: PointerId) -> Option<NodeId> {
         self.scene.pointer_capture_target(pointer)

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -1587,6 +1587,17 @@ mod tests {
                 node: missing
             }))
         );
+        assert_eq!(surface.update_host_scroll_offset(root, [1.0, 2.0]), Ok(()));
+        assert_eq!(
+            surface.update_host_scroll_offset(root, [f32::NAN, 0.0]),
+            Err(SurfaceError::Scene(SceneError::NonFiniteNumber))
+        );
+        assert_eq!(
+            surface.update_host_scroll_offset(missing, [0.0, 0.0]),
+            Err(SurfaceError::Scene(SceneError::UnknownNode {
+                node: missing
+            }))
+        );
 
         surface.set_event_mask(root, 5).unwrap();
         assert_eq!(surface.node(root).unwrap().event_mask(), Some(5));

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -291,6 +291,9 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
             y: f32,
             buttons: u32,
             changed_button: i16,
+            scroll_nodes: *const u64,
+            scroll_offsets: *const f32,
+            scroll_count: usize,
         ) -> bool {
             unsafe {
                 ::whisker::__driver_runtime::dispatch_pointer(
@@ -303,6 +306,9 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     y,
                     buttons,
                     changed_button,
+                    scroll_nodes,
+                    scroll_offsets,
+                    scroll_count,
                 )
             }
         }

--- a/crates/whisker-protocol/src/input.rs
+++ b/crates/whisker-protocol/src/input.rs
@@ -87,6 +87,31 @@ pub struct PointerInput {
     pub changed_button: i16,
 }
 
+/// Latest Host-owned presentation state that must be visible to input routing.
+///
+/// Hosts coalesce high-frequency changes locally and attach only the newest
+/// value immediately before an input event. Applying these updates does not
+/// invalidate layout or produce frame operations.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HostPresentationUpdate {
+    /// Logical scroll offset currently presented by a native scroll container.
+    ScrollOffset {
+        /// Scroll container whose descendants are translated by the offset.
+        node: NodeId,
+        /// Latest logical-pixel offset.
+        offset: InputPoint,
+    },
+}
+
+impl HostPresentationUpdate {
+    /// Returns whether all numeric presentation data is finite.
+    pub fn is_valid(self) -> bool {
+        match self {
+            Self::ScrollOffset { offset, .. } => offset.is_valid(),
+        }
+    }
+}
+
 /// One input or provider event entering a retained surface.
 #[derive(Clone, Debug, PartialEq)]
 pub struct InputEvent {

--- a/crates/whisker-protocol/src/input.rs
+++ b/crates/whisker-protocol/src/input.rs
@@ -219,4 +219,28 @@ mod tests {
         event.detail = WhiskerValue::Error("provider failed".into());
         assert_eq!(event.validate(), Err(InputEventError::InvalidDetail));
     }
+
+    #[test]
+    fn host_presentation_updates_require_finite_offsets() {
+        let update = |offset| HostPresentationUpdate::ScrollOffset {
+            node: NodeId::new(1).unwrap(),
+            offset,
+        };
+
+        assert!(update(InputPoint { x: 1.0, y: 2.0 }).is_valid());
+        assert!(
+            !update(InputPoint {
+                x: f32::NAN,
+                y: 2.0
+            })
+            .is_valid()
+        );
+        assert!(
+            !update(InputPoint {
+                x: 1.0,
+                y: f32::INFINITY
+            })
+            .is_valid()
+        );
+    }
 }

--- a/crates/whisker-protocol/src/lib.rs
+++ b/crates/whisker-protocol/src/lib.rs
@@ -49,7 +49,8 @@ pub use id::{
     PreparedContentId, PropertyId, ResourceId, SurfaceId,
 };
 pub use input::{
-    InputEvent, InputEventError, InputEventKind, InputPoint, PointerInput, PointerKind,
+    HostPresentationUpdate, InputEvent, InputEventError, InputEventKind, InputPoint, PointerInput,
+    PointerKind,
 };
 pub use measurement::{
     AvailableSpace, CustomMeasurePayload, EmbeddedSurfaceMeasurePayload, FontFeature,

--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -19,8 +19,8 @@ use crate::{
 };
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
-    ApplyResult, InputEvent, InputEventKind, InputPoint, MeasurementReady, NodeId, PointerId,
-    PointerKind, ResourceEvent, WhiskerValue,
+    ApplyResult, HostPresentationUpdate, InputEvent, InputEventKind, InputPoint, MeasurementReady,
+    NodeId, PointerId, PointerKind, ResourceEvent, WhiskerValue,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{DeferredMeasurementApply, FrameSink, LayoutOptions, MeasurementProvider};
@@ -544,7 +544,10 @@ pub struct RuntimeInstance {
 }
 
 enum PendingHostEvent {
-    Input(InputEvent),
+    Input {
+        event: InputEvent,
+        presentation: Vec<HostPresentationUpdate>,
+    },
     Module {
         modules: Rc<ModuleHost>,
         module: String,
@@ -556,7 +559,6 @@ enum PendingHostEvent {
 }
 
 const HOST_EVENT_QUEUE_CAP: usize = 4096;
-
 #[derive(Clone, Copy, Debug)]
 struct ActivationCandidate {
     target: NodeId,
@@ -852,6 +854,19 @@ impl RuntimeInstance {
 
     /// Delivers one Host-normalized event and flushes its reactive transaction.
     pub fn dispatch_input(&self, event: &InputEvent) -> Result<InputDispatch, RuntimeEventError> {
+        self.dispatch_input_with_presentation(event, &[])
+    }
+
+    /// Delivers coalesced Host presentation changes immediately before one event.
+    ///
+    /// This is the input-side synchronization point for state such as native
+    /// scroll offsets. Hosts should overwrite repeated changes locally and call
+    /// this only when an input sample actually needs Rust hit testing.
+    pub fn dispatch_input_with_presentation(
+        &self,
+        event: &InputEvent,
+        presentation: &[HostPresentationUpdate],
+    ) -> Result<InputDispatch, RuntimeEventError> {
         self.require(RuntimeLifecycle::Running, "dispatch input")
             .map_err(RuntimeEventError::Lifecycle)?;
         if self.context.is_entered() {
@@ -867,7 +882,10 @@ impl RuntimeInstance {
                 .validate()
                 .map_err(RuntimeInputError::InvalidInput)
                 .map_err(RuntimeEventError::Input)?;
-            self.enqueue_host_event(PendingHostEvent::Input(event.clone()))?;
+            self.enqueue_host_event(PendingHostEvent::Input {
+                event: event.clone(),
+                presentation: presentation.to_vec(),
+            })?;
             return Ok(InputDispatch {
                 queued: true,
                 ..InputDispatch::default()
@@ -878,7 +896,7 @@ impl RuntimeInstance {
             view::with_installed_renderer(surface.renderer(), || {
                 crate::drain_runtime_dispatches();
                 let dispatch = self
-                    .dispatch_input_active(event)
+                    .dispatch_input_active(event, presentation)
                     .map_err(RuntimeEventError::Input)?;
                 self.drain_pending_host_events()?;
                 Ok(dispatch)
@@ -1084,6 +1102,7 @@ impl RuntimeInstance {
     fn dispatch_input_active(
         &self,
         event: &InputEvent,
+        presentation: &[HostPresentationUpdate],
     ) -> Result<InputDispatch, RuntimeInputError> {
         // Treat listener execution and the reactive cascade it schedules as
         // one retained-scene transaction. Renderer calls still update the
@@ -1091,7 +1110,9 @@ impl RuntimeInstance {
         // is committed once after the queue settles.
         self.surface.begin_mutation_batch();
         let dispatch = (|| {
-            let mut dispatch = self.surface.dispatch_input(event)?;
+            let mut dispatch = self
+                .surface
+                .dispatch_input_with_presentation(event, presentation)?;
             let activation = self
                 .activations
                 .borrow_mut()
@@ -1195,8 +1216,11 @@ impl RuntimeInstance {
                     return Ok(());
                 };
                 match event {
-                    PendingHostEvent::Input(event) => self
-                        .dispatch_input_active(&event)
+                    PendingHostEvent::Input {
+                        event,
+                        presentation,
+                    } => self
+                        .dispatch_input_active(&event, &presentation)
                         .map_err(RuntimeEventError::Input)
                         .map(|_| ())?,
                     PendingHostEvent::Module {

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -21,8 +21,8 @@ use crate::view::{BindType, DynRenderer, Element, with_installed_renderer};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
     Accessibility, BoxPaint, ElementRegistration, ElementSchema, ElementValueKind, HitTestBehavior,
-    InputEvent, InputEventError, LayoutGeometry, MeasurementReady, NodeId, PaintColor,
-    ResourceCommand, ResourceEvent, ResourceId, ResourceMessageError, SurfaceId,
+    HostPresentationUpdate, InputEvent, InputEventError, LayoutGeometry, MeasurementReady, NodeId,
+    PaintColor, ResourceCommand, ResourceEvent, ResourceId, ResourceMessageError, SurfaceId,
 };
 #[cfg(test)]
 use whisker_engine::whisker_style::ComputedTransformFunction;
@@ -171,6 +171,8 @@ pub enum RuntimeInputError {
     },
     /// Host timing or pointer geometry was invalid.
     InvalidInput(InputEventError),
+    /// Coalesced Host presentation state contained invalid numeric data.
+    InvalidPresentation,
     /// The Host named a node that is no longer live.
     UnknownTarget {
         /// Stale or invalid target.
@@ -480,6 +482,15 @@ impl SurfaceRuntime {
 
     /// Hit-tests and routes one Host-normalized event through Rust listeners.
     pub fn dispatch_input(&self, event: &InputEvent) -> Result<InputDispatch, RuntimeInputError> {
+        self.dispatch_input_with_presentation(event, &[])
+    }
+
+    /// Applies coalesced Host presentation state, then hit-tests and routes one event.
+    pub fn dispatch_input_with_presentation(
+        &self,
+        event: &InputEvent,
+        presentation: &[HostPresentationUpdate],
+    ) -> Result<InputDispatch, RuntimeInputError> {
         let (target, firings, body) = {
             let mut state = self.state.borrow_mut();
             state
@@ -492,6 +503,28 @@ impl SurfaceRuntime {
                 });
             }
             event.validate().map_err(RuntimeInputError::InvalidInput)?;
+            for update in presentation {
+                if !update.is_valid() {
+                    return Err(RuntimeInputError::InvalidPresentation);
+                }
+                match *update {
+                    HostPresentationUpdate::ScrollOffset { node, .. }
+                        if state.surface.node(node).is_none() =>
+                    {
+                        return Err(RuntimeInputError::UnknownTarget { node });
+                    }
+                    HostPresentationUpdate::ScrollOffset { .. } => {}
+                }
+            }
+            for update in presentation {
+                match *update {
+                    HostPresentationUpdate::ScrollOffset { node, offset } => state
+                        .surface
+                        .update_host_scroll_offset(node, [offset.x, offset.y])
+                        .map_err(RuntimeBindingError::from)
+                        .map_err(RuntimeInputError::Binding)?,
+                }
+            }
             let root = state.root.ok_or(RuntimeInputError::MissingRoot)?;
             let captured = event
                 .pointer

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -117,6 +117,7 @@ public open class WhiskerContainerView(context: Context) : ViewGroup(context) {
 public class WhiskerScrollContainerView(context: Context) : FrameLayout(context), WhiskerEventSource {
     public val contentView: WhiskerContainerView = WhiskerContainerView(context)
     private var eventSink: ((String, WhiskerValue) -> Unit)? = null
+    private var presentationSink: ((Float, Float) -> Unit)? = null
     private var horizontal = false
     private var snapFactor: Double? = null
     private var snapOffset = 0.0
@@ -196,6 +197,11 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
 
     override fun installWhiskerEventSink(sink: ((String, WhiskerValue) -> Unit)?) {
         eventSink = sink
+    }
+
+    /** Installs the Host-internal scroll mirror, independent of app listeners. */
+    public fun installWhiskerPresentationSink(sink: ((Float, Float) -> Unit)?) {
+        presentationSink = sink
     }
 
     /** Switches the native scrolling axis without changing the Rust-owned child tree. */
@@ -282,6 +288,10 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
     private fun emitScroll() {
         val density = resources.displayMetrics.density.toDouble()
         val scroller = activeScroller()
+        presentationSink?.invoke(
+            (scroller.scrollX / density).toFloat(),
+            (scroller.scrollY / density).toFloat(),
+        )
         eventSink?.invoke(
             "scroll",
             WhiskerValue.Map(

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -112,6 +112,12 @@ class HostConformanceTest {
                     (300 * density).roundToInt(),
                 )
                 var detail: WhiskerValue? = null
+                var presentedX = Float.NaN
+                var presentedY = Float.NaN
+                scrollView.installWhiskerPresentationSink { x, y ->
+                    presentedX = x
+                    presentedY = y
+                }
                 scrollView.installWhiskerEventSink { name, value ->
                     if (name == "scroll") detail = value
                 }
@@ -122,6 +128,8 @@ class HostConformanceTest {
                 assertEquals(120.0, (values.getValue("scrollTop") as WhiskerValue.Float).value, 0.001)
                 assertEquals(80.0, (values.getValue("viewportHeight") as WhiskerValue.Float).value, 0.001)
                 assertEquals(300.0, (values.getValue("scrollHeight") as WhiskerValue.Float).value, 0.001)
+                assertEquals(0f, presentedX, 0.001f)
+                assertEquals(120f, presentedY, 0.001f)
             }
     }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -35,6 +35,8 @@ import rs.whisker.runtime.scene.HostSceneOperation
 private const val HOST_APPLY_ACCEPTED = MobileAbi.APPLY_ACCEPTED
 private const val HOST_APPLY_REJECTED = MobileAbi.APPLY_REJECTED
 
+private class ScrollOffsetBatch(val nodes: LongArray, val offsets: FloatArray)
+
 /** The single Android View that owns a Whisker runtime and its native scene. */
 class WhiskerView(context: Context) :
     WhiskerContainerView(context),
@@ -51,7 +53,17 @@ class WhiskerView(context: Context) :
     private val measurements = HostMeasurementProvider(context)
     private val bootstrap = HostElementBootstrap()
     private val rasterResources = HostRasterResourceStore()
-    private val scene = HostScene(this, context, ::dispatchElementEvent, rasterResources)
+    private val dirtyScrollOffsets = LinkedHashMap<Long, FloatArray>()
+    private val emptyScrollNodes = LongArray(0)
+    private val emptyScrollOffsets = FloatArray(0)
+    private val scene = HostScene(
+        this,
+        context,
+        ::dispatchElementEvent,
+        ::recordScrollOffset,
+        { node -> dirtyScrollOffsets.remove(node) },
+        rasterResources,
+    )
     private val resourceService = HostResourceService(
         rasterResources,
         ::handleResourceEvent,
@@ -219,6 +231,7 @@ class WhiskerView(context: Context) :
         pointers.forEach { pointer ->
             val handle = nativeHandle
             if (handle != 0L) {
+                val scrollBatch = takeScrollOffsets()
                 nativeDispatchPointer(
                     handle,
                     pointer.timestampMs,
@@ -229,6 +242,8 @@ class WhiskerView(context: Context) :
                     pointer.y,
                     pointer.buttons,
                     pointer.changedButton,
+                    scrollBatch?.nodes ?: emptyScrollNodes,
+                    scrollBatch?.offsets ?: emptyScrollOffsets,
                 )
             }
         }
@@ -237,6 +252,28 @@ class WhiskerView(context: Context) :
         // an Android ownership decision, so receiving a normalized sample is
         // enough to claim it while the runtime is mounted.
         return nativeHandle != 0L && pointers.isNotEmpty()
+    }
+
+    private fun recordScrollOffset(node: Long, x: Float, y: Float) {
+        val offset = dirtyScrollOffsets[node]
+        if (offset == null) dirtyScrollOffsets[node] = floatArrayOf(x, y)
+        else {
+            offset[0] = x
+            offset[1] = y
+        }
+    }
+
+    private fun takeScrollOffsets(): ScrollOffsetBatch? {
+        if (dirtyScrollOffsets.isEmpty()) return null
+        val nodes = LongArray(dirtyScrollOffsets.size)
+        val offsets = FloatArray(dirtyScrollOffsets.size * 2)
+        dirtyScrollOffsets.entries.forEachIndexed { index, entry ->
+            nodes[index] = entry.key
+            offsets[index * 2] = entry.value[0]
+            offsets[index * 2 + 1] = entry.value[1]
+        }
+        dirtyScrollOffsets.clear()
+        return ScrollOffsetBatch(nodes, offsets)
     }
 
     /** Called from Rust through JNI. Safe even when the wake originates off-main. */
@@ -608,6 +645,8 @@ class WhiskerView(context: Context) :
         y: Float,
         buttons: Int,
         changedButton: Int,
+        scrollNodes: LongArray,
+        scrollOffsets: FloatArray,
     ): Boolean
     private external fun nativeResolveModule(
         callbackPtr: Long,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
@@ -12,7 +12,7 @@ internal object MobileAbi {
     const val VALUE_MAP: Int = 7
     const val VALUE_ERROR: Int = 8
     const val MOBILE_ABI_MAJOR: Int = 2
-    const val MOBILE_ABI_MINOR: Int = 29
+    const val MOBILE_ABI_MINOR: Int = 30
     const val FRAME_PROTOCOL_MAJOR: Int = 1
     const val FRAME_PROTOCOL_MINOR: Int = 4
     const val CAPABILITY_ELLIPTICAL_BORDER_RADIUS: Long = 0x0001

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import java.util.ArrayDeque
 import rs.whisker.runtime.WhiskerChildPolicy
 import rs.whisker.runtime.WhiskerContainerView
+import rs.whisker.runtime.WhiskerScrollContainerView
 import rs.whisker.runtime.WhiskerView
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerTextContent
@@ -77,6 +78,8 @@ internal class HostScene(
     private val root: WhiskerContainerView,
     private val context: Context,
     private val emitElementEvent: (Long, String, WhiskerValue) -> Unit,
+    private val updateScrollOffset: (Long, Float, Float) -> Unit,
+    private val removeScrollOffset: (Long) -> Unit,
     private val rasterResources: HostRasterResourceStore,
 ) {
     private val nodes = LinkedHashMap<Long, HostNode>()
@@ -145,6 +148,7 @@ internal class HostScene(
     }
 
     fun clear() {
+        nodes.keys.forEach(removeScrollOffset)
         nodes.values.toList().forEach(::releasePresentation)
         nodes.clear()
         parents.clear()
@@ -260,6 +264,8 @@ internal class HostScene(
                 )
                 val node = HostNode(context, registration.name, root as? WhiskerView)
                 node.mountedElement = mounted
+                (mounted.view as? WhiskerScrollContainerView)
+                    ?.installWhiskerPresentationSink { x, y -> updateScrollOffset(id, x, y) }
                 node.addView(
                     mounted.view,
                     ViewGroup.LayoutParams(
@@ -403,10 +409,12 @@ internal class HostScene(
         pointerCaptures.entries.removeAll { it.value in removedNodes }
         if (pointerCaptures.isEmpty()) root.parent?.requestDisallowInterceptTouchEvent(false)
         descendants.forEach { child ->
+            removeScrollOffset(child)
             nodes.remove(child)?.let(::releasePresentation)
             parents.remove(child)
         }
         parents.remove(id)
+        removeScrollOffset(id)
         (node.parent as? ViewGroup)?.removeView(node)
         releasePresentation(node)
     }

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -419,18 +419,17 @@ impl DesktopApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, mut event: InputEvent) {
-        if let Some(host) = &self.host {
-            host.target_input(&mut event);
-        }
+    fn dispatch_input(&mut self, event: InputEvent) {
         let Some(runtime) = &self.runtime else {
             return;
         };
-        if let Err(error) = self
+        let host = self
             .host
-            .as_ref()
-            .expect("mounted Desktop runtime has a Host")
-            .with_modules(|| runtime.dispatch_input(&event))
+            .as_mut()
+            .expect("mounted Desktop runtime has a Host");
+        let presentation = host.take_presentation_updates();
+        if let Err(error) =
+            host.with_modules(|| runtime.dispatch_input_with_presentation(&event, &presentation))
         {
             eprintln!("dispatch {TARGET_NAME} input failed: {error}");
         }

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -200,6 +200,12 @@ impl DesktopRuntime {
         self.modules.with_host(work)
     }
 
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.surface.take_presentation_updates()
+    }
+
     /// Reconfigures the GPU surface after an OS resize notification.
     pub fn resize(&mut self, physical_size: [u32; 2]) {
         self.surface.resize(physical_size);
@@ -209,17 +215,6 @@ impl DesktopRuntime {
     /// logical window position.
     pub fn cursor_at(&self, logical_position: [f32; 2]) -> Option<whisker_protocol::CursorKeyword> {
         self.surface.cursor_at(logical_position)
-    }
-
-    /// Resolves the Host-visible target after applying transient scroll state.
-    pub fn target_input(&self, event: &mut InputEvent) {
-        if event.target.is_none()
-            && let Some(pointer) = event.pointer
-        {
-            event.target = self
-                .surface
-                .hit_test([pointer.position.x, pointer.position.y]);
-        }
     }
 
     pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -339,6 +339,7 @@ pub(crate) struct DesktopScene {
     nodes: HashMap<NodeId, RenderNode>,
     smooth_scrolls: HashMap<NodeId, SmoothScroll>,
     pointer_captures: HashMap<PointerId, NodeId>,
+    dirty_scroll_offsets: HashSet<NodeId>,
     presentation_pool: HashMap<ElementTypeId, Vec<DesktopElementContent>>,
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -638,6 +638,14 @@ fn scroll_container_offsets_paint_and_hit_testing_inside_its_viewport() {
     assert!(scene.scroll_at([10.0, 60.0], [0.0, 120.0]));
     assert_eq!(scene.nodes[&scroll].scroll_offset, [0.0, 120.0]);
     assert_eq!(
+        scene.take_presentation_updates(),
+        vec![whisker_protocol::HostPresentationUpdate::ScrollOffset {
+            node: scroll,
+            offset: whisker_protocol::InputPoint { x: 0.0, y: 120.0 },
+        }]
+    );
+    assert!(scene.take_presentation_updates().is_empty());
+    assert_eq!(
         scene.take_events(),
         vec![DesktopProviderEvent {
             target: scroll,
@@ -989,6 +997,73 @@ fn cursor_hit_testing_respects_pointer_events_and_child_z_order() {
         Some(whisker_protocol::CursorKeyword::Grab)
     );
     assert_eq!(scene.cursor_at([200.0, 20.0]), None);
+}
+
+#[test]
+fn cursor_and_native_scroll_hit_testing_follow_transforms() {
+    let root = id(1);
+    let child = id(2);
+    let element_type = element_type(whisker::VIEW_ELEMENT_NAME);
+    let mut transform = Transform::IDENTITY;
+    transform.0[12] = 100.0;
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node: root,
+                    element_type,
+                },
+                Operation::CreateNode {
+                    node: child,
+                    element_type,
+                },
+                Operation::InsertChild {
+                    parent: root,
+                    child,
+                    index: 0,
+                },
+                Operation::SetLayout {
+                    node: root,
+                    geometry: geometry(0.0, 0.0, 300.0, 100.0),
+                },
+                Operation::SetLayout {
+                    node: child,
+                    geometry: geometry(0.0, 0.0, 50.0, 50.0),
+                },
+                Operation::SetTransform {
+                    node: child,
+                    transform,
+                },
+                Operation::SetCursor {
+                    node: root,
+                    cursor: Cursor {
+                        resources: Vec::new(),
+                        fallback: whisker_protocol::CursorKeyword::Pointer,
+                    },
+                },
+                Operation::SetCursor {
+                    node: child,
+                    cursor: Cursor {
+                        resources: Vec::new(),
+                        fallback: whisker_protocol::CursorKeyword::Grab,
+                    },
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert_eq!(
+        scene.cursor_at([110.0, 10.0]),
+        Some(whisker_protocol::CursorKeyword::Grab)
+    );
+    assert_eq!(
+        scene.cursor_at([10.0, 10.0]),
+        Some(whisker_protocol::CursorKeyword::Pointer)
+    );
 }
 
 #[test]

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -1,5 +1,31 @@
 use super::*;
 
+fn inverse_map_around(transform: Transform, point: [f32; 2], origin: [f32; 2]) -> Option<[f32; 2]> {
+    if transform == Transform::IDENTITY {
+        return Some(point);
+    }
+    let [x, y] = [point[0] - origin[0], point[1] - origin[1]];
+    let matrix = transform.0;
+    let [a, c, tx] = [matrix[0], matrix[4], matrix[12]];
+    let [b, d, ty] = [matrix[1], matrix[5], matrix[13]];
+    let [p, q, r] = [matrix[3], matrix[7], matrix[15]];
+    let determinant = a * (d * r - ty * q) - c * (b * r - ty * p) + tx * (b * q - d * p);
+    if determinant.abs() <= f32::EPSILON {
+        return None;
+    }
+    let inverse_x = (d * r - ty * q) * x + (tx * q - c * r) * y + (c * ty - tx * d);
+    let inverse_y = (ty * p - b * r) * x + (a * r - tx * p) * y + (tx * b - a * ty);
+    let inverse_w = (b * q - d * p) * x + (c * p - a * q) * y + (a * d - c * b);
+    if inverse_w.abs() <= f32::EPSILON {
+        return None;
+    }
+    let mapped = [
+        origin[0] + inverse_x / inverse_w,
+        origin[1] + inverse_y / inverse_w,
+    ];
+    mapped.into_iter().all(f32::is_finite).then_some(mapped)
+}
+
 impl DesktopScene {
     #[cfg(test)]
     pub(crate) fn new(surface: SurfaceId, elements: DesktopElementRegistry) -> Self {
@@ -17,6 +43,7 @@ impl DesktopScene {
             nodes: HashMap::new(),
             smooth_scrolls: HashMap::new(),
             pointer_captures: HashMap::new(),
+            dirty_scroll_offsets: HashSet::new(),
             presentation_pool: HashMap::new(),
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
@@ -50,6 +77,24 @@ impl DesktopScene {
                     target: event.target,
                     name,
                     detail: event.detail,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.dirty_scroll_offsets
+            .drain()
+            .filter_map(|node| {
+                let offset = self.nodes.get(&node)?.scroll_offset;
+                Some(whisker_protocol::HostPresentationUpdate::ScrollOffset {
+                    node,
+                    offset: whisker_protocol::InputPoint {
+                        x: offset[0],
+                        y: offset[1],
+                    },
                 })
             })
             .collect()
@@ -213,6 +258,7 @@ impl DesktopScene {
         let visible = presentation.visibility == Visibility::Visible;
         let rect = presentation.layout.border_box;
         let origin = [parent_origin[0] + rect.x, parent_origin[1] + rect.y];
+        let point = inverse_map_around(presentation.transform, point, origin)?;
         let contains_x = point[0] >= origin[0] && point[0] <= origin[0] + rect.width;
         let contains_y = point[1] >= origin[1] && point[1] <= origin[1] + rect.height;
         let clipped = (presentation.clip.horizontal == OverflowClip::Hidden && !contains_x)
@@ -226,23 +272,43 @@ impl DesktopScene {
             } else {
                 origin
             };
-            let mut children = presentation
-                .children
-                .iter()
-                .enumerate()
-                .map(|(index, child)| {
-                    (
-                        *child,
-                        self.nodes
-                            .get(child)
-                            .map_or(0, |child| child.presentation.z_order),
-                        index,
-                    )
-                })
-                .collect::<Vec<_>>();
-            children.sort_by_key(|(_, z_order, index)| (*z_order, *index));
-            for (child, _, _) in children.into_iter().rev() {
-                if let Some(target) = self.hit_test_node(child, point, child_origin) {
+            let first_z = presentation.children.first().map_or(0, |child| {
+                self.nodes
+                    .get(child)
+                    .map_or(0, |child| child.presentation.z_order)
+            });
+            let uniform_z = presentation.children.iter().all(|child| {
+                self.nodes
+                    .get(child)
+                    .map_or(0, |child| child.presentation.z_order)
+                    == first_z
+            });
+            if uniform_z {
+                if let Some(target) = presentation
+                    .children
+                    .iter()
+                    .rev()
+                    .find_map(|child| self.hit_test_node(*child, point, child_origin))
+                {
+                    return Some(target);
+                }
+            } else {
+                let mut best = None;
+                for (index, child) in presentation.children.iter().copied().enumerate() {
+                    let Some(target) = self.hit_test_node(child, point, child_origin) else {
+                        continue;
+                    };
+                    let z = self
+                        .nodes
+                        .get(&child)
+                        .map_or(0, |child| child.presentation.z_order);
+                    if best
+                        .is_none_or(|((best_z, best_index), _)| (z, index) > (best_z, best_index))
+                    {
+                        best = Some(((z, index), target));
+                    }
+                }
+                if let Some((_, target)) = best {
                     return Some(target);
                 }
             }
@@ -499,7 +565,8 @@ impl DesktopScene {
         None
     }
 
-    fn emit_scroll(&self, node: NodeId, offset: [f32; 2], max: [f32; 2]) {
+    fn emit_scroll(&mut self, node: NodeId, offset: [f32; 2], max: [f32; 2]) {
+        self.dirty_scroll_offsets.insert(node);
         let viewport = self.nodes[&node].presentation.layout.content_box;
         self.pending_events
             .lock()
@@ -917,6 +984,7 @@ impl DesktopScene {
             }
             self.pending_events.lock().unwrap().clear();
             self.pointer_captures.clear();
+            self.dirty_scroll_offsets.clear();
         }
         for operation in &packet.operations {
             match operation {
@@ -1172,6 +1240,7 @@ impl DesktopScene {
 
     fn delete_subtree(&mut self, node: NodeId) {
         self.smooth_scrolls.remove(&node);
+        self.dirty_scroll_offsets.remove(&node);
         let Some(removed) = self.nodes.remove(&node) else {
             return;
         };

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -63,15 +63,17 @@ impl DesktopSurface {
         self.scene.take_events()
     }
 
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.scene.take_presentation_updates()
+    }
+
     pub(crate) fn cursor_at(
         &self,
         logical_position: [f32; 2],
     ) -> Option<whisker_protocol::CursorKeyword> {
         self.scene.cursor_at(logical_position)
-    }
-
-    pub(crate) fn hit_test(&self, logical_position: [f32; 2]) -> Option<whisker_protocol::NodeId> {
-        self.scene.hit_test(logical_position)
     }
 
     pub(crate) fn scroll_at(&mut self, logical_position: [f32; 2], delta: [f32; 2]) -> bool {

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 29
+#define WHISKER_MOBILE_ABI_MINOR 30
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -797,7 +797,10 @@ extern bool whisker_view_dispatch_pointer(void *handle,
                                           float x,
                                           float y,
                                           uint32_t buttons,
-                                          int16_t changed_button);
+                                          int16_t changed_button,
+                                          const uint64_t *scroll_nodes,
+                                          const float *scroll_offsets,
+                                          size_t scroll_count);
 
 extern bool whisker_view_dispatch_module_event(void *handle,
                                                const uint8_t *module,

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -16,6 +16,7 @@ public class WhiskerContainerView: UIView {
 public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegate, WhiskerEventSource {
     public let contentView = WhiskerContainerView(frame: .zero)
     private var eventSink: ((String, WhiskerValue) -> Void)?
+    private var presentationSink: ((CGPoint) -> Void)?
     private var horizontal = false
     private var snapFactor: CGFloat?
     private var snapOffset: CGFloat = 0
@@ -39,6 +40,11 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
 
     public func installWhiskerEventSink(_ sink: ((String, WhiskerValue) -> Void)?) {
         eventSink = sink
+    }
+
+    /** Installs the Host-internal scroll mirror, independent of app listeners. */
+    public func installWhiskerPresentationSink(_ sink: ((CGPoint) -> Void)?) {
+        presentationSink = sink
     }
 
     public func setScrollOrientation(_ value: String) {
@@ -78,6 +84,7 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        presentationSink?(contentOffset)
         eventSink?("scroll", .map([
             "scrollLeft": .float(Double(contentOffset.x)),
             "scrollTop": .float(Double(contentOffset.y)),

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -17,6 +17,7 @@ public final class WhiskerView: UIView {
         return recognizer
     }()
     private var touchIdentities = HostTouchIdentityMap()
+    private var dirtyScrollOffsets: [UInt64: CGPoint] = [:]
     private let modules = HostModuleDispatcher()
     private let resources = HostResourceStore()
     private lazy var resourceService = HostResourceService(store: resources)
@@ -27,6 +28,12 @@ public final class WhiskerView: UIView {
         logicalBounds: { [unowned self] in self.logicalBounds },
         emitElementEvent: { [weak self] node, name, detail in
             self?.dispatchElementEvent(node: node, name: name, detail: detail)
+        },
+        updateScrollOffset: { [weak self] node, offset in
+            self?.dirtyScrollOffsets[node] = offset
+        },
+        removeScrollOffset: { [weak self] node in
+            self?.dirtyScrollOffsets.removeValue(forKey: node)
         }
     )
 
@@ -237,8 +244,15 @@ public final class WhiskerView: UIView {
               ) else { return }
         _ = dispatchWhiskerPointer(
             handle: handle,
-            input: input
+            input: input,
+            scrollOffsets: takeScrollOffsets()
         )
+    }
+
+    private func takeScrollOffsets() -> [UInt64: CGPoint] {
+        let result = dirtyScrollOffsets
+        dirtyScrollOffsets.removeAll(keepingCapacity: true)
+        return result
     }
 
     private func unmount() {
@@ -256,6 +270,7 @@ public final class WhiskerView: UIView {
         if ownedRuntime { scene.clear() }
         pendingModuleEvents.clear()
         touchIdentities.clear()
+        dirtyScrollOffsets.removeAll(keepingCapacity: false)
         if let token = hostToken {
             Unmanaged<WhiskerView>.fromOpaque(token).release()
             hostToken = nil

--- a/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
@@ -63,11 +63,14 @@ func whiskerViewDispatchPointer(
     _ x: Float,
     _ y: Float,
     _ buttons: UInt32,
-    _ changedButton: Int16
+    _ changedButton: Int16,
+    _ scrollNodes: UnsafePointer<UInt64>?,
+    _ scrollOffsets: UnsafePointer<Float>?,
+    _ scrollCount: Int
 ) -> Bool {
     whisker_view_dispatch_pointer(
         handle, timestampMs, event, pointerID, pointerKind,
-        x, y, buttons, changedButton
+        x, y, buttons, changedButton, scrollNodes, scrollOffsets, scrollCount
     )
 }
 
@@ -106,19 +109,35 @@ func makeWhiskerPointerDispatch(
 @discardableResult
 func dispatchWhiskerPointer(
     handle: UnsafeMutableRawPointer,
-    input: WhiskerPointerDispatch
+    input: WhiskerPointerDispatch,
+    scrollOffsets: [UInt64: CGPoint]
 ) -> Bool {
-    return whiskerViewDispatchPointer(
-        handle,
-        input.timestampMs,
-        input.event,
-        input.pointerID,
-        input.pointerKind,
-        input.x,
-        input.y,
-        input.buttons,
-        input.changedButton
-    )
+    let nodes = Array(scrollOffsets.keys)
+    var values = [Float]()
+    values.reserveCapacity(nodes.count * 2)
+    for node in nodes {
+        let offset = scrollOffsets[node] ?? .zero
+        values.append(Float(offset.x))
+        values.append(Float(offset.y))
+    }
+    return nodes.withUnsafeBufferPointer { nodeBuffer in
+        values.withUnsafeBufferPointer { valueBuffer in
+            whiskerViewDispatchPointer(
+                handle,
+                input.timestampMs,
+                input.event,
+                input.pointerID,
+                input.pointerKind,
+                input.x,
+                input.y,
+                input.buttons,
+                input.changedButton,
+                nodeBuffer.baseAddress,
+                valueBuffer.baseAddress,
+                nodes.count
+            )
+        }
+    }
 }
 
 func whiskerViewDispatchModuleEvent(

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -7,6 +7,8 @@ final class HostScene {
     private let resources: HostResourceStore
     private let logicalBounds: () -> CGRect
     private let emitElementEvent: (UInt64, String, WhiskerValue) -> Void
+    private let updateScrollOffset: (UInt64, CGPoint) -> Void
+    private let removeScrollOffset: (UInt64) -> Void
     private var nodes: [UInt64: WhiskerNodeView] = [:]
     private var nodeOrder: [UInt64] = []
     private var parents: [UInt64: UInt64] = [:]
@@ -22,12 +24,16 @@ final class HostScene {
         root: UIView,
         resources: HostResourceStore,
         logicalBounds: @escaping () -> CGRect,
-        emitElementEvent: @escaping (UInt64, String, WhiskerValue) -> Void
+        emitElementEvent: @escaping (UInt64, String, WhiskerValue) -> Void,
+        updateScrollOffset: @escaping (UInt64, CGPoint) -> Void,
+        removeScrollOffset: @escaping (UInt64) -> Void
     ) {
         self.root = root
         self.resources = resources
         self.logicalBounds = logicalBounds
         self.emitElementEvent = emitElementEvent
+        self.updateScrollOffset = updateScrollOffset
+        self.removeScrollOffset = removeScrollOffset
     }
 
     func applyFrame(
@@ -86,6 +92,7 @@ final class HostScene {
     }
 
     func clear() {
+        nodes.keys.forEach(removeScrollOffset)
         nodes.values.forEach(releasePresentation)
         nodes.values.forEach { $0.removeFromSuperview() }
         nodes.removeAll()
@@ -280,6 +287,9 @@ final class HostScene {
             }
             let node = WhiskerNodeView(element: registration.name)
             node.mountedElement = mounted
+            (mounted.view as? WhiskerScrollContainerView)?.installWhiskerPresentationSink {
+                [weak self] offset in self?.updateScrollOffset(id, offset)
+            }
             mounted.view.frame = node.bounds
             mounted.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
             node.addSubview(mounted.view)
@@ -503,6 +513,7 @@ final class HostScene {
         guard let node = nodes.removeValue(forKey: id) else { return }
         let descendants = nodes.keys.filter { isDescendant($0, of: id) }
         descendants.forEach {
+            removeScrollOffset($0)
             if let removed = nodes.removeValue(forKey: $0) {
                 releasePresentation(removed)
             }
@@ -513,6 +524,7 @@ final class HostScene {
         nodeOrder.removeAll { removed.contains($0) }
         removed.forEach { zOrders.removeValue(forKey: $0) }
         parents.removeValue(forKey: id)
+        removeScrollOffset(id)
         releasePresentation(node)
         node.removeFromSuperview()
     }

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -299,6 +299,8 @@ final class HostConformanceTests: XCTestCase {
         )
         scrollView.layoutIfNeeded()
         var detail: WhiskerValue?
+        var presentedOffset: CGPoint?
+        scrollView.installWhiskerPresentationSink { presentedOffset = $0 }
         scrollView.installWhiskerEventSink { name, value in
             if name == "scroll" { detail = value }
         }
@@ -311,6 +313,7 @@ final class HostConformanceTests: XCTestCase {
         XCTAssertEqual(values["scrollTop"], .float(120))
         XCTAssertEqual(values["viewportHeight"], .float(80))
         XCTAssertEqual(values["scrollHeight"], .float(300))
+        XCTAssertEqual(presentedOffset, CGPoint(x: 0, y: 120))
     }
 
     func testHorizontalScrollViewSettlesOnNearestCarouselItem() {

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -427,6 +427,7 @@ fn install_pointer_listeners(root: &web_sys::Element) -> Result<(), WebError> {
                     application
                         .modules
                         .with_host(|| {
+                            let presentation = application.frames.take_presentation_updates();
                             dispatch_pointer(
                                 &application.runtime,
                                 InputPoint {
@@ -434,6 +435,7 @@ fn install_pointer_listeners(root: &web_sys::Element) -> Result<(), WebError> {
                                     y: bounds.top() as f32,
                                 },
                                 input,
+                                &presentation,
                             )
                         })
                         .map(|_| ())

--- a/platforms/web/src/input.rs
+++ b/platforms/web/src/input.rs
@@ -34,6 +34,7 @@ pub(crate) fn dispatch_pointer(
     runtime: &RuntimeInstance,
     root_origin: InputPoint,
     input: WebPointerEvent,
+    presentation: &[whisker_protocol::HostPresentationUpdate],
 ) -> Result<InputEvent, WebError> {
     let pointer_id = PointerId::new(input.pointer_id)
         .ok_or_else(|| WebError("browser pointer id must be non-zero".into()))?;
@@ -60,7 +61,7 @@ pub(crate) fn dispatch_pointer(
         detail: WhiskerValue::Null,
     };
     runtime
-        .dispatch_input(&event)
+        .dispatch_input_with_presentation(&event, presentation)
         .map_err(|error| WebError(format!("dispatch Web pointer input: {error}")))?;
     Ok(event)
 }

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -39,6 +39,7 @@ pub(crate) struct DomFrameSink {
     scroll_listeners: HashMap<NodeId, Vec<ScrollListener>>,
     pointer_captures: HashMap<PointerId, NodeId>,
     pending_events: Rc<RefCell<VecDeque<WebProviderEvent>>>,
+    dirty_scroll_offsets: Rc<RefCell<HashMap<NodeId, whisker_protocol::InputPoint>>>,
 }
 
 struct PooledWebPresentation {
@@ -123,11 +124,27 @@ impl DomFrameSink {
             scroll_listeners: HashMap::new(),
             pointer_captures: HashMap::new(),
             pending_events: Rc::new(RefCell::new(VecDeque::new())),
+            dirty_scroll_offsets: Rc::new(RefCell::new(HashMap::new())),
         })
     }
 
     pub(crate) fn take_events(&self) -> Vec<WebProviderEvent> {
         self.pending_events.borrow_mut().drain(..).collect()
+    }
+
+    pub(crate) fn take_presentation_updates(
+        &self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.dirty_scroll_offsets
+            .borrow_mut()
+            .drain()
+            .map(
+                |(node, offset)| whisker_protocol::HostPresentationUpdate::ScrollOffset {
+                    node,
+                    offset,
+                },
+            )
+            .collect()
     }
 
     pub(crate) fn register_resource_url(
@@ -207,6 +224,7 @@ impl DomFrameSink {
             self.scroll_listeners.clear();
             self.pointer_captures.clear();
             self.pending_events.borrow_mut().clear();
+            self.dirty_scroll_offsets.borrow_mut().clear();
         }
         for operation in &packet.operations {
             self.apply_operation(operation)?;
@@ -303,10 +321,19 @@ impl DomFrameSink {
                     set_style(&element, "overflow-y", "auto")?;
                     let emitter = emitter.clone();
                     let scroll_element = element.clone();
+                    let dirty_scroll_offsets = Rc::clone(&self.dirty_scroll_offsets);
+                    let scroll_node = *node;
                     let listener = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
                         let Some(html) = scroll_element.dyn_ref::<web_sys::HtmlElement>() else {
                             return;
                         };
+                        dirty_scroll_offsets.borrow_mut().insert(
+                            scroll_node,
+                            whisker_protocol::InputPoint {
+                                x: html.scroll_left() as f32,
+                                y: html.scroll_top() as f32,
+                            },
+                        );
                         emitter.emit_urgent(WebNativeEvent {
                             event: "scroll".to_owned(),
                             detail: WhiskerValue::map([
@@ -757,6 +784,7 @@ impl DomFrameSink {
             let native = self.native_nodes.remove(&node);
             self.event_masks.remove(&node);
             self.scroll_listeners.remove(&node);
+            self.dirty_scroll_offsets.borrow_mut().remove(&node);
             if let (Some(element), Some(element_type)) = (element, element_type)
                 && self.elements.binding(element_type).is_ok_and(|binding| {
                     matches!(

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -274,6 +274,14 @@ async fn scroll_view_emits_geometry_and_honors_scroll_behavior() {
     assert_eq!(detail.get("scrollTop"), Some(&WhiskerValue::Int(120)));
     assert_eq!(detail.get("viewportHeight"), Some(&WhiskerValue::Int(80)));
     assert_eq!(detail.get("scrollHeight"), Some(&WhiskerValue::Int(300)));
+    assert_eq!(
+        driver.sink.take_presentation_updates(),
+        vec![whisker_protocol::HostPresentationUpdate::ScrollOffset {
+            node: scroll,
+            offset: whisker_protocol::InputPoint { x: 0.0, y: 120.0 },
+        }]
+    );
+    assert!(driver.sink.take_presentation_updates().is_empty());
 
     driver
         .sink
@@ -1139,8 +1147,13 @@ impl Driver {
         let local_position = input.client_position;
         input.client_position.x += root_origin.x;
         input.client_position.y += root_origin.y;
-        let event = dispatch_pointer(self.input_runtime.as_ref().unwrap(), root_origin, input)
-            .expect("fixture pointer dispatch succeeds through the production Web path");
+        let event = dispatch_pointer(
+            self.input_runtime.as_ref().unwrap(),
+            root_origin,
+            input,
+            &[],
+        )
+        .expect("fixture pointer dispatch succeeds through the production Web path");
         let pointer = event.pointer.expect("pointer fixture has pointer payload");
         assert_eq!(event.timestamp_ms, input.timestamp_ms);
         assert_eq!(pointer.position, local_position);


### PR DESCRIPTION
## Summary
- route ordinary pointer input through the retained Rust scene on every Host
- account for transforms, z-order, visibility overrides, overflow/rounded/clip-path geometry, and pointer capture without per-event sorting or inverse-matrix caches
- coalesce Host-owned native scroll offsets locally and piggyback only the latest changed values on the next pointer call
- extend the mobile pointer ABI without adding an extra JNI/FFI round trip

## Performance model
- scrolling alone performs no new RuntimeInstance or JNI call
- repeated offsets overwrite one per-scroll-node entry in Host memory
- the common uniform-z hit-test path is allocation-free and early-exits front-to-back
- pointer capture is indexed by active pointer rather than scanning every scene node

## Verification
- cargo test -p whisker-protocol -p whisker-engine -p whisker-runtime -p whisker-driver -p whisker-desktop --all-targets
- cargo clippy -p whisker-protocol -p whisker-engine -p whisker-runtime -p whisker-driver -p whisker-desktop -p whisker-web --all-targets -- -D warnings
- cargo xtask host-conformance web
- cargo xtask host-conformance ios
- Android runtime/module/debugAndroidTest Kotlin compilation
- cargo xtask mobile-link-test android
- cargo xtask mobile-link-test ios
- cargo xtask mobile-abi check

Android connected tests were compiled but not executed because no emulator/device was connected.