### PR TITLE
fix: enforce MSRV and preserve mobile runtime lifecycle

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,6 +10,11 @@ coverage-text = "llvm-cov --workspace"
 # `cargo coverage-lcov` → LCOV for CI consumption.
 coverage-lcov = "llvm-cov --workspace --lcov --output-path lcov.info"
 
+[resolver]
+# Keep lockfile refreshes on releases compatible with the workspace MSRV.
+# The dedicated 1.85 CI job still verifies source-level compatibility.
+incompatible-rust-versions = "fallback"
+
 [target.aarch64-linux-android]
 # Keep the target at its default Armv8.0 baseline. Current Rust emits
 # classic `ldxr`/`stxr` loops for atomics on `aarch64-linux-android`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
   msrv:
     name: MSRV (rust 1.85)
     runs-on: ubuntu-latest
+    env:
+      # A checked-in rust-toolchain.toml outranks rustup's default toolchain.
+      # Pin the environment so this job actually exercises the advertised MSRV.
+      RUSTUP_TOOLCHAIN: 1.85.0
     steps:
       - uses: actions/checkout@v4
       # The version here must match `rust-version` in the root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "pin-project",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
@@ -164,7 +164,7 @@ dependencies = [
  "hkdf",
  "io_tee",
  "nom 7.1.3",
- "rand 0.8.7",
+ "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
 ]
@@ -491,7 +491,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -571,7 +571,7 @@ dependencies = [
  "jose-jwa",
  "jose-jwk",
  "p256",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -716,12 +716,6 @@ dependencies = [
  "const-str",
  "match-lookup",
 ]
-
-[[package]]
-name = "base45"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -927,7 +921,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1042,7 +1036,7 @@ checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
  "proc-macro2",
  "quote",
@@ -1055,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1090,12 +1084,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1181,7 +1175,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1224,9 +1218,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -1369,18 +1363,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1535,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1545,26 +1539,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1604,7 +1599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1667,7 +1662,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1716,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -1912,12 +1907,13 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1965,6 +1961,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,9 +1980,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75382bc7392ef10aad10935f92fc3db36d2d4dad0e5d96d8d65e04f89a07ec39"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
@@ -2026,7 +2028,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2122,7 +2124,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2242,7 +2244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "stable_deref_trait",
 ]
 
@@ -2431,9 +2433,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2463,7 +2465,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.7",
+ "rand 0.8.8",
  "thiserror 1.0.69",
  "tinyvec",
  "tracing",
@@ -2558,9 +2560,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2708,13 +2710,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2722,9 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2735,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2749,17 +2750,16 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.3.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2770,15 +2770,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.3.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2817,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2827,9 +2827,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -2865,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2928,15 +2928,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.13"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3134,12 +3134,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.104"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3231,14 +3232,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.2",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
@@ -3258,7 +3259,7 @@ checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3311,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru"
@@ -3359,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "match-lookup"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+checksum = "549e39695cc0b640f3cb378053832db3d2133422d49e8dcae5c866a2aaf1f730"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3382,9 +3383,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+checksum = "57804b2c9b69967f1536a56f86297e367a33b19e98852ed624b84551cdbc0d90"
 dependencies = [
  "rustix 1.1.4",
 ]
@@ -3465,10 +3466,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.2"
+name = "miniz_oxide"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3505,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3515,13 +3526,12 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
 dependencies = [
  "base-x",
  "base256emoji",
- "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -3550,7 +3560,7 @@ dependencies = [
  "half",
  "hashbrown 0.15.5",
  "hexf-parse",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
  "num-traits",
  "once_cell",
@@ -3992,7 +4002,7 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "memchr",
 ]
 
@@ -4022,9 +4032,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
-version = "5.4.2"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4066,7 +4076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4160,7 +4170,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
 ]
 
 [[package]]
@@ -4191,7 +4201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -4317,7 +4327,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -4589,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -4646,9 +4656,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4671,7 +4681,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -4819,9 +4829,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93da5bb2c5d4e6c0ef7abeead62c89169a0a4882bfb83ac892f2423aea2fe"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -4942,12 +4952,12 @@ dependencies = [
 
 [[package]]
 name = "rtoolbox"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5082,9 +5092,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5252,7 +5262,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5262,7 +5272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde_core",
@@ -5289,7 +5299,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5351,7 +5361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5463,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5621,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5748,7 +5758,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5826,7 +5836,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5912,7 +5922,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -5923,11 +5933,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5969,7 +5979,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5983,7 +5993,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -6125,9 +6135,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.120"
+version = "1.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+checksum = "4c5c9f7b7b1a048dd2bebdb7260b0cc71ec5587b19352fa5c3cd9e1c067103f0"
 dependencies = [
  "glob",
  "serde",
@@ -6135,7 +6145,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 1.1.4+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -6162,7 +6172,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.7",
+ "rand 0.8.8",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -6385,9 +6395,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6486,18 +6496,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6508,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9582933b7fdee22f4ac90145336564dd0bc97c1ccb424e01c53926eb322312"
+checksum = "56574baa147c7433657bdfa369f32850d98d928be100828a7b7babb266b31f0e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6526,9 +6536,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.77"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6536,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6546,9 +6556,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6559,18 +6569,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.77"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
+checksum = "941c102b3f0c15b6d72a53205e09e6646aafcf2991e18412cc331dbac1806bc0"
 dependencies = [
  "async-trait",
  "cast",
@@ -6590,9 +6600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.77"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
+checksum = "a26bd6570f39bb1440fd8f01b63461faaf2a3f6078a508e4e54efa99363108d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6601,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.127"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
+checksum = "1c29582b14d5bf030b02fa232b9b57faf2afc322d2c61964dd80bad02bf76207"
 
 [[package]]
 name = "wasm-encoder"
@@ -6633,7 +6643,7 @@ dependencies = [
  "ahash",
  "bitflags 2.13.1",
  "hashbrown 0.14.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "semver",
  "serde",
 ]
@@ -6646,7 +6656,7 @@ checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "semver",
  "serde",
 ]
@@ -6659,7 +6669,7 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "semver",
  "serde",
 ]
@@ -6714,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.13"
+version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
  "bitflags 2.13.1",
  "wayland-backend",
@@ -6775,9 +6785,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.104"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6856,7 +6866,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
  "naga",
  "once_cell",
@@ -7062,7 +7072,7 @@ dependencies = [
  "indicatif",
  "libc",
  "p256",
- "rand 0.8.7",
+ "rand 0.8.8",
  "ratatui",
  "rpassword",
  "serde",
@@ -8142,9 +8152,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.57.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wl-clipboard-rs"
@@ -8465,9 +8475,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "yoke",
@@ -8477,13 +8487,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8497,6 +8507,12 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/crates/whisker-build/Cargo.toml
+++ b/crates/whisker-build/Cargo.toml
@@ -36,4 +36,4 @@ libc = { workspace = true }
 # events. Stays a single shared crate so the three orchestration
 # layers all hit the same look + feel.
 indicatif = "0.17"
-wasm-bindgen-cli-support = "=0.2.127"
+wasm-bindgen-cli-support = "=0.2.117"

--- a/crates/whisker-cng/src/modules/platforms.rs
+++ b/crates/whisker-cng/src/modules/platforms.rs
@@ -475,12 +475,12 @@ fn resolve_legacy_rust_host(
     manifest_dir: &Path,
     published: Option<&RustHostSectionRaw>,
 ) -> Result<Option<ResolvedRustModuleContribution>> {
-    if let Some(published) = published
-        && published.package.trim().is_empty()
-    {
-        return Err(anyhow!(
-            "module `{package}` metadata.whisker.{target}.package must not be empty"
-        ));
+    if let Some(published) = published {
+        if published.package.trim().is_empty() {
+            return Err(anyhow!(
+                "module `{package}` metadata.whisker.{target}.package must not be empty"
+            ));
+        }
     }
     let cargo_toml = manifest_dir.join(target).join("Cargo.toml");
     if !cargo_toml.is_file() {
@@ -505,14 +505,14 @@ fn resolve_legacy_rust_host(
                 "module `{package}` {target}/Cargo.toml must declare a non-empty [package].name"
             )
         })?;
-    if let Some(published) = published
-        && published.package != host_package
-    {
-        return Err(anyhow!(
-            "module `{package}` metadata.whisker.{target}.package is {:?}, but {target}/Cargo.toml declares package {:?}",
-            published.package,
-            host_package,
-        ));
+    if let Some(published) = published {
+        if published.package != host_package {
+            return Err(anyhow!(
+                "module `{package}` metadata.whisker.{target}.package is {:?}, but {target}/Cargo.toml declares package {:?}",
+                published.package,
+                host_package,
+            ));
+        }
     }
     let host_root = cargo_toml
         .parent()

--- a/crates/whisker-cng/src/templates/web/Cargo.toml
+++ b/crates/whisker-cng/src/templates/web/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 hot-reload = ["whisker-web/hot-reload"]
 
 [dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.117"
 whisker-app = { package = {{user_package_toml}}, path = {{user_crate_path_toml}} }
 whisker-web = {{whisker_web_dependency}}
 {{element_module_dependencies}}

--- a/crates/whisker-cng/src/web.rs
+++ b/crates/whisker-cng/src/web.rs
@@ -52,7 +52,7 @@ pub fn inputs_from(
         user_crate_path,
         whisker_web_dependency,
         element_modules: Vec::new(),
-        template_version: 12,
+        template_version: 13,
     })
 }
 
@@ -186,7 +186,7 @@ mod tests {
             user_crate_path: PathBuf::from("/tmp/hello"),
             whisker_web_dependency: "{ path = \"/tmp/whisker/platforms/web\" }".into(),
             element_modules: Vec::new(),
-            template_version: 12,
+            template_version: 13,
         }
     }
 

--- a/crates/whisker-css/src/shorthand/keyframes.rs
+++ b/crates/whisker-css/src/shorthand/keyframes.rs
@@ -145,12 +145,12 @@ impl KeyframesBuilder {
         frames.sort_by(|left, right| left.offset.get().total_cmp(&right.offset.get()));
         let mut merged = Vec::<KeyframeDefinition>::with_capacity(frames.len());
         for frame in frames {
-            if let Some(previous) = merged.last_mut()
-                && previous.offset == frame.offset
-            {
-                previous.style = previous.style.clone().merge(frame.style);
-                previous.easing = frame.easing;
-                continue;
+            if let Some(previous) = merged.last_mut() {
+                if previous.offset == frame.offset {
+                    previous.style = previous.style.clone().merge(frame.style);
+                    previous.easing = frame.easing;
+                    continue;
+                }
             }
             merged.push(frame);
         }

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -780,6 +780,10 @@ extern bool whisker_view_tick(void *handle,
                               float height,
                               float scale);
 
+extern bool whisker_view_pause(void *handle);
+
+extern bool whisker_view_resume(void *handle);
+
 extern void whisker_view_destroy(void *handle);
 
 extern bool whisker_view_dispatch_event(void *handle,

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -1067,6 +1067,8 @@ JNIEXPORT jlong JNICALL Java_rs_whisker_runtime_WhiskerView_nativeCreate(JNIEnv*
     if(!view->runtime){(*env)->DeleteGlobalRef(env,view->surface);free(view);return 0;}return(jlong)(uintptr_t)view;
 }
 JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeTick(JNIEnv* env,jobject self,jlong handle,jdouble timestamp,jfloat width,jfloat height,jfloat scale){(void)env;(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;return view&&view->runtime&&whisker_view_tick(view->runtime,timestamp,width,height,scale)?JNI_TRUE:JNI_FALSE;}
+JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativePause(JNIEnv* env,jobject self,jlong handle){(void)env;(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;return view&&view->runtime&&whisker_view_pause(view->runtime)?JNI_TRUE:JNI_FALSE;}
+JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeResume(JNIEnv* env,jobject self,jlong handle){(void)env;(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;return view&&view->runtime&&whisker_view_resume(view->runtime)?JNI_TRUE:JNI_FALSE;}
 JNIEXPORT void JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDestroy(JNIEnv* env,jobject self,jlong handle){(void)self;WhiskerAndroidView* view=(void*)(uintptr_t)handle;if(!view)return;if(view->runtime)whisker_view_destroy(view->runtime);if(view->surface)(*env)->DeleteGlobalRef(env,view->surface);free(view);}
 
 JNIEXPORT jboolean JNICALL Java_rs_whisker_runtime_WhiskerView_nativeDispatchEvent(JNIEnv* env,jobject self,jlong handle,jlong node,jstring name,jobject detail,jdouble timestamp){

--- a/crates/whisker-driver-sys/src/mobile.rs
+++ b/crates/whisker-driver-sys/src/mobile.rs
@@ -614,6 +614,8 @@ unsafe extern "C" {
         height: f32,
         scale: f32,
     ) -> bool;
+    pub fn whisker_view_pause(handle: *mut c_void) -> bool;
+    pub fn whisker_view_resume(handle: *mut c_void) -> bool;
     pub fn whisker_view_destroy(handle: *mut c_void);
     pub fn whisker_view_dispatch_event(
         handle: *mut c_void,

--- a/crates/whisker-driver/src/ffi_runtime.rs
+++ b/crates/whisker-driver/src/ffi_runtime.rs
@@ -327,6 +327,40 @@ pub unsafe fn tick(
     }
 }
 
+/// Suspends one mounted runtime while retaining its application and scene.
+///
+/// # Safety
+/// `handle` must be a live pointer returned by [`create`] on this UI thread.
+pub unsafe fn pause(handle: *mut c_void) -> bool {
+    let Some(mobile) = (unsafe { handle.cast::<MobileRuntime>().as_mut() }) else {
+        return false;
+    };
+    let modules = std::rc::Rc::clone(&mobile.modules);
+    with_module_host(&modules, || mobile.runtime.pause())
+        .map(|()| true)
+        .unwrap_or_else(|error| {
+            mobile_error(format_args!("Whisker mobile pause failed: {error}"));
+            false
+        })
+}
+
+/// Resumes one retained runtime and schedules its deferred work.
+///
+/// # Safety
+/// `handle` must be a live pointer returned by [`create`] on this UI thread.
+pub unsafe fn resume(handle: *mut c_void) -> bool {
+    let Some(mobile) = (unsafe { handle.cast::<MobileRuntime>().as_mut() }) else {
+        return false;
+    };
+    let modules = std::rc::Rc::clone(&mobile.modules);
+    with_module_host(&modules, || mobile.runtime.resume())
+        .map(|()| true)
+        .unwrap_or_else(|error| {
+            mobile_error(format_args!("Whisker mobile resume failed: {error}"));
+            false
+        })
+}
+
 /// # Safety
 /// `handle` must be live and must not be used after this call.
 pub unsafe fn destroy(handle: *mut c_void) {

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -300,9 +300,10 @@ impl MeasurementCoordinator {
             pending_policy: PendingMeasurePolicy::Placeholder(size),
             ..
         }) = &spec
-            && !size.is_valid()
         {
-            return Err(MeasurementError::InvalidPlaceholder { node });
+            if !size.is_valid() {
+                return Err(MeasurementError::InvalidPlaceholder { node });
+            }
         }
         if self
             .specs

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -357,13 +357,13 @@ impl LayoutTree {
             if child == parent || self.is_ancestor(child, parent) {
                 return Err(LayoutError::TreeCycle { parent, child });
             }
-            if let Some(attached) = retained.parent
-                && attached != parent
-            {
-                return Err(LayoutError::ChildAlreadyAttached {
-                    child,
-                    parent: attached,
-                });
+            if let Some(attached) = retained.parent {
+                if attached != parent {
+                    return Err(LayoutError::ChildAlreadyAttached {
+                        child,
+                        parent: attached,
+                    });
+                }
             }
         }
         if old_children == children {
@@ -488,14 +488,14 @@ impl LayoutTree {
             self.surface_viewport = Some(viewport);
         }
         if self.surface_child != Some(root) {
-            if let Some(previous) = self.surface_child
-                && let Some(retained) = self.nodes.get(&previous)
-            {
-                let restored = convert_retained_style(&retained.style, retained.measurable)
-                    .expect("a retained style was validated when it entered layout");
-                self.backend
-                    .set_style(retained.backend, restored)
-                    .expect("previous surface child remains retained");
+            if let Some(previous) = self.surface_child {
+                if let Some(retained) = self.nodes.get(&previous) {
+                    let restored = convert_retained_style(&retained.style, retained.measurable)
+                        .expect("a retained style was validated when it entered layout");
+                    self.backend
+                        .set_style(retained.backend, restored)
+                        .expect("previous surface child remains retained");
+                }
             }
             let constrained = convert_surface_child_style(&retained.style, retained.measurable)
                 .expect("a retained style was validated when it entered layout");

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -251,6 +251,22 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
         #[cfg(any(target_os = "android", target_os = "ios"))]
         #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn whisker_view_pause(
+            handle: *mut ::std::ffi::c_void,
+        ) -> bool {
+            unsafe { ::whisker::__driver_runtime::pause(handle) }
+        }
+
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn whisker_view_resume(
+            handle: *mut ::std::ffi::c_void,
+        ) -> bool {
+            unsafe { ::whisker::__driver_runtime::resume(handle) }
+        }
+
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        #[unsafe(no_mangle)]
         pub unsafe extern "C" fn whisker_view_destroy(
             handle: *mut ::std::ffi::c_void,
         ) {
@@ -488,7 +504,7 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[whisker::module_element(
-///     name = "example.ui/Hello",
+///     name = "example-ui:Hello",
 ///     measurement = None,
 /// )]
 /// pub fn hello(style: whisker::Style) {}
@@ -504,8 +520,10 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// effect-wraps the attribute write.
 ///
 /// `name` is the stable, versionless identity shared by Rust authoring and
-/// independently compiled platform `WhiskerModule` declarations. Bootstrap
-/// validates the strings and binds them to Rust-assigned compact IDs.
+/// independently compiled platform `WhiskerModule` declarations. Public
+/// modules conventionally use `<cargo-crate>:<Name>`, which is also the
+/// macro's implicit form. Bootstrap validates the strings and binds them to
+/// Rust-assigned compact IDs.
 /// Properties and events receive generated numeric IDs from the function
 /// signature. `Children` selects ordinary element children and
 /// `TextChildren` selects normalized plain-text content.

--- a/crates/whisker-macros/src/module_element.rs
+++ b/crates/whisker-macros/src/module_element.rs
@@ -16,7 +16,7 @@
 //!
 //! ```ignore
 //! #[whisker::module_element(
-//!     name = "example.forms/Input",
+//!     name = "example-forms:Input",
 //!     measurement = None,
 //! )]
 //! pub fn input(

--- a/crates/whisker-protocol/src/resource.rs
+++ b/crates/whisker-protocol/src/resource.rs
@@ -174,15 +174,16 @@ impl ResourceEvent {
         if generation == 0 {
             return Err(ResourceMessageError::ZeroGeneration);
         }
-        if let Some(dimensions) = dimensions
-            && (!dimensions.width.is_finite()
+        if let Some(dimensions) = dimensions {
+            if !dimensions.width.is_finite()
                 || dimensions.width < 0.0
                 || !dimensions.height.is_finite()
                 || dimensions.height < 0.0
                 || !dimensions.scale.is_finite()
-                || dimensions.scale <= 0.0)
-        {
-            return Err(ResourceMessageError::InvalidDimensions);
+                || dimensions.scale <= 0.0
+            {
+                return Err(ResourceMessageError::InvalidDimensions);
+            }
         }
         Ok(())
     }

--- a/crates/whisker-runtime/src/background_resources.rs
+++ b/crates/whisker-runtime/src/background_resources.rs
@@ -196,10 +196,10 @@ impl BackgroundResourceManager {
             self.node_layer_styles.remove(node);
             self.dirty_nodes.remove(node);
             for key in resource_keys(&previous) {
-                if let Some(resource) = self.resources_by_key.get(&key).copied()
-                    && let Some(entry) = self.entries.get_mut(&resource)
-                {
-                    entry.projected_users.remove(node);
+                if let Some(resource) = self.resources_by_key.get(&key).copied() {
+                    if let Some(entry) = self.entries.get_mut(&resource) {
+                        entry.projected_users.remove(node);
+                    }
                 }
                 commands.extend(self.drop_user(*node, &key));
             }

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -958,10 +958,8 @@ impl BindingState {
             // changes.
             .filter(|snapshot| self.elements.contains_key(&snapshot.element))
             .collect::<Vec<_>>();
-        if !snapshots.is_empty()
-            && let Err(error) = self.configure_style_motion(snapshots)
-        {
-            return Err(error);
+        if !snapshots.is_empty() {
+            self.configure_style_motion(snapshots)?;
         }
         recorded_error.map_or(Ok(()), Err)
     }
@@ -1045,14 +1043,14 @@ impl BindingState {
         }
         match &command {
             ResourceCommand::Load(request) => {
-                if let Some(current) = self.resource_generations.get(&request.resource).copied()
-                    && request.generation <= current
-                {
-                    return Err(RuntimeResourceError::NonMonotonicGeneration {
-                        resource: request.resource,
-                        current,
-                        received: request.generation,
-                    });
+                if let Some(current) = self.resource_generations.get(&request.resource).copied() {
+                    if request.generation <= current {
+                        return Err(RuntimeResourceError::NonMonotonicGeneration {
+                            resource: request.resource,
+                            current,
+                            received: request.generation,
+                        });
+                    }
                 }
                 self.resource_generations
                     .insert(request.resource, request.generation);

--- a/crates/whisker-runtime/src/surface_runtime/motion.rs
+++ b/crates/whisker-runtime/src/surface_runtime/motion.rs
@@ -449,10 +449,10 @@ impl ActiveKeyframeAnimation {
     }
 
     pub(super) fn sample(&mut self, timestamp_ms: f64) -> Vec<&'static str> {
-        if let Some(previous_timestamp_ms) = self.last_timestamp_ms
-            && self.declaration.play_state == MotionPlayState::Running
-        {
-            self.current_time_ms += (timestamp_ms - previous_timestamp_ms).max(0.0);
+        if self.declaration.play_state == MotionPlayState::Running {
+            if let Some(previous_timestamp_ms) = self.last_timestamp_ms {
+                self.current_time_ms += (timestamp_ms - previous_timestamp_ms).max(0.0);
+            }
         }
         self.last_timestamp_ms = Some(timestamp_ms);
         self.sample_current_time();

--- a/crates/whisker-runtime/src/surface_runtime/renderer.rs
+++ b/crates/whisker-runtime/src/surface_runtime/renderer.rs
@@ -52,10 +52,10 @@ impl DynRenderer for SurfaceRuntime {
             let Some(entry) = state.elements.remove(&handle) else {
                 return Ok(());
             };
-            if let Some(parent) = entry.parent
-                && let Some(parent_entry) = state.elements.get_mut(&parent)
-            {
-                parent_entry.children.retain(|child| *child != handle);
+            if let Some(parent) = entry.parent {
+                if let Some(parent_entry) = state.elements.get_mut(&parent) {
+                    parent_entry.children.retain(|child| *child != handle);
+                }
             }
             if let Some(node) = entry.node {
                 state.node_elements.remove(&node);

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -399,10 +399,10 @@ pub fn create_element_by_schema(schema: &ElementSchema) -> Element {
     );
     if handle.id() != u32::MAX {
         crate::reactive::with_runtime(|runtime| {
-            if let Some(owner_id) = runtime.current_owner()
-                && let Some(owner) = runtime.owners.get_mut(owner_id)
-            {
-                owner.elements.push(handle);
+            if let Some(owner_id) = runtime.current_owner() {
+                if let Some(owner) = runtime.owners.get_mut(owner_id) {
+                    owner.elements.push(handle);
+                }
             }
         });
     }

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -478,36 +478,41 @@ pub fn virtualize<T, K>(
                         let corrected_offset = anchor.and_then(|(key, within_item)| {
                             layout.anchored_offset(&key, within_item)
                         });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
+                        if changed {
+                            if let Some(list_ref) = &list_ref {
+                                let (starts, ends) = layout.item_offsets();
+                                list_ref.update_layout(
+                                    &layout.keys,
+                                    &starts,
+                                    &ends,
+                                    layout.total_extent(),
+                                );
+                            }
                         }
                         (changed, corrected_offset)
                     };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
+                    if changed {
+                        if let Some(offset) = corrected_offset {
+                            if (offset - current_geometry.offset).abs() >= 0.5 {
+                                geometry.borrow_mut().offset = offset;
+                                if let Some(list_ref) = &list_ref {
+                                    list_ref.update_geometry(offset, current_geometry.viewport);
+                                }
+                                let _ = try_invoke_element_command(
+                                    scroll_view,
+                                    "scrollTo",
+                                    WhiskerValue::map([
+                                        ("offset", WhiskerValue::Float(f64::from(offset))),
+                                        ("smooth", WhiskerValue::Bool(false)),
+                                    ]),
+                                );
+                            }
                         }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
                     }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
+                    if changed {
+                        if let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
+                            reconcile();
+                        }
                     }
                 }),
             );
@@ -554,36 +559,41 @@ pub fn virtualize<T, K>(
                         let corrected_offset = anchor.and_then(|(key, within_item)| {
                             layout.anchored_offset(&key, within_item)
                         });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
+                        if changed {
+                            if let Some(list_ref) = &list_ref {
+                                let (starts, ends) = layout.item_offsets();
+                                list_ref.update_layout(
+                                    &layout.keys,
+                                    &starts,
+                                    &ends,
+                                    layout.total_extent(),
+                                );
+                            }
                         }
                         (changed, corrected_offset)
                     };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
+                    if changed {
+                        if let Some(offset) = corrected_offset {
+                            if (offset - current_geometry.offset).abs() >= 0.5 {
+                                geometry.borrow_mut().offset = offset;
+                                if let Some(list_ref) = &list_ref {
+                                    list_ref.update_geometry(offset, current_geometry.viewport);
+                                }
+                                let _ = try_invoke_element_command(
+                                    scroll_view,
+                                    "scrollTo",
+                                    WhiskerValue::map([
+                                        ("offset", WhiskerValue::Float(f64::from(offset))),
+                                        ("smooth", WhiskerValue::Bool(false)),
+                                    ]),
+                                );
+                            }
                         }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
                     }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
+                    if changed {
+                        if let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
+                            reconcile();
+                        }
                     }
                 }),
             );
@@ -620,36 +630,41 @@ pub fn virtualize<T, K>(
                         let corrected_offset = anchor.and_then(|(key, within_item)| {
                             layout.anchored_offset(&key, within_item)
                         });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
+                        if changed {
+                            if let Some(list_ref) = &list_ref {
+                                let (starts, ends) = layout.item_offsets();
+                                list_ref.update_layout(
+                                    &layout.keys,
+                                    &starts,
+                                    &ends,
+                                    layout.total_extent(),
+                                );
+                            }
                         }
                         (changed, corrected_offset)
                     };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
+                    if changed {
+                        if let Some(offset) = corrected_offset {
+                            if (offset - current_geometry.offset).abs() >= 0.5 {
+                                geometry.borrow_mut().offset = offset;
+                                if let Some(list_ref) = &list_ref {
+                                    list_ref.update_geometry(offset, current_geometry.viewport);
+                                }
+                                let _ = try_invoke_element_command(
+                                    scroll_view,
+                                    "scrollTo",
+                                    WhiskerValue::map([
+                                        ("offset", WhiskerValue::Float(f64::from(offset))),
+                                        ("smooth", WhiskerValue::Bool(false)),
+                                    ]),
+                                );
+                            }
                         }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
                     }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
+                    if changed {
+                        if let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
+                            reconcile();
+                        }
                     }
                 }),
             );
@@ -854,18 +869,18 @@ pub fn virtualize<T, K>(
                     anchor.and_then(|(key, within_item)| layout.anchored_offset(&key, within_item))
                 })
             };
-            if let Some(offset) = corrected_offset
-                && (offset - current_geometry.offset).abs() >= 0.5
-            {
-                geometry.borrow_mut().offset = offset;
-                let _ = try_invoke_element_command(
-                    scroll_view,
-                    "scrollTo",
-                    WhiskerValue::map([
-                        ("offset", WhiskerValue::Float(f64::from(offset))),
-                        ("smooth", WhiskerValue::Bool(false)),
-                    ]),
-                );
+            if let Some(offset) = corrected_offset {
+                if (offset - current_geometry.offset).abs() >= 0.5 {
+                    geometry.borrow_mut().offset = offset;
+                    let _ = try_invoke_element_command(
+                        scroll_view,
+                        "scrollTo",
+                        WhiskerValue::map([
+                            ("offset", WhiskerValue::Float(f64::from(offset))),
+                            ("smooth", WhiskerValue::Bool(false)),
+                        ]),
+                    );
+                }
             }
             if let Some(list_ref) = &list_ref {
                 let layout = layout.borrow();
@@ -904,17 +919,15 @@ pub fn virtualize<T, K>(
                         content_extent - (next.offset + next.viewport) <= end_reached_threshold;
                     let was_at_start = inside_start_threshold.replace(at_start);
                     let was_at_end = inside_end_threshold.replace(at_end);
-                    if at_start
-                        && !was_at_start
-                        && let Some(callback) = &on_start_reached
-                    {
-                        callback();
+                    if at_start && !was_at_start {
+                        if let Some(callback) = &on_start_reached {
+                            callback();
+                        }
                     }
-                    if at_end
-                        && !was_at_end
-                        && let Some(callback) = &on_end_reached
-                    {
-                        callback();
+                    if at_end && !was_at_end {
+                        if let Some(callback) = &on_end_reached {
+                            callback();
+                        }
                     }
                 }
             }),
@@ -925,10 +938,10 @@ pub fn virtualize<T, K>(
         reconcile_slot.borrow_mut().take();
         for (_, track) in mounted_tracks.borrow_mut().drain() {
             for key in &track.keys {
-                if let Some(entry) = mounted.borrow().get(key)
-                    && children_of(track.handle).contains(&entry.mount_handle)
-                {
-                    remove_child(track.handle, entry.mount_handle);
+                if let Some(entry) = mounted.borrow().get(key) {
+                    if children_of(track.handle).contains(&entry.mount_handle) {
+                        remove_child(track.handle, entry.mount_handle);
+                    }
                 }
             }
             if children_of(content).contains(&track.handle) {
@@ -949,20 +962,20 @@ pub fn virtualize<T, K>(
         if attached.contains(&trailing_spacer) {
             remove_child(content, trailing_spacer);
         }
-        if let Some(header) = header
-            && children_of(content).contains(&header)
-        {
-            remove_child(content, header);
+        if let Some(header) = header {
+            if children_of(content).contains(&header) {
+                remove_child(content, header);
+            }
         }
-        if let Some(footer) = footer
-            && children_of(content).contains(&footer)
-        {
-            remove_child(content, footer);
+        if let Some(footer) = footer {
+            if children_of(content).contains(&footer) {
+                remove_child(content, footer);
+            }
         }
-        if let Some(empty) = empty
-            && children_of(content).contains(&empty)
-        {
-            remove_child(content, empty);
+        if let Some(empty) = empty {
+            if children_of(content).contains(&empty) {
+                remove_child(content, empty);
+            }
         }
         remove_child(scroll_view, content);
         if let Some(list_ref) = &list_ref {
@@ -1089,10 +1102,10 @@ fn reconcile_grid_window<T, K>(
     if layout.items.is_empty() {
         for (_, track) in mounted_tracks.drain() {
             for key in &track.keys {
-                if let Some(entry) = mounted.get(key)
-                    && children_of(track.handle).contains(&entry.mount_handle)
-                {
-                    remove_child(track.handle, entry.mount_handle);
+                if let Some(entry) = mounted.get(key) {
+                    if children_of(track.handle).contains(&entry.mount_handle) {
+                        remove_child(track.handle, entry.mount_handle);
+                    }
                 }
             }
             if children_of(content).contains(&track.handle) {
@@ -1140,10 +1153,10 @@ fn reconcile_grid_window<T, K>(
             .remove(&track_index)
             .expect("stale Grid track remains mounted");
         for key in &track.keys {
-            if let Some(entry) = mounted.get(key)
-                && children_of(track.handle).contains(&entry.mount_handle)
-            {
-                remove_child(track.handle, entry.mount_handle);
+            if let Some(entry) = mounted.get(key) {
+                if children_of(track.handle).contains(&entry.mount_handle) {
+                    remove_child(track.handle, entry.mount_handle);
+                }
             }
         }
         if children_of(content).contains(&track.handle) {

--- a/crates/whisker-subsecond/Cargo.toml
+++ b/crates/whisker-subsecond/Cargo.toml
@@ -37,7 +37,7 @@ memmap2 = "0.9.8"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-wasm-bindgen = "0.2.100"
+wasm-bindgen = "=0.2.117"
 wasm-bindgen-futures = "0.4.50"
 web-sys = { version = "0.3.77", default-features = false, features = [
     "FetchEvent",

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -340,7 +340,7 @@ pub mod __main_runtime {
 pub mod __driver_runtime {
     pub use whisker_driver::ffi_runtime::{
         create, destroy, dispatch_event, dispatch_module_event, dispatch_pointer,
-        dispatch_resource_event, tick,
+        dispatch_resource_event, pause, resume, tick,
     };
 }
 

--- a/docs/module-api-design.md
+++ b/docs/module-api-design.md
@@ -92,7 +92,7 @@ In words:
 
 Every shape below uses one of two Rust-side macros:
 
-- `#[whisker::module_element(name = "package/Name", ...)]` — declares a
+- `#[whisker::module_element(name = "<cargo-crate>:<Name>", ...)]` — declares a
   **Host view** element and its portable schema for `render!`. The element
   name is explicit, stable, and versionless. Shapes 1 and 2 use it.
 - `whisker::module!("Name")` — resolves a **function module** handle
@@ -139,7 +139,7 @@ public final class LocalStoreModule: Module {
 
 ```rust
 #[whisker::module_element(
-    name = "whisker.image/Image",
+    name = "whisker-image:Image",
     measurement = ReplacedContent,
 )]
 pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: whisker::Style) {}
@@ -177,7 +177,7 @@ there's nothing to observe.
 
 ```rust
 #[whisker::module_element(
-    name = "whisker.video/Video",
+    name = "whisker-video:Video",
     measurement = None,
     commands = [("play", Null), ("pause", Null), ("seek", Float)],
 )]

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -377,6 +377,9 @@ Host container attached/resumed
 Host container hidden/paused
   -> pause Surface and idle its frame source
 
+Host container temporarily detached
+  -> pause Surface and retain RuntimeInstance, scene, and module state
+
 WhiskerView.unmount()
   -> stop Application and scoped modules in reverse order
   -> delete Host nodes and release pending commands/resources
@@ -384,7 +387,14 @@ WhiskerView.unmount()
 ```
 
 The exact Kotlin, Swift, JavaScript, and Desktop wrapper method names are not
-fixed by this RFC.
+fixed by this RFC. A temporary window-hierarchy detach is not an unmount: this
+is required by ordinary Host operations such as presenting a full-screen iOS
+controller or temporarily reparenting an Android view. On iOS the default
+wrapper unmounts when `WhiskerView` is deinitialized. On Android it unmounts
+when the enclosing `LifecycleOwner` is destroyed. A custom embedding without a
+view-tree lifecycle owner falls back to unmounting on detach to avoid retaining
+the JNI Host reference indefinitely; it can also use the wrapper's explicit
+destroy operation for permanent teardown while still attached.
 
 Multiple Host `WhiskerView`s may mount the same application descriptor. By
 default each creates an isolated `RuntimeInstance`:
@@ -926,7 +936,7 @@ property/event/command members:
 
 ```rust,ignore
 #[whisker::module_element(
-    name = "example.controls/Toggle",
+    name = "example-controls:Toggle",
     measurement = None,
 )]
 pub fn toggle(checked: Signal<bool>, on_change: ChangeEvent) {}
@@ -1015,7 +1025,7 @@ whisker-video package
 |- Rust declarative component API
 |- Rust typed ElementHandle, props, events, and commands
 |- runtime module providing an ElementProvider
-|- canonical whisker.video/Video element schema
+|- canonical whisker-video:Video element schema
 |- Android Host element factory
 |- iOS Host element factory
 |- JavaScript Host element factory
@@ -1094,7 +1104,7 @@ An illustrative generated schema is:
 
 ```rust,ignore
 ElementSchema {
-    key: "whisker.video/Video",
+    key: "whisker-video:Video",
     presentation: Presentation::Box,
     children: ChildrenPolicy::None,
     content: Content::Native,
@@ -1185,7 +1195,7 @@ later factory through `PreparedContentId`.
 The same element key can map to different concrete objects:
 
 ```text
-whisker.video/Video
+whisker-video:Video
   Android -> PlayerView / Media3 player
   iOS     -> AVPlayerLayer-backed UIView
   Web     -> HTMLVideoElement
@@ -1202,7 +1212,7 @@ and generated registration to be included in Project IR. At runtime:
 
 ```text
 Video module
-  -> provides ElementSchema("whisker.video/Video")
+  -> provides ElementSchema("whisker-video:Video")
 
 Whisker Core
   -> collects and normalizes the schema
@@ -1269,7 +1279,7 @@ composition fails. It must not silently emit an empty view or ignore commands:
 
 ```text
 cannot compose target `web`:
-  whisker.video/Video is selected
+  whisker-video:Video is selected
   available Host providers: android, ios
   missing Host provider: web
 ```

--- a/docs/rfcs/0004-native-modules-and-host-elements.md
+++ b/docs/rfcs/0004-native-modules-and-host-elements.md
@@ -161,9 +161,12 @@ per target, but it is not decomposed into one renderer per element.
 
 ### Registration and identity
 
-An element has one versionless name, for example `whisker.ui/Text`
-or `whisker.google-maps/GoogleMap`. Build composition embeds a matching Host
-factory. During surface bootstrap, core:
+An element has one versionless name. Public modules use
+`<cargo-crate>:<Name>`, for example `whisker-google-maps:GoogleMap`; omitting
+an explicit name in the Rust declaration produces this form. Built-in UI
+retains the reserved `whisker.ui/<Name>` namespace, for example
+`whisker.ui/Text`. Build composition embeds a matching Host factory. During
+surface bootstrap, core:
 
 1. collects element schemas from selected modules;
 2. rejects duplicate names;
@@ -187,7 +190,7 @@ The author-facing definition states only the cross-platform contract:
 
 ```rust,ignore
 #[whisker::module_element(
-    name = "example.controls/Toggle",
+    name = "example-controls:Toggle",
     measurement = None,
 )]
 pub fn toggle(
@@ -589,8 +592,9 @@ ModuleDefinition
 qualified as `<cargo-crate>:<Name>` by mobile build composition. Ordinary Rust
 Desktop/Web Host crates declare that resulting qualified name directly because
 they use Cargo dependency resolution rather than mobile discovery codegen.
-Every `View` uses an explicit, versionless, package-qualified element name such
-as `whisker.video/Video`; element and service identities are separate.
+Every public module `View` uses an explicit, versionless, package-qualified
+element name such as `whisker-video:Video`; element and service identities are
+separate. Built-in UI names remain in the reserved `whisker.ui/` namespace.
 
 All application data crossing this boundary is composed from `WhiskerValue`.
 Properties and events carry one value, service functions carry a positional

--- a/examples/bluesky/crates/bsky-auth/src/session.rs
+++ b/examples/bluesky/crates/bsky-auth/src/session.rs
@@ -43,6 +43,13 @@ pub(super) type BskyAgent = Agent<OAuthSess>;
 /// restore from the secure store.
 const ACTIVE_DID_KEY: &str = "bsky.active_did";
 
+fn stored_active_did() -> Option<Did> {
+    WhiskerLocalStore::load(ACTIVE_DID_KEY.to_string())
+        .ok()
+        .flatten()
+        .and_then(|did| Did::new(did).ok())
+}
+
 /// Secure-store key for a given account's serialized OAuth `Session`
 /// (DPoP key + token set). Namespaced per-DID so multiple accounts
 /// wouldn't collide.
@@ -109,9 +116,7 @@ impl Store<Did, Session> for SecureSessionStore {
     async fn clear(&self) -> Result<(), Self::Error> {
         // No key enumeration in the secure store; we only track the one
         // active account, so clear that entry (best-effort).
-        if let Ok(Some(did)) = WhiskerLocalStore::load(ACTIVE_DID_KEY.to_string())
-            && let Ok(did) = Did::new(did)
-        {
+        if let Some(did) = stored_active_did() {
             let _ = WhiskerSecureStore::remove(session_key(&did));
         }
         let _ = WhiskerLocalStore::remove(ACTIVE_DID_KEY.to_string());
@@ -237,9 +242,7 @@ pub async fn restore_session() -> bool {
 /// Forget the current session: drop the in-memory agent and erase the
 /// persisted session + active-DID pointer from the secure / local stores.
 pub async fn logout() {
-    if let Ok(Some(did_str)) = WhiskerLocalStore::load(ACTIVE_DID_KEY.to_string())
-        && let Ok(did) = Did::new(did_str)
-    {
+    if let Some(did) = stored_active_did() {
         let _ = client().revoke(&did).await;
         let _ = WhiskerSecureStore::remove(session_key(&did));
     }

--- a/packages/whisker-image/desktop/src/lib.rs
+++ b/packages/whisker-image/desktop/src/lib.rs
@@ -153,12 +153,13 @@ impl ImageDesktopView {
             return None;
         }
         let mut state = self.state.lock().expect("Image state lock poisoned");
-        if let Some(cache) = state.cache.as_ref()
-            && cache.generation == state.generation
-            && cache.width == width
-            && cache.height == height
-        {
-            return Some(cache.raster.clone());
+        if let Some(cache) = state.cache.as_ref() {
+            if cache.generation == state.generation
+                && cache.width == width
+                && cache.height == height
+            {
+                return Some(cache.raster.clone());
+            }
         }
         let decoded = state.decoded.as_ref()?;
         let pixels = fit_image(decoded, state.mode, width, height);

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -281,13 +281,14 @@ impl InputDesktopView {
             return None;
         }
         let mut state = self.raster.lock().expect("Input raster lock poisoned");
-        if let Some(cache) = &state.cached
-            && cache.generation == self.generation
-            && cache.width == width
-            && cache.height == height
-            && cache.scale_bits == scale.to_bits()
-        {
-            return Some(cache.raster.clone());
+        if let Some(cache) = &state.cached {
+            if cache.generation == self.generation
+                && cache.width == width
+                && cache.height == height
+                && cache.scale_bits == scale.to_bits()
+            {
+                return Some(cache.raster.clone());
+            }
         }
         let mut text = text_rasterizer()
             .lock()
@@ -358,25 +359,24 @@ impl InputDesktopView {
             },
         );
 
-        if self.focused
-            && !placeholder
-            && let Some((start, end)) = self.composition.map(ordered)
-        {
-            let start = text_cursor(&display, self.display_offset(start));
-            let end = text_cursor(&display, self.display_offset(end));
-            let thickness = scale.ceil().max(1.0);
-            for run in buffer.layout_runs() {
-                if let Some((x, highlight_width)) = run.highlight(start, end) {
-                    fill_rect(
-                        &mut pixels,
-                        width,
-                        height,
-                        x.floor() as i32,
-                        (run.line_top + run.line_height - thickness).floor() as i32,
-                        highlight_width.ceil().max(1.0) as u32,
-                        thickness as u32,
-                        foreground,
-                    );
+        if self.focused && !placeholder {
+            if let Some((start, end)) = self.composition.map(ordered) {
+                let start = text_cursor(&display, self.display_offset(start));
+                let end = text_cursor(&display, self.display_offset(end));
+                let thickness = scale.ceil().max(1.0);
+                for run in buffer.layout_runs() {
+                    if let Some((x, highlight_width)) = run.highlight(start, end) {
+                        fill_rect(
+                            &mut pixels,
+                            width,
+                            height,
+                            x.floor() as i32,
+                            (run.line_top + run.line_height - thickness).floor() as i32,
+                            highlight_width.ceil().max(1.0) as u32,
+                            thickness as u32,
+                            foreground,
+                        );
+                    }
                 }
             }
         }

--- a/packages/whisker-router/web/Cargo.toml
+++ b/packages/whisker-router/web/Cargo.toml
@@ -10,7 +10,7 @@ description = "Web History API Host adapter for whisker-router."
 [dependencies]
 whisker = { workspace = true }
 whisker-web = { workspace = true }
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.117"
 web-sys = { version = "0.3", features = [
     "EventTarget",
     "History",

--- a/packages/whisker-svg/desktop/src/lib.rs
+++ b/packages/whisker-svg/desktop/src/lib.rs
@@ -66,12 +66,13 @@ impl SvgDesktopView {
             return None;
         }
         let mut cache = self.cache.lock().expect("SVG raster cache lock poisoned");
-        if let Some(cached) = cache.as_ref()
-            && cached.generation == self.generation
-            && cached.width == width
-            && cached.height == height
-        {
-            return Some(cached.raster.clone());
+        if let Some(cached) = cache.as_ref() {
+            if cached.generation == self.generation
+                && cached.width == width
+                && cached.height == height
+            {
+                return Some(cached.raster.clone());
+            }
         }
         let raster = render_raster(
             &self.display_list,

--- a/packages/whisker-web-browser/web/src/lib.rs
+++ b/packages/whisker-web-browser/web/src/lib.rs
@@ -108,18 +108,19 @@ fn open_popup(url: &str, kind: SessionKind, emitter: &ModuleEventEmitter) -> Whi
             clear_later();
             return;
         }
-        if let SessionKind::Auth { redirect_url } = &kind
-            && let Ok(location) = polled_popup.location().href()
-            && location.starts_with(redirect_url)
-        {
-            emit_result(
-                &event_emitter,
-                "authSessionCompleted",
-                "success",
-                Some(location),
-            );
-            let _ = polled_popup.close();
-            clear_later();
+        if let SessionKind::Auth { redirect_url } = &kind {
+            if let Ok(location) = polled_popup.location().href() {
+                if location.starts_with(redirect_url) {
+                    emit_result(
+                        &event_emitter,
+                        "authSessionCompleted",
+                        "success",
+                        Some(location),
+                    );
+                    let _ = polled_popup.close();
+                    clear_later();
+                }
+            }
         }
     });
     let interval = match window

--- a/platforms/android/runtime/build.gradle.kts
+++ b/platforms/android/runtime/build.gradle.kts
@@ -52,6 +52,7 @@ tasks.configureEach {
 dependencies {
     val moduleProject = if (rootProject.findProject(":module") != null) ":module" else ":whisker-module"
     api(project(moduleProject))
+    implementation("androidx.lifecycle:lifecycle-runtime:2.8.7")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test:core-ktx:1.6.1")
     androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -10,6 +10,10 @@ import android.util.Log
 import android.view.Choreographer
 import android.view.MotionEvent
 import android.view.View
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.findViewTreeLifecycleOwner
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.bridge.AndroidFrameBatch
 import rs.whisker.runtime.bridge.AndroidHostCapabilities
@@ -45,6 +49,14 @@ class WhiskerView(context: Context) :
 
     private val choreographer = Choreographer.getInstance()
     private var nativeHandle = 0L
+    private var runtimePaused = false
+    private var permanentlyDestroyed = false
+    private var lifecycleOwner: LifecycleOwner? = null
+    private val lifecycleObserver = LifecycleEventObserver { owner, event ->
+        if (event == Lifecycle.Event.ON_DESTROY && owner === lifecycleOwner) {
+            destroyRuntime(permanent = true)
+        }
+    }
     private var frameScheduled = false
     private var windowVisible = true
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -130,8 +142,10 @@ class WhiskerView(context: Context) :
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
+        bindLifecycleOwner()
         WhiskerAppContext.pushRuntimeOwner(this)
         mountWhenSized()
+        resumeRuntime()
     }
 
     override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
@@ -141,7 +155,10 @@ class WhiskerView(context: Context) :
     }
 
     private fun mountWhenSized() {
-        if (nativeHandle == 0L && isAttachedToWindow && width > 0 && height > 0) {
+        if (
+            !permanentlyDestroyed && nativeHandle == 0L &&
+            isAttachedToWindow && width > 0 && height > 0
+        ) {
             moduleEventSinkEpoch += 1
             val sinkEpoch = moduleEventSinkEpoch
             WhiskerModuleEventCenter.installEventSink(this) { module, event, payload ->
@@ -160,6 +177,7 @@ class WhiskerView(context: Context) :
                 AndroidHostCapabilities.current().wireValues(),
             )
             if (nativeHandle != 0L) {
+                runtimePaused = false
                 requestFrameFromNative()
             } else {
                 moduleEventSinkEpoch += 1
@@ -170,10 +188,59 @@ class WhiskerView(context: Context) :
     }
 
     override fun onDetachedFromWindow() {
+        pauseRuntime()
+        frameScheduled = false
+        continuousEventFlushPending = false
+        choreographer.removeFrameCallback(this)
+        mainHandler.removeCallbacks(continuousEventFlush)
+        mainHandler.removeCallbacks(moduleEventFlush)
+        pendingContinuousEvents.clear()
+        WhiskerAppContext.popRuntimeOwner(this)
+        if (lifecycleOwner == null) destroyRuntime()
+        super.onDetachedFromWindow()
+    }
+
+    /** Permanently releases this View's Rust runtime and retained Host scene. */
+    fun destroy() {
+        check(Looper.myLooper() == Looper.getMainLooper()) {
+            "WhiskerView.destroy() must run on the main thread"
+        }
+        destroyRuntime(permanent = true)
+    }
+
+    private fun bindLifecycleOwner() {
+        val next = findViewTreeLifecycleOwner()
+        if (next === lifecycleOwner) return
+        lifecycleOwner?.lifecycle?.removeObserver(lifecycleObserver)
+        lifecycleOwner = next
+        next?.lifecycle?.addObserver(lifecycleObserver)
+    }
+
+    private fun pauseRuntime() {
+        val handle = nativeHandle
+        if (handle != 0L && !runtimePaused && nativePause(handle)) {
+            runtimePaused = true
+        }
+    }
+
+    private fun resumeRuntime() {
+        val handle = nativeHandle
+        if (handle != 0L && runtimePaused && nativeResume(handle)) {
+            runtimePaused = false
+            requestFrameFromNative()
+        }
+    }
+
+    private fun destroyRuntime(permanent: Boolean = false) {
+        permanentlyDestroyed = permanentlyDestroyed || permanent
+        lifecycleOwner?.lifecycle?.removeObserver(lifecycleObserver)
+        lifecycleOwner = null
         moduleEventSinkEpoch += 1
         WhiskerModuleEventCenter.installEventSink(this, null)
-        if (nativeHandle != 0L) nativeDestroy(nativeHandle)
+        val handle = nativeHandle
         nativeHandle = 0L
+        runtimePaused = false
+        if (handle != 0L) nativeDestroy(handle)
         frameScheduled = false
         continuousEventFlushPending = false
         choreographer.removeFrameCallback(this)
@@ -183,7 +250,6 @@ class WhiskerView(context: Context) :
         pendingContinuousEvents.clear()
         pendingModuleEvents.clear()
         WhiskerAppContext.popRuntimeOwner(this)
-        super.onDetachedFromWindow()
     }
 
     override fun onWindowVisibilityChanged(visibility: Int) {
@@ -590,6 +656,8 @@ class WhiskerView(context: Context) :
         height: Float,
         scale: Float,
     ): Boolean
+    private external fun nativePause(handle: Long): Boolean
+    private external fun nativeResume(handle: Long): Boolean
     private external fun nativeDestroy(handle: Long)
     private external fun nativeDispatchEvent(
         handle: Long,

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -369,10 +369,10 @@ impl DesktopApplication {
         else {
             return;
         };
-        if let Some(hot_reload) = &mut self.hot_reload
-            && let Err(error) = host.with_modules(|| hot_reload.apply(runtime))
-        {
-            eprintln!("whisker {TARGET_NAME} hot reload failed: {error}");
+        if let Some(hot_reload) = &mut self.hot_reload {
+            if let Err(error) = host.with_modules(|| hot_reload.apply(runtime)) {
+                eprintln!("whisker {TARGET_NAME} hot reload failed: {error}");
+            }
         }
         let scale = window.scale_factor();
         let logical = self.viewport.to_logical::<f32>(scale);
@@ -497,10 +497,10 @@ impl DesktopApplication {
                         }
                     }
                     "v" => {
-                        if let Some(clipboard) = &mut self.clipboard
-                            && let Ok(text) = clipboard.get_text()
-                        {
-                            self.dispatch_text_input(DesktopTextInputEvent::Paste(text));
+                        if let Some(clipboard) = &mut self.clipboard {
+                            if let Ok(text) = clipboard.get_text() {
+                                self.dispatch_text_input(DesktopTextInputEvent::Paste(text));
+                            }
                         }
                     }
                     _ => {}
@@ -685,14 +685,15 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                 ) {
                     self.dispatch_input(input);
                 }
-                if button == MouseButton::Left
-                    && state == ElementState::Pressed
-                    && let (Some(position), Some(host)) =
+                if button == MouseButton::Left && state == ElementState::Pressed {
+                    if let (Some(position), Some(host)) =
                         (self.pointer.mouse_position(), self.host.as_mut())
-                    && host.focus_text_input_at([position.x, position.y])
-                {
-                    self.request_frame();
-                    self.sync_text_input();
+                    {
+                        if host.focus_text_input_at([position.x, position.y]) {
+                            self.request_frame();
+                            self.sync_text_input();
+                        }
+                    }
                 }
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {

--- a/platforms/desktop/src/gpu/renderer.rs
+++ b/platforms/desktop/src/gpu/renderer.rs
@@ -291,43 +291,44 @@ impl GpuRenderer {
                     ..
                 } => {
                     let decoration = &content.paint.decoration;
-                    if (decoration.lines.underline || decoration.lines.line_through)
-                        && let Some(prepared) = content
+                    if decoration.lines.underline || decoration.lines.line_through {
+                        if let Some(prepared) = content
                             .prepared_content
                             .and_then(|id| text.prepared.get(&id))
-                    {
-                        let thickness = (content.payload.style.font_size / 16.0).max(1.0);
-                        for run in prepared.buffer.layout_runs() {
-                            let Some(line_x) =
-                                run.glyphs.iter().map(|glyph| glyph.x).reduce(f32::min)
-                            else {
-                                continue;
-                            };
-                            let baseline = rect.y + run.line_y;
-                            let y = if decoration.lines.underline {
-                                baseline + thickness * 1.5
-                            } else {
-                                baseline - content.payload.style.font_size * 0.3
-                            };
-                            for line in text_decoration_rects(
-                                rect.x + line_x,
-                                run.line_w,
-                                y,
-                                thickness,
-                                decoration.style,
-                            ) {
-                                push_quad_draw(
-                                    &mut vertices,
-                                    &mut draws,
-                                    solid_rect_primitive(
-                                        line,
-                                        gpu_color(&decoration.color, *opacity),
-                                    ),
-                                    *transform,
-                                    *clip,
-                                    shape_clips,
-                                    (None, None, false),
-                                );
+                        {
+                            let thickness = (content.payload.style.font_size / 16.0).max(1.0);
+                            for run in prepared.buffer.layout_runs() {
+                                let Some(line_x) =
+                                    run.glyphs.iter().map(|glyph| glyph.x).reduce(f32::min)
+                                else {
+                                    continue;
+                                };
+                                let baseline = rect.y + run.line_y;
+                                let y = if decoration.lines.underline {
+                                    baseline + thickness * 1.5
+                                } else {
+                                    baseline - content.payload.style.font_size * 0.3
+                                };
+                                for line in text_decoration_rects(
+                                    rect.x + line_x,
+                                    run.line_w,
+                                    y,
+                                    thickness,
+                                    decoration.style,
+                                ) {
+                                    push_quad_draw(
+                                        &mut vertices,
+                                        &mut draws,
+                                        solid_rect_primitive(
+                                            line,
+                                            gpu_color(&decoration.color, *opacity),
+                                        ),
+                                        *transform,
+                                        *clip,
+                                        shape_clips,
+                                        (None, None, false),
+                                    );
+                                }
                             }
                         }
                     }

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -213,12 +213,12 @@ impl DesktopRuntime {
 
     /// Resolves the Host-visible target after applying transient scroll state.
     pub fn target_input(&self, event: &mut InputEvent) {
-        if event.target.is_none()
-            && let Some(pointer) = event.pointer
-        {
-            event.target = self
-                .surface
-                .hit_test([pointer.position.x, pointer.position.y]);
+        if event.target.is_none() {
+            if let Some(pointer) = event.pointer {
+                event.target = self
+                    .surface
+                    .hit_test([pointer.position.x, pointer.position.y]);
+            }
         }
     }
 

--- a/platforms/desktop/src/resource.rs
+++ b/platforms/desktop/src/resource.rs
@@ -105,14 +105,14 @@ impl DesktopResourceService {
         if request.kind != ResourceKind::RasterImage {
             return Err(DesktopResourceError::UnsupportedKind(request.kind));
         }
-        if let Some(current) = self.current.get(&request.resource).copied()
-            && request.generation <= current
-        {
-            return Err(DesktopResourceError::NonMonotonicGeneration {
-                resource: request.resource,
-                current,
-                received: request.generation,
-            });
+        if let Some(current) = self.current.get(&request.resource).copied() {
+            if request.generation <= current {
+                return Err(DesktopResourceError::NonMonotonicGeneration {
+                    resource: request.resource,
+                    current,
+                    received: request.generation,
+                });
+            }
         }
         self.current.insert(request.resource, request.generation);
         self.states.insert(

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -641,18 +641,20 @@ impl DesktopScene {
             });
             node_clip_bounds = transform_rect_aabb(clip_rect, transform);
         }
-        if visible
-            && let Some(radius) = presentation
+        if visible {
+            if let Some(radius) = presentation
                 .visual_effects
                 .backdrop_blur
                 .filter(|value| *value > 0.0)
-            && let Some(rect) = transform_rect_aabb(border, transform)
-        {
-            commands.push(PaintCommand::BackdropBlur {
-                rect,
-                radius,
-                clip: context.clip,
-            });
+            {
+                if let Some(rect) = transform_rect_aabb(border, transform) {
+                    commands.push(PaintCommand::BackdropBlur {
+                        rect,
+                        radius,
+                        clip: context.clip,
+                    });
+                }
+            }
         }
         if visible
             && (presentation.paint.is_some()
@@ -714,33 +716,37 @@ impl DesktopScene {
                 );
             }
         }
-        if visible && let Some(content) = node.content.text() {
-            let content_rect = LayoutRect {
-                x: border.x + presentation.layout.content_box.x,
-                y: border.y + presentation.layout.content_box.y,
-                width: presentation.layout.content_box.width,
-                height: presentation.layout.content_box.height,
-            };
-            commands.push(PaintCommand::Text {
-                node: id,
-                rect: content_rect,
-                content,
-                clip: descendant_clip.intersect(content_rect, true, true),
-                shape_clips: descendant_shape_clips.clone(),
-                transform,
-                opacity,
-            });
+        if visible {
+            if let Some(content) = node.content.text() {
+                let content_rect = LayoutRect {
+                    x: border.x + presentation.layout.content_box.x,
+                    y: border.y + presentation.layout.content_box.y,
+                    width: presentation.layout.content_box.width,
+                    height: presentation.layout.content_box.height,
+                };
+                commands.push(PaintCommand::Text {
+                    node: id,
+                    rect: content_rect,
+                    content,
+                    clip: descendant_clip.intersect(content_rect, true, true),
+                    shape_clips: descendant_shape_clips.clone(),
+                    transform,
+                    opacity,
+                });
+            }
         }
-        if visible && let Some(rasterizer) = node.content.rasterizer() {
-            commands.push(PaintCommand::Raster {
-                node: id,
-                rect: content,
-                rasterizer,
-                clip: descendant_clip.intersect(content, true, true),
-                shape_clips: descendant_shape_clips.clone(),
-                transform,
-                opacity,
-            });
+        if visible {
+            if let Some(rasterizer) = node.content.rasterizer() {
+                commands.push(PaintCommand::Raster {
+                    node: id,
+                    rect: content,
+                    rasterizer,
+                    clip: descendant_clip.intersect(content, true, true),
+                    shape_clips: descendant_shape_clips.clone(),
+                    transform,
+                    opacity,
+                });
+            }
         }
 
         let mut children = node
@@ -801,12 +807,13 @@ impl DesktopScene {
                     types.insert(*node, *element_type);
                 }
                 Operation::InsertChild { parent, .. } => {
-                    if let Some(element_type) = types.get(parent).copied()
-                        && !self.elements.child_policy(element_type)?.accepts_elements()
-                    {
-                        return Err(
-                            DesktopElementError::ChildrenNotAllowed { parent: *parent }.into()
-                        );
+                    if let Some(element_type) = types.get(parent).copied() {
+                        if !self.elements.child_policy(element_type)?.accepts_elements() {
+                            return Err(DesktopElementError::ChildrenNotAllowed {
+                                parent: *parent,
+                            }
+                            .into());
+                        }
                     }
                 }
                 Operation::SetText { node, content } => {
@@ -1176,13 +1183,13 @@ impl DesktopScene {
             return;
         };
         self.pointer_captures.retain(|_, target| *target != node);
-        if let Some(parent) = removed.presentation.parent
-            && let Some(parent) = self.nodes.get_mut(&parent)
-        {
-            parent
-                .presentation
-                .children
-                .retain(|candidate| *candidate != node);
+        if let Some(parent) = removed.presentation.parent {
+            if let Some(parent) = self.nodes.get_mut(&parent) {
+                parent
+                    .presentation
+                    .children
+                    .retain(|candidate| *candidate != node);
+            }
         }
         let children = removed.presentation.children.clone();
         for child in children {

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -186,35 +186,36 @@ impl NativeTextHost {
             Cow::Borrowed(payload.text.as_str())
         };
         let mut buffer = self.shape_text(payload, &display_text, width, height, line_height);
-        if payload.overflow == MeasureTextOverflow::Ellipsis
-            && let Some(width) = width
-            && !buffer_fits(&buffer, width, payload.max_lines)
-        {
-            let characters = payload.text.chars().collect::<Vec<_>>();
-            let mut lower = 0;
-            let mut upper = characters.len();
-            let mut best = String::from("…");
-            while lower <= upper {
-                let middle = lower + (upper - lower) / 2;
-                let mut candidate = characters[..middle].iter().collect::<String>();
-                candidate.push('…');
-                let candidate = if payload.word_break == MeasureTextWordBreak::KeepAll {
-                    protect_cjk_breaks(&candidate)
-                } else {
-                    candidate
-                };
-                let candidate_buffer =
-                    self.shape_text(payload, &candidate, Some(width), height, line_height);
-                if buffer_fits(&candidate_buffer, width, payload.max_lines) {
-                    best = candidate;
-                    lower = middle + 1;
-                } else if middle == 0 {
-                    break;
-                } else {
-                    upper = middle - 1;
+        if payload.overflow == MeasureTextOverflow::Ellipsis {
+            if let Some(width) = width {
+                if !buffer_fits(&buffer, width, payload.max_lines) {
+                    let characters = payload.text.chars().collect::<Vec<_>>();
+                    let mut lower = 0;
+                    let mut upper = characters.len();
+                    let mut best = String::from("…");
+                    while lower <= upper {
+                        let middle = lower + (upper - lower) / 2;
+                        let mut candidate = characters[..middle].iter().collect::<String>();
+                        candidate.push('…');
+                        let candidate = if payload.word_break == MeasureTextWordBreak::KeepAll {
+                            protect_cjk_breaks(&candidate)
+                        } else {
+                            candidate
+                        };
+                        let candidate_buffer =
+                            self.shape_text(payload, &candidate, Some(width), height, line_height);
+                        if buffer_fits(&candidate_buffer, width, payload.max_lines) {
+                            best = candidate;
+                            lower = middle + 1;
+                        } else if middle == 0 {
+                            break;
+                        } else {
+                            upper = middle - 1;
+                        }
+                    }
+                    buffer = self.shape_text(payload, &best, Some(width), height, line_height);
                 }
             }
-            buffer = self.shape_text(payload, &best, Some(width), height, line_height);
         }
 
         let mut measured_width = 0.0_f32;

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -780,6 +780,10 @@ extern bool whisker_view_tick(void *handle,
                               float height,
                               float scale);
 
+extern bool whisker_view_pause(void *handle);
+
+extern bool whisker_view_resume(void *handle);
+
 extern void whisker_view_destroy(void *handle);
 
 extern bool whisker_view_dispatch_event(void *handle,

--- a/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/WhiskerView.swift
@@ -6,6 +6,7 @@ public final class WhiskerView: UIView {
     private var displayLink: CADisplayLink?
     private var hostToken: UnsafeMutableRawPointer?
     private var runtimeHandle: UnsafeMutableRawPointer?
+    private var runtimePaused = false
     private var isApplicationActive = true
     private var moduleEventSinkEpoch: UInt64 = 0
     private let pendingModuleEvents = PendingModuleEvents()
@@ -106,8 +107,10 @@ public final class WhiskerView: UIView {
         if window != nil {
             WhiskerInsetsDispatcher.attach(self)
             mountWhenSized()
+            resumeRuntime()
+            flushModuleEventsOnMain()
         } else {
-            unmount()
+            pauseRuntime()
             WhiskerInsetsDispatcher.detach(self)
         }
     }
@@ -154,6 +157,7 @@ public final class WhiskerView: UIView {
             whiskerIOSInvokeModule, whiskerIOSObserveModule, token
         )
         if runtimeHandle != nil {
+            runtimePaused = false
             driveRuntimeFrame(timestampMs: ProcessInfo.processInfo.systemUptime * 1_000)
             requestFrame()
         } else {
@@ -247,6 +251,7 @@ public final class WhiskerView: UIView {
         let handle = runtimeHandle
         let ownedRuntime = handle != nil || hostToken != nil
         runtimeHandle = nil
+        runtimePaused = false
         displayLink?.invalidate()
         displayLink = nil
         if let handle { whiskerViewDestroy(handle) }
@@ -263,7 +268,7 @@ public final class WhiskerView: UIView {
     }
 
     func requestFrame() {
-        guard runtimeHandle != nil, isApplicationActive, window != nil else { return }
+        guard runtimeHandle != nil, !runtimePaused, isApplicationActive, window != nil else { return }
         if displayLink == nil {
             displayLink = CADisplayLink(target: self, selector: #selector(driveFrame(_:)))
             displayLink?.add(to: .main, forMode: .common)
@@ -272,7 +277,10 @@ public final class WhiskerView: UIView {
     }
 
     @objc private func driveFrame(_ link: CADisplayLink) {
-        guard runtimeHandle != nil, isApplicationActive else { link.isPaused = true; return }
+        guard runtimeHandle != nil, !runtimePaused, isApplicationActive else {
+            link.isPaused = true
+            return
+        }
         let idle = driveRuntimeFrame(timestampMs: link.timestamp * 1_000)
         link.isPaused = idle
     }
@@ -290,12 +298,26 @@ public final class WhiskerView: UIView {
     @objc private func applicationDidBecomeActive() {
         isApplicationActive = true
         mountWhenSized()
+        resumeRuntime()
         requestFrame()
     }
 
     @objc private func applicationWillResignActive() {
         isApplicationActive = false
-        displayLink?.isPaused = true
+        pauseRuntime()
+    }
+
+    private func pauseRuntime() {
+        displayLink?.invalidate()
+        displayLink = nil
+        guard let handle = runtimeHandle, !runtimePaused else { return }
+        if whiskerViewPause(handle) { runtimePaused = true }
+    }
+
+    private func resumeRuntime() {
+        guard isApplicationActive, window != nil,
+              let handle = runtimeHandle, runtimePaused else { return }
+        if whiskerViewResume(handle) { runtimePaused = false }
     }
 
     func bootstrap(_ raw: WhiskerMobileBootstrap) -> Bool {

--- a/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
@@ -42,6 +42,14 @@ func whiskerViewTick(
     whisker_view_tick(handle, timestampMs, width, height, scale)
 }
 
+func whiskerViewPause(_ handle: UnsafeMutableRawPointer?) -> Bool {
+    whisker_view_pause(handle)
+}
+
+func whiskerViewResume(_ handle: UnsafeMutableRawPointer?) -> Bool {
+    whisker_view_resume(handle)
+}
+
 func whiskerViewDestroy(_ handle: UnsafeMutableRawPointer?) {
     whisker_view_destroy(handle)
 }

--- a/platforms/ios/Tests/WhiskerHostConformanceStubs/stubs.c
+++ b/platforms/ios/Tests/WhiskerHostConformanceStubs/stubs.c
@@ -5,6 +5,8 @@ void whisker_host_conformance_stubs_link_anchor(void) {}
 
 void *whisker_view_create(void) { return NULL; }
 bool whisker_view_tick(void) { return true; }
+bool whisker_view_pause(void *handle) { (void)handle; return true; }
+bool whisker_view_resume(void *handle) { (void)handle; return true; }
 void whisker_view_destroy(void *handle) { (void)handle; }
 bool whisker_view_dispatch_event(void) { return false; }
 bool whisker_view_dispatch_pointer(void) { return false; }

--- a/platforms/web/Cargo.toml
+++ b/platforms/web/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = { workspace = true, optional = true }
 subsecond = { workspace = true, optional = true }
 subsecond-types = { workspace = true, optional = true }
 js-sys = "0.3"
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.117"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3", features = [
     "Blob",

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -740,11 +740,12 @@ impl DomFrameSink {
                 .filter_map(|(pointer, target)| (*target == node).then_some(*pointer))
                 .collect::<Vec<_>>();
             for pointer in captures {
-                if let Some(element) = self.nodes.get(&node)
-                    && let Ok(pointer_id) = browser_pointer_id(pointer)
-                    && element.has_pointer_capture(pointer_id)
-                {
-                    let _ = element.release_pointer_capture(pointer_id);
+                if let Some(element) = self.nodes.get(&node) {
+                    if let Ok(pointer_id) = browser_pointer_id(pointer) {
+                        if element.has_pointer_capture(pointer_id) {
+                            let _ = element.release_pointer_capture(pointer_id);
+                        }
+                    }
                 }
                 self.pointer_captures.remove(&pointer);
             }
@@ -757,17 +758,17 @@ impl DomFrameSink {
             let native = self.native_nodes.remove(&node);
             self.event_masks.remove(&node);
             self.scroll_listeners.remove(&node);
-            if let (Some(element), Some(element_type)) = (element, element_type)
-                && self.elements.binding(element_type).is_ok_and(|binding| {
+            if let (Some(element), Some(element_type)) = (element, element_type) {
+                if self.elements.binding(element_type).is_ok_and(|binding| {
                     matches!(
                         binding.registration.name.as_str(),
                         "whisker.ui/View" | "whisker.ui/Text"
                     )
-                })
-            {
-                let pool = self.presentation_pool.entry(element_type).or_default();
-                if pool.len() < 256 {
-                    pool.push(PooledWebPresentation { element, native });
+                }) {
+                    let pool = self.presentation_pool.entry(element_type).or_default();
+                    if pool.len() < 256 {
+                        pool.push(PooledWebPresentation { element, native });
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- make the advertised Rust 1.85 MSRV an actual CI contract and resolve dependencies compatibly
- document canonical module names as `<cargo-crate>:<Name>` while reserving `whisker.ui/*` for built-ins
- pause and retain mobile RuntimeInstance state across temporary Host detaches
- tie final teardown to `WhiskerView` deinitialization on iOS and `LifecycleOwner` destruction on Android
- expose lightweight pause/resume calls through the existing mobile ABI

## Performance

Temporary detach no longer destroys and reconstructs the runtime, scene, or module state. Pause/resume is an O(1) FFI call and stops frame sources while detached. No polling or background runtime is added.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.85.0 cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo deny --all-features check advisories bans sources`
- `cargo xtask mobile-abi check`
- `cargo xtask mobile-link-test ios`
- `JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home cargo xtask mobile-link-test android`