### PR TITLE
fix(layout): bound measurement cache lifetime

### DIFF
--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -246,6 +246,7 @@ struct PassState {
 pub(crate) struct MeasurementCoordinator {
     specs: BTreeMap<NodeId, SpecState>,
     cache: HashMap<CacheKey, CacheEntry>,
+    consumer_keys: HashMap<NodeId, Vec<CacheKey>>,
     outstanding: BTreeMap<MeasurementKey, OutstandingRequest>,
     outstanding_by_cache: HashMap<CacheKey, MeasurementKey>,
     pending: BTreeMap<MeasurementRequestId, PendingRequest>,
@@ -259,6 +260,7 @@ impl Default for MeasurementCoordinator {
         Self {
             specs: BTreeMap::new(),
             cache: HashMap::new(),
+            consumer_keys: HashMap::new(),
             outstanding: BTreeMap::new(),
             outstanding_by_cache: HashMap::new(),
             pending: BTreeMap::new(),
@@ -279,6 +281,7 @@ impl MeasurementCoordinator {
             return Vec::new();
         }
         self.cache.clear();
+        self.consumer_keys.clear();
         self.outstanding.clear();
         self.outstanding_by_cache.clear();
         self.pending.clear();
@@ -547,23 +550,41 @@ impl MeasurementCoordinator {
     }
 
     fn remove_consumer(&mut self, node: NodeId) {
-        for entry in self.cache.values_mut() {
-            entry.consumers.remove(&node);
-        }
-        let mut empty = Vec::new();
-        for (key, request) in &mut self.outstanding {
-            request.consumers.remove(&node);
-            if request.consumers.is_empty() {
-                empty.push(*key);
+        let Some(cache_keys) = self.consumer_keys.remove(&node) else {
+            return;
+        };
+        for cache_key in cache_keys {
+            let remove_cached = self.cache.get_mut(&cache_key).is_some_and(|entry| {
+                entry.consumers.remove(&node);
+                entry.consumers.is_empty()
+            });
+            if remove_cached {
+                let entry = self
+                    .cache
+                    .remove(&cache_key)
+                    .expect("checked cache entry remains present");
+                if let CachedState::Pending { request_id, .. } = entry.state {
+                    self.pending.remove(&request_id);
+                }
+                continue;
+            }
+
+            let Some(key) = self.outstanding_by_cache.get(&cache_key).copied() else {
+                continue;
+            };
+            let remove_outstanding = self.outstanding.get_mut(&key).is_some_and(|request| {
+                request.consumers.remove(&node);
+                request.consumers.is_empty()
+            });
+            if remove_outstanding {
+                self.outstanding.remove(&key);
+                self.outstanding_by_cache.remove(&cache_key);
             }
         }
-        for key in empty {
-            let request = self
-                .outstanding
-                .remove(&key)
-                .expect("collected key remains outstanding");
-            self.outstanding_by_cache.remove(&request.cache_key);
-        }
+    }
+
+    fn remember_consumer(&mut self, node: NodeId, cache_key: CacheKey) {
+        self.consumer_keys.entry(node).or_default().push(cache_key);
     }
 
     fn cache_key(state: &SpecState, constraints: MeasureConstraints, epoch: u64) -> CacheKey {
@@ -627,8 +648,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
         let cache_key = Self::cache_key(&state, constraints, epoch);
 
         if let Some(entry) = self.cache.get_mut(&cache_key) {
-            entry.consumers.insert(node);
+            let added = entry.consumers.insert(node);
             let cached = entry.state.clone();
+            if added {
+                self.remember_consumer(node, cache_key);
+            }
             return match cached {
                 CachedState::Ready(metrics) => {
                     self.specs
@@ -663,8 +687,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
                 .outstanding
                 .get_mut(&key)
                 .expect("cache index points to an outstanding request");
-            request.consumers.insert(node);
+            let added = request.consumers.insert(node);
             self.pass.requests.insert(key, request.request.clone());
+            if added {
+                self.remember_consumer(node, cache_key);
+            }
             return self.use_fallback(state.spec.pending_policy, state.last_ready.as_ref(), None);
         }
 
@@ -688,10 +715,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
             key,
             OutstandingRequest {
                 request: request.clone(),
-                cache_key,
+                cache_key: cache_key.clone(),
                 consumers: BTreeSet::from([node]),
             },
         );
+        self.remember_consumer(node, cache_key);
         self.pass.requests.insert(key, request);
         self.use_fallback(state.spec.pending_policy, state.last_ready.as_ref(), None)
     }
@@ -1219,6 +1247,9 @@ mod tests {
         let (mut no_consumers, _, _) = pending_coordinator();
         no_consumers.set_spec(node(1), element(), None).unwrap();
         assert_eq!(no_consumers.pending_count(), 0);
+        assert!(no_consumers.cache.is_empty());
+        assert!(no_consumers.pending.is_empty());
+        assert!(no_consumers.consumer_keys.is_empty());
 
         let mut outstanding = MeasurementCoordinator::default();
         outstanding.set_environment(1);
@@ -1240,6 +1271,7 @@ mod tests {
         outstanding.set_spec(node(2), element(), None).unwrap();
         assert!(outstanding.outstanding.is_empty());
         assert!(outstanding.outstanding_by_cache.is_empty());
+        assert!(outstanding.consumer_keys.is_empty());
 
         let mut invalid_pending = MeasurementCoordinator::default();
         invalid_pending.set_environment(1);
@@ -1264,6 +1296,82 @@ mod tests {
                 ))),
             }]),
             Err(MeasurementError::InvalidMetrics { key })
+        );
+    }
+
+    #[test]
+    fn unused_ready_cache_entries_are_reclaimed_without_breaking_shared_entries() {
+        let mut coordinator = MeasurementCoordinator::default();
+        coordinator.set_environment(1);
+        for value in 1..=2 {
+            coordinator
+                .set_spec(
+                    node(value),
+                    element(),
+                    Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+                )
+                .unwrap();
+        }
+
+        coordinator.begin_pass();
+        coordinator.measure(node(1), constraints(10.0));
+        coordinator.measure(node(2), constraints(10.0));
+        let request = coordinator.finish_pass().unwrap().requests.remove(0);
+        coordinator
+            .apply_batch(&[MeasurementResponse::Ready {
+                key: request.key,
+                environment_epoch: 1,
+                metrics: metrics(5.0, 4.0),
+            }])
+            .unwrap();
+        assert_eq!(coordinator.cache.len(), 1);
+
+        coordinator.remove_node(node(1));
+        assert_eq!(coordinator.cache.len(), 1);
+        assert!(!coordinator.consumer_keys.contains_key(&node(1)));
+
+        coordinator.remove_node(node(2));
+        assert!(coordinator.cache.is_empty());
+        assert!(coordinator.consumer_keys.is_empty());
+    }
+
+    #[test]
+    fn removing_last_pending_consumer_makes_deferred_completion_stale() {
+        let mut coordinator = MeasurementCoordinator::default();
+        coordinator.set_environment(1);
+        coordinator
+            .set_spec(
+                node(1),
+                element(),
+                Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+            )
+            .unwrap();
+        coordinator.begin_pass();
+        coordinator.measure(node(1), constraints(10.0));
+        let key = coordinator.finish_pass().unwrap().requests[0].key;
+        let request_id = MeasurementRequestId::new(30).expect("request");
+        coordinator
+            .apply_batch(&[MeasurementResponse::Pending {
+                key,
+                environment_epoch: 1,
+                request_id,
+                provisional: None,
+            }])
+            .unwrap();
+
+        coordinator.remove_node(node(1));
+        assert!(coordinator.pending.is_empty());
+        assert!(coordinator.cache.is_empty());
+        assert_eq!(
+            coordinator
+                .apply_ready(&MeasurementReady {
+                    key,
+                    request_id,
+                    environment_epoch: 1,
+                    metrics: metrics(5.0, 4.0),
+                })
+                .unwrap(),
+            DeferredMeasurementApply::IgnoredStale
         );
     }
 }

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -1326,11 +1326,27 @@ mod tests {
             .unwrap();
         assert_eq!(coordinator.cache.len(), 1);
 
+        coordinator
+            .set_spec(
+                node(3),
+                element(),
+                Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+            )
+            .unwrap();
+        coordinator.begin_pass();
+        assert_eq!(
+            coordinator.measure(node(3), constraints(10.0)),
+            LayoutSize::new(5.0, 4.0)
+        );
+        assert!(coordinator.finish_pass().unwrap().requests.is_empty());
+
         coordinator.remove_node(node(1));
         assert_eq!(coordinator.cache.len(), 1);
         assert!(!coordinator.consumer_keys.contains_key(&node(1)));
 
         coordinator.remove_node(node(2));
+        assert_eq!(coordinator.cache.len(), 1);
+        coordinator.remove_node(node(3));
         assert!(coordinator.cache.is_empty());
         assert!(coordinator.consumer_keys.is_empty());
     }

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -6,7 +6,11 @@
 
 #![warn(missing_docs)]
 
-use std::{collections::BTreeMap, error::Error, fmt};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    fmt,
+};
 
 use taffy::{
     AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing,
@@ -507,7 +511,7 @@ impl LayoutTree {
                 .expect("retained surface and application roots");
             self.surface_child = Some(root);
         }
-        let mut invalid_measurement = None;
+        let mut invalid_measurements = BTreeSet::new();
         self.backend
             .compute_layout_with_measure(
                 self.surface_root,
@@ -530,7 +534,7 @@ impl LayoutTree {
                         },
                     );
                     if !measured.is_valid() {
-                        invalid_measurement.get_or_insert(node);
+                        invalid_measurements.insert(node);
                         Size::ZERO
                     } else {
                         Size {
@@ -541,10 +545,17 @@ impl LayoutTree {
                 },
             )
             .expect("retained backend root");
-        if let Some(node) = invalid_measurement {
-            self.backend
-                .mark_dirty(backend_root)
-                .expect("retained backend root");
+        if let Some(node) = invalid_measurements.first().copied() {
+            for invalid in invalid_measurements {
+                let backend = self
+                    .nodes
+                    .get(&invalid)
+                    .expect("measurement context belongs to a retained node")
+                    .backend;
+                self.backend
+                    .mark_dirty(backend)
+                    .expect("retained backend node");
+            }
             return Err(LayoutError::InvalidMeasurement(node));
         }
         let mut snapshot = LayoutSnapshot::default();
@@ -1627,6 +1638,43 @@ mod tests {
             .unwrap();
         assert_eq!(snapshot.get(root).unwrap().border_box.width, 100.0);
         assert_eq!(snapshot.get(root).unwrap().border_box.height, 0.0);
+    }
+
+    #[test]
+    fn invalid_nested_measurement_is_retried_on_the_measured_leaf() {
+        use std::cell::Cell;
+
+        let root = id(1);
+        let child = id(2);
+        let mut tree = LayoutTree::default();
+        tree.create_node(root, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.create_node(child, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.set_measurable(child, true).unwrap();
+        tree.set_children(root, &[child]).unwrap();
+
+        let invalid_calls = Cell::new(0);
+        assert_eq!(
+            tree.compute(root, LayoutSize::new(100.0, 100.0), &mut |node, _| {
+                assert_eq!(node, child);
+                invalid_calls.set(invalid_calls.get() + 1);
+                LayoutSize::new(f32::NAN, 1.0)
+            }),
+            Err(LayoutError::InvalidMeasurement(child))
+        );
+        assert!(invalid_calls.get() > 0);
+
+        let retry_calls = Cell::new(0);
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 100.0), &mut |node, _| {
+                assert_eq!(node, child);
+                retry_calls.set(retry_calls.get() + 1);
+                LayoutSize::new(12.0, 8.0)
+            })
+            .unwrap();
+        assert!(retry_calls.get() > 0);
+        assert_eq!(snapshot.get(child).unwrap().border_box.height, 8.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- retry invalid intrinsic measurements by dirtying the measured Taffy leaves instead of only the surface root
- track measurement cache ownership per node so updates and removals avoid full-cache scans
- reclaim unused ready, pending, and outstanding entries; make late completions for removed nodes stale

## Performance
- the measure hot path records one reverse-index entry only when a node first consumes a cache key
- node removal now scales with keys used by that node rather than the entire historical cache
- no additional Host or FFI calls

## Verification
- cargo test -p whisker-protocol -p whisker-layout -p whisker-engine -p whisker-runtime -p whisker-driver
- cargo clippy -p whisker-layout -p whisker-engine --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check