### PR TITLE
fix: isolate Host element failures

### DIFF
--- a/docs/rfcs/0004-native-modules-and-host-elements.md
+++ b/docs/rfcs/0004-native-modules-and-host-elements.md
@@ -1067,6 +1067,15 @@ at runtime rejects the frame or emits a structured capability error according
 to whether the capability was declared optional. Silent no-op behavior is not
 allowed for required semantics.
 
+Frame protocol and common-presentation failures are frame failures. A failure
+inside a third-party element factory, property setter, text-style consumer, or
+command is instead isolated to that mounted element: the Host reports one
+diagnostic, disables later element-owned callbacks for the node, and continues
+to apply its common layout, paint, clipping, accessibility, and child-tree
+operations. Built-in elements remain core invariants and do not use this
+recovery path. This keeps one module defect from leaving a frame half-applied
+without adding exception handling to the common View/Text/paint hot path.
+
 ## Prior-art and failure-mode review
 
 This section is normative where it records a Whisker decision. It compares the

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ElementBinding.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ElementBinding.kt
@@ -9,6 +9,20 @@ public enum class WhiskerChildPolicy { None, Elements, PlainText }
 /** Top-level shape of a value carried by [WhiskerValue]. */
 public enum class WhiskerValueKind { Null, Bool, Int, Float, String, Bytes, Array, Map }
 
+public fun WhiskerValueKind.accepts(value: WhiskerValue): Boolean {
+    if (!value.isData()) return false
+    return when (this) {
+        WhiskerValueKind.Null -> value is WhiskerValue.Null
+        WhiskerValueKind.Bool -> value is WhiskerValue.Bool
+        WhiskerValueKind.Int -> value is WhiskerValue.Int
+        WhiskerValueKind.Float -> value is WhiskerValue.Float
+        WhiskerValueKind.String -> value is WhiskerValue.Str
+        WhiskerValueKind.Bytes -> value is WhiskerValue.Bytes
+        WhiskerValueKind.Array -> value is WhiskerValue.Array
+        WhiskerValueKind.Map -> value is WhiskerValue.Map
+    }
+}
+
 /** Runtime-assigned property identity received during surface bootstrap. */
 public data class WhiskerPropertyBinding(
     public val id: Int,
@@ -88,9 +102,13 @@ public class WhiskerElementRegistration(
     public fun property(id: Int): WhiskerPropertyBinding =
         requireNotNull(propertiesById[id]) { "unknown property id $id on $name" }
 
+    public fun propertyOrNull(id: Int): WhiskerPropertyBinding? = propertiesById[id]
+
     public fun event(id: Int): WhiskerEventBinding =
         requireNotNull(eventsById[id]) { "unknown event id $id on $name" }
 
     public fun command(id: Int): WhiskerCommandBinding =
         requireNotNull(commandsById[id]) { "unknown command id $id on $name" }
+
+    public fun commandOrNull(id: Int): WhiskerCommandBinding? = commandsById[id]
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -128,9 +128,12 @@ public class WhiskerMountedElement internal constructor(
     private val commands: Map<Int, WhiskerCommandComponent>,
     private val eventsByName: Map<String, WhiskerEventBinding>,
     eventSink: WhiskerElementEventSink,
+    private val isolatesFailures: Boolean = false,
+    initiallyFailed: Boolean = false,
 ) {
     private var eventMask: Long = 0
     private var eventSink: WhiskerElementEventSink = eventSink
+    private var failed: Boolean = initiallyFailed
 
     init {
         installEventSink()
@@ -145,43 +148,81 @@ public class WhiskerMountedElement internal constructor(
     }
 
     public fun setProperty(id: Int, value: WhiskerValue) {
-        properties[id]?.setter?.invoke(view, value)
+        runElementOperation("set property", id) { properties[id]?.setter?.invoke(view, value) }
     }
 
     /** Clear is a protocol operation and is intentionally not `WhiskerValue.Null`. */
     public fun clearProperty(id: Int) {
-        properties[id]?.clearer?.invoke(view)
+        runElementOperation("clear property", id) { properties[id]?.clearer?.invoke(view) }
     }
 
     public fun invokeCommand(id: Int, parameters: WhiskerValue) {
-        commands[id]?.handler?.invoke(view, parameters)
+        runElementOperation("invoke command", id) { commands[id]?.handler?.invoke(view, parameters) }
     }
 
     public fun setEventMask(mask: Long) { eventMask = mask }
 
     public fun setText(content: WhiskerTextContent): Boolean {
         val update = textUpdater ?: return false
-        update(view, content)
+        runElementOperation("set text") { update(view, content) }
         return true
     }
 
     public fun setTextStyle(style: WhiskerTextStyle): Boolean {
         val update = textStyleUpdater ?: return false
-        update(view, style)
+        runElementOperation("set text style") { update(view, style) }
         return true
     }
 
-    public fun childrenHost(): android.view.ViewGroup? = childrenHost?.invoke(view)
+    public fun childrenHost(): android.view.ViewGroup? {
+        if (failed) return null
+        if (!isolatesFailures) return childrenHost?.invoke(view)
+        return try {
+            childrenHost?.invoke(view)
+        } catch (error: Exception) {
+            fail("resolve children host", null, error)
+            null
+        }
+    }
 
     /** Resets protocol-owned state before a built-in presentation is reused. */
     public fun prepareForReuse(eventSink: WhiskerElementEventSink) {
         properties.values.forEach { it.clearer(view) }
+        view.visibility = View.VISIBLE
         eventMask = 0
         this.eventSink = eventSink
         installEventSink()
     }
 
     public fun dispose() { (view as? WhiskerEventSource)?.installWhiskerEventSink(null) }
+
+    private inline fun runElementOperation(
+        label: String,
+        member: Int? = null,
+        operation: () -> Unit,
+    ) {
+        if (failed) return
+        if (!isolatesFailures) {
+            operation()
+            return
+        }
+        try {
+            operation()
+        } catch (error: Exception) {
+            fail(label, member, error)
+        }
+    }
+
+    private fun fail(label: String, member: Int?, error: Exception) {
+        if (failed) return
+        failed = true
+        val operation = if (member == null) label else "$label $member"
+        Log.e(
+            "WhiskerElement",
+            "Disabled `${registration.name}` after it failed to $operation; common presentation remains active",
+            error,
+        )
+    }
 }
 
 /** Host-owned declaration. It contains names and behavior, never Rust IDs. */
@@ -362,7 +403,24 @@ public object WhiskerElementRegistry {
         eventSink: WhiskerElementEventSink,
     ): WhiskerMountedElement? {
         val element = boundByType[elementType] ?: return null
-        val view = element.factory.makeView(context)
+        val isolatesFailures = when (element.registration.name) {
+            "whisker.ui/View", "whisker.ui/Text", "whisker.ui/ScrollView" -> false
+            else -> true
+        }
+        val (view, factoryFailed) = if (isolatesFailures) {
+            try {
+                element.factory.makeView(context) to false
+            } catch (error: Exception) {
+                Log.e(
+                    LOG_TAG,
+                    "Disabled `${element.registration.name}` after its View factory failed; common presentation remains active",
+                    error,
+                )
+                View(context) to true
+            }
+        } else {
+            element.factory.makeView(context) to false
+        }
         return WhiskerMountedElement(
             element.registration,
             view,
@@ -373,6 +431,8 @@ public object WhiskerElementRegistry {
             element.commands,
             element.registration.events.associateBy { it.name },
             eventSink,
+            isolatesFailures,
+            factoryFailed,
         )
     }
 

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -50,6 +50,19 @@ private data class CapturedPointerInput(
     val y: Float,
 )
 
+private class FailingElementView(context: android.content.Context) : View(context)
+
+private class FailingElementModule : Module() {
+    override fun definition(): ModuleDefinition = ModuleDefinition {
+        Name("FailingElement")
+        View("whisker.test/Failing", FailingElementView::class.java) {
+            Prop("checked") { _: FailingElementView, _: WhiskerValue ->
+                error("module property failure")
+            }
+        }
+    }
+}
+
 @RunWith(AndroidJUnit4::class)
 class HostConformanceTest {
     companion object {
@@ -58,6 +71,58 @@ class HostConformanceTest {
         fun registerBuiltIns() {
             WhiskerModuleKernel.install(BuiltInElementModule())
         }
+    }
+
+    @Test
+    fun pooledBuiltInVisibilityIsResetBeforeReuse() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val registration = WhiskerElementRegistration(
+                    elementType = 1,
+                    name = WhiskerBuiltInElements.TEXT,
+                    childPolicy = WhiskerChildPolicy.PlainText,
+                    measurement = WhiskerMeasurement.Text,
+                )
+                assertTrue(WhiskerElementRegistry.bind(listOf(registration)))
+                val mounted = checkNotNull(
+                    WhiskerElementRegistry.mount(1, context) { _, _ -> },
+                )
+                mounted.view.visibility = View.INVISIBLE
+
+                mounted.prepareForReuse { _, _ -> }
+
+                assertEquals(View.VISIBLE, mounted.view.visibility)
+            }
+    }
+
+    @Test
+    fun throwingModulePropertyDisablesOnlyTheMountedElement() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                WhiskerModuleKernel.install(FailingElementModule())
+                val registration = WhiskerElementRegistration(
+                    elementType = 20,
+                    name = "whisker.test/Failing",
+                    childPolicy = WhiskerChildPolicy.None,
+                    measurement = WhiskerMeasurement.None,
+                    properties = listOf(
+                        WhiskerPropertyBinding(1, "checked", WhiskerValueKind.Bool),
+                    ),
+                )
+                assertTrue(WhiskerElementRegistry.bind(listOf(registration)))
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val mounted = checkNotNull(
+                    WhiskerElementRegistry.mount(20, context) { _, _ -> },
+                )
+
+                mounted.setProperty(1, WhiskerValue.Bool(true))
+                mounted.setProperty(1, WhiskerValue.Bool(false))
+
+                assertEquals(View.VISIBLE, mounted.view.visibility)
+            }
     }
 
     @Test

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -11,6 +11,7 @@ import rs.whisker.runtime.WhiskerChildPolicy
 import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerView
 import rs.whisker.runtime.WhiskerElementRegistry
+import rs.whisker.runtime.accepts
 import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerFontStyle
 import rs.whisker.runtime.WhiskerFontFeature
@@ -193,8 +194,13 @@ internal class HostScene(
                 operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
             ) return false
-            OP_CLIP, OP_Z_ORDER, OP_CLEAR_PROPERTY, OP_EVENT_MASK ->
+            OP_CLIP, OP_Z_ORDER, OP_EVENT_MASK ->
                 if (operation.node !in existing) return false
+            OP_CLEAR_PROPERTY -> {
+                val registration = elementTypes[operation.node]
+                    ?.let(WhiskerElementRegistry::registration) ?: return false
+                if (registration.propertyOrNull(operation.member) == null) return false
+            }
             OP_HIT_TEST -> if (operation.node !in existing || operation.integer !in 0..3) return false
             OP_CURSOR -> if (operation.node !in existing || operation.integer !in 0..34) return false
             OP_CAPTURE, OP_RELEASE_CAPTURE -> if (
@@ -218,29 +224,65 @@ internal class HostScene(
             OP_VISIBILITY -> if (operation.node !in existing || operation.integer !in 0..1) return false
             OP_TEXT, OP_TEXT_STYLE -> {
                 val values = operation.numbers ?: return false
+                val names = operation.names ?: return false
                 val registration = elementTypes[operation.node]
                     ?.let(WhiskerElementRegistry::registration) ?: return false
                 if (
                     operation.node !in existing || operation.text == null ||
-                    values.size < 37 || operation.names?.size ?: 0 < 3 ||
-                    !values.all { it.isFinite() } || values[17].toInt() !in 0..2 ||
-                    values[17] != values[17].toInt().toFloat() ||
-                    values[18].toInt() !in 0..4 ||
-                    values[18] != values[18].toInt().toFloat() ||
-                    values[24].toInt() !in 0..4 ||
-                    values[24] != values[24].toInt().toFloat() ||
-                    values[36].toInt() !in 0..2 ||
-                    values[36] != values[36].toInt().toFloat()
+                    !validTextPayload(values, names)
                 ) return false
                 if (operation.tag == OP_TEXT && registration.childPolicy != WhiskerChildPolicy.PlainText) return false
                 if (operation.tag == OP_TEXT_STYLE && !registration.textStyle) return false
             }
-            OP_PROPERTY, OP_COMMAND, OP_ACCESSIBILITY ->
-                if (operation.node !in existing || operation.value == null) return false
+            OP_PROPERTY -> {
+                val value = operation.value ?: return false
+                val registration = elementTypes[operation.node]
+                    ?.let(WhiskerElementRegistry::registration) ?: return false
+                val property = registration.propertyOrNull(operation.member) ?: return false
+                if (!property.value.accepts(value)) return false
+            }
+            OP_COMMAND -> {
+                val value = operation.value ?: return false
+                val registration = elementTypes[operation.node]
+                    ?.let(WhiskerElementRegistry::registration) ?: return false
+                val command = registration.commandOrNull(operation.member) ?: return false
+                if (!command.arguments.accepts(value)) return false
+            }
+            OP_ACCESSIBILITY -> if (
+                operation.node !in existing || operation.value !is rs.whisker.runtime.WhiskerValue.Map
+            ) return false
             OP_BACKGROUND_LAYERS -> if (!validBackgroundLayers(operation, existing, rasterResources)) return false
             else -> return false
         }
         return true
+    }
+
+    private fun validTextPayload(values: FloatArray, names: Array<String>): Boolean {
+        if (values.size < 37 || names.size < 3 || !values.all { it.isFinite() }) return false
+        val integralIn = { index: Int, range: IntRange ->
+            val integer = values[index].toInt()
+            integer in range && values[index] == integer.toFloat()
+        }
+        if (
+            values[0] <= 0f || !integralIn(1, 1..1_000) || !integralIn(2, 0..2) ||
+            !integralIn(17, 0..2) || !integralIn(18, 0..4) || !integralIn(24, 0..4) ||
+            (values[27] != 0f && values[27] != 1f) || !integralIn(28, 0..2) ||
+            values[29] < 0f || values[29] != values[29].toInt().toFloat() ||
+            (values[30] != 0f && values[30] != 1f) ||
+            (values[31] != 0f && values[31] != 1f) || !integralIn(36, 0..2) ||
+            values[34] < 0f
+        ) return false
+        val featureCount = values[32].toInt()
+        val familyCount = values[33].toInt()
+        if (
+            featureCount < 0 || values[32] != featureCount.toFloat() || familyCount <= 0 ||
+            values[33] != familyCount.toFloat() || names.size < 3 + familyCount + featureCount
+        ) return false
+        if (names.slice(3 until 3 + familyCount).any(String::isEmpty)) return false
+        return names.drop(3 + familyCount).all { setting ->
+            val separator = setting.indexOf('=')
+            separator == 4 && setting.substring(separator + 1).toDoubleOrNull()?.isFinite() == true
+        }
     }
 
     private fun applyOperation(operation: HostSceneOperation) {

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use whisker::WhiskerModule;
@@ -145,11 +146,36 @@ impl DesktopElementFactory {
             DesktopElementFactoryKind::Presentation => DesktopElementContent::Empty,
             DesktopElementFactoryKind::Text => DesktopElementContent::Text(None),
             DesktopElementFactoryKind::ScrollContainer => DesktopElementContent::ScrollContainer,
-            DesktopElementFactoryKind::Native(create) => DesktopElementContent::Native {
-                implementation: create(events),
-                text: None,
-                plain_text: self.plain_text,
-            },
+            DesktopElementFactoryKind::Native(create) => {
+                let isolates_failures = !matches!(
+                    self.name.as_str(),
+                    "whisker.ui/View" | "whisker.ui/Text" | "whisker.ui/ScrollView"
+                );
+                if isolates_failures {
+                    match catch_unwind(AssertUnwindSafe(|| create(events))) {
+                        Ok(implementation) => DesktopElementContent::Native {
+                            implementation,
+                            text: None,
+                            plain_text: self.plain_text,
+                            isolates_failures,
+                        },
+                        Err(_) => {
+                            eprintln!(
+                                "[whisker] disabled `{}` after its Desktop factory panicked; common presentation remains active",
+                                self.name
+                            );
+                            DesktopElementContent::Failed
+                        }
+                    }
+                } else {
+                    DesktopElementContent::Native {
+                        implementation: create(events),
+                        text: None,
+                        plain_text: self.plain_text,
+                        isolates_failures,
+                    }
+                }
+            }
             DesktopElementFactoryKind::Declared(_) => {
                 unreachable!("Desktop declared factory was not bound at bootstrap")
             }
@@ -577,10 +603,12 @@ pub(crate) enum DesktopElementContent {
     Empty,
     Text(Option<TextContent>),
     ScrollContainer,
+    Failed,
     Native {
         implementation: Box<dyn DesktopNativeElement>,
         text: Option<TextContent>,
         plain_text: bool,
+        isolates_failures: bool,
     },
 }
 
@@ -589,7 +617,7 @@ impl DesktopElementContent {
         match self {
             Self::Text(text) => *text = None,
             Self::Native { text, .. } => *text = None,
-            Self::Empty | Self::ScrollContainer => {}
+            Self::Empty | Self::ScrollContainer | Self::Failed => {}
         }
     }
 
@@ -597,28 +625,28 @@ impl DesktopElementContent {
         match self {
             Self::ScrollContainer => true,
             Self::Native { implementation, .. } => implementation.is_scroll_container(),
-            Self::Empty | Self::Text(_) => false,
+            Self::Empty | Self::Text(_) | Self::Failed => false,
         }
     }
 
     pub(crate) fn scroll_horizontal(&self) -> bool {
         match self {
             Self::Native { implementation, .. } => implementation.scroll_horizontal(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => false,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => false,
         }
     }
 
     pub(crate) fn item_snap(&self) -> Option<(f64, f64)> {
         match self {
             Self::Native { implementation, .. } => implementation.item_snap(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
     pub(crate) fn snap_stop_always(&self) -> bool {
         match self {
             Self::Native { implementation, .. } => implementation.snap_stop_always(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => false,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => false,
         }
     }
 
@@ -626,7 +654,7 @@ impl DesktopElementContent {
         match self {
             Self::Native { implementation, .. } => implementation.scroll_enabled(),
             Self::ScrollContainer => true,
-            Self::Empty | Self::Text(_) => false,
+            Self::Empty | Self::Text(_) | Self::Failed => false,
         }
     }
 
@@ -634,7 +662,7 @@ impl DesktopElementContent {
         match self {
             Self::Text(content) => content.as_ref(),
             Self::Native { text, .. } => text.as_ref(),
-            Self::Empty | Self::ScrollContainer => None,
+            Self::Empty | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -644,7 +672,7 @@ impl DesktopElementContent {
                 Some(implementation.as_ref())
             }
             Self::Native { .. } => None,
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -671,7 +699,7 @@ impl DesktopElementContent {
     pub(crate) fn selected_text(&self) -> Option<String> {
         match self {
             Self::Native { implementation, .. } => implementation.selected_text(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -684,7 +712,7 @@ impl DesktopElementContent {
             Self::Native { implementation, .. } => {
                 implementation.text_input_caret_rect(logical_size, scale)
             }
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -706,6 +734,7 @@ impl DesktopElementContent {
                 *text = Some(content);
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::ScrollContainer | Self::Native { .. } => {
                 Err(DesktopElementError::UnexpectedText { node })
             }
@@ -718,10 +747,25 @@ impl DesktopElementContent {
         style: &WhiskerTextStyle,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.set_text_style(style);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.set_text_style(style);
+                } else if catch_unwind(AssertUnwindSafe(|| implementation.set_text_style(style)))
+                    .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after set_text_style panicked; common presentation remains active",
+                        node.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnexpectedText { node })
             }
@@ -735,10 +779,28 @@ impl DesktopElementContent {
         value: &WhiskerValue,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.set_property(property, value);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.set_property(property, value);
+                } else if catch_unwind(AssertUnwindSafe(|| {
+                    implementation.set_property(property, value)
+                }))
+                .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after property {} panicked; common presentation remains active",
+                        node.get(),
+                        property.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedProperty { node, property })
             }
@@ -751,10 +813,26 @@ impl DesktopElementContent {
         property: PropertyId,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.clear_property(property);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.clear_property(property);
+                } else if catch_unwind(AssertUnwindSafe(|| implementation.clear_property(property)))
+                    .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after clearing property {} panicked; common presentation remains active",
+                        node.get(),
+                        property.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedProperty { node, property })
             }
@@ -768,10 +846,28 @@ impl DesktopElementContent {
         arguments: &WhiskerValue,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.invoke_command(command, arguments);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.invoke_command(command, arguments);
+                } else if catch_unwind(AssertUnwindSafe(|| {
+                    implementation.invoke_command(command, arguments)
+                }))
+                .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after command {} panicked; common presentation remains active",
+                        node.get(),
+                        command.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedCommand { node, command })
             }

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -262,6 +262,124 @@ fn toggle_scene() -> (DesktopScene, ElementTypeId) {
     toggle_scene_with_wake(RuntimeWakeHandle::new(|| {}))
 }
 
+#[derive(Debug)]
+struct FailingNative;
+
+impl DesktopNativeElement for FailingNative {
+    fn set_property(&mut self, _property: PropertyId, _value: &WhiskerValue) {
+        panic!("module property failure")
+    }
+
+    fn clear_property(&mut self, _property: PropertyId) {
+        panic!("module property clear failure")
+    }
+
+    fn invoke_command(&mut self, _command: CommandId, _arguments: &WhiskerValue) {
+        panic!("module command failure")
+    }
+}
+
+fn failing_scene(factory_panics: bool) -> (DesktopScene, ElementTypeId) {
+    let element_type = ElementTypeId::new(22).unwrap();
+    let mut registrations = standard_element_registrations();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/Failing".into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![ElementPropertySchema {
+            property: CHECKED,
+            name: "checked".into(),
+            value: ElementValueKind::Bool,
+        }],
+        events: vec![],
+        commands: vec![ElementCommandSchema {
+            command: TOGGLE,
+            name: "fail".into(),
+            arguments: ElementValueKind::Null,
+        }],
+    });
+    let mut factories = built_in_element_factories();
+    factories.push(DesktopElementFactory::native(
+        "whisker.test/Failing",
+        move |_| {
+            assert!(!factory_panics, "module factory failure");
+            Box::new(FailingNative)
+        },
+    ));
+    (
+        DesktopScene::new(
+            SurfaceId::new(1).unwrap(),
+            DesktopElementRegistry::bind(&registrations, &factories).unwrap(),
+        ),
+        element_type,
+    )
+}
+
+#[test]
+fn native_element_failure_is_isolated_from_common_presentation() {
+    let node = id(1);
+    let (mut scene, element_type) = failing_scene(false);
+    let result = scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetProperty {
+                    node,
+                    property: CHECKED,
+                    value: WhiskerValue::Bool(true),
+                },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(4.0, 5.0, 80.0, 30.0),
+                },
+                Operation::InvokeCommand {
+                    node,
+                    command: TOGGLE,
+                    arguments: WhiskerValue::Null,
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert!(matches!(result, ApplyResult::Accepted { revision: 1 }));
+    let state = &scene.nodes[&node];
+    assert!(matches!(state.content, DesktopElementContent::Failed));
+    assert_eq!(state.presentation.layout.border_box.x, 4.0);
+    assert_eq!(state.presentation.layout.border_box.y, 5.0);
+}
+
+#[test]
+fn native_factory_failure_keeps_an_inert_common_node() {
+    let node = id(1);
+    let (mut scene, element_type) = failing_scene(true);
+    let result = scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(7.0, 9.0, 40.0, 20.0),
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert!(matches!(result, ApplyResult::Accepted { revision: 1 }));
+    assert!(matches!(
+        scene.nodes[&node].content,
+        DesktopElementContent::Failed
+    ));
+    assert_eq!(scene.nodes[&node].presentation.layout.border_box.x, 7.0);
+}
+
 #[derive(Debug, Default)]
 struct TextInputProbe {
     focused: bool,

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -796,8 +796,7 @@ impl DesktopScene {
         for operation in &packet.operations {
             match operation {
                 Operation::CreateNode { node, element_type } => {
-                    self.elements
-                        .create(*element_type, DesktopEventEmitter::default())?;
+                    self.elements.child_policy(*element_type)?;
                     types.insert(*node, *element_type);
                 }
                 Operation::InsertChild { parent, .. } => {
@@ -821,9 +820,13 @@ impl DesktopScene {
                         return Err(DesktopPresentError::Unsupported("text-decoration"));
                     }
                     if let Some(element_type) = types.get(node).copied() {
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text(*node, content.clone())?;
+                        if !self
+                            .elements
+                            .child_policy(element_type)?
+                            .accepts_plain_text()
+                        {
+                            return Err(DesktopElementError::UnexpectedText { node: *node }.into());
+                        }
                     }
                 }
                 Operation::SetTextStyle { node, style } => {
@@ -831,9 +834,7 @@ impl DesktopScene {
                         if !self.elements.receives_text_style(element_type)? {
                             return Err(DesktopPresentError::Unsupported("text-style"));
                         }
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text_style(*node, style)?;
+                        let _ = style;
                     }
                 }
                 Operation::SetProperty {

--- a/platforms/ios/Sources/WhiskerModule/ElementBinding.swift
+++ b/platforms/ios/Sources/WhiskerModule/ElementBinding.swift
@@ -16,6 +16,17 @@ public enum WhiskerChildPolicy: Hashable {
 /// Top-level shape of a value carried by `WhiskerValue`.
 public enum WhiskerValueKind: Hashable {
     case null, bool, int, float, string, bytes, array, map
+
+    public func accepts(_ value: WhiskerValue) -> Bool {
+        guard value.isData else { return false }
+        switch (self, value) {
+        case (.null, .null), (.bool, .bool), (.int, .int), (.float, .float),
+             (.string, .string), (.bytes, .bytes), (.array, .array), (.map, .map):
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 /// Runtime-assigned property identity received during surface bootstrap.
@@ -70,6 +81,8 @@ public struct WhiskerElementRegistration {
     public let properties: [WhiskerPropertyBinding]
     public let events: [WhiskerEventBinding]
     public let commands: [WhiskerCommandBinding]
+    private let propertiesByID: [Int: WhiskerPropertyBinding]
+    private let commandsByID: [Int: WhiskerCommandBinding]
 
     public init(
         elementType: Int,
@@ -97,5 +110,11 @@ public struct WhiskerElementRegistration {
         self.properties = properties
         self.events = events
         self.commands = commands
+        self.propertiesByID = Dictionary(uniqueKeysWithValues: properties.map { ($0.id, $0) })
+        self.commandsByID = Dictionary(uniqueKeysWithValues: commands.map { ($0.id, $0) })
     }
+
+    public func property(_ id: Int) -> WhiskerPropertyBinding? { propertiesByID[id] }
+
+    public func command(_ id: Int) -> WhiskerCommandBinding? { commandsByID[id] }
 }

--- a/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
+++ b/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
@@ -114,8 +114,8 @@ public struct WhiskerViewComponent: WhiskerDefinitionComponent {
 /// `view` is the native element instance the value was set on; `value`
 /// is the raw `WhiskerValue` — no auto-deserialization, the author
 /// destructures it, e.g. `value.asString`.
-public typealias WhiskerPropSetter = (_ view: AnyObject, _ value: WhiskerValue) -> Void
-public typealias WhiskerPropClearer = (_ view: AnyObject) -> Void
+public typealias WhiskerPropSetter = (_ view: AnyObject, _ value: WhiskerValue) throws -> Void
+public typealias WhiskerPropClearer = (_ view: AnyObject) throws -> Void
 
 /// Prop component — a single named setter on the view class.
 public struct WhiskerPropComponent: WhiskerViewDefinitionComponent {
@@ -169,7 +169,7 @@ public struct WhiskerAsyncFunctionComponent: WhiskerDefinitionComponent {
 }
 
 /// One-way command applied to a mounted Host View.
-public typealias WhiskerCommandHandler = (_ view: AnyObject, _ parameters: WhiskerValue) -> Void
+public typealias WhiskerCommandHandler = (_ view: AnyObject, _ parameters: WhiskerValue) throws -> Void
 
 public struct WhiskerCommandComponent: WhiskerViewDefinitionComponent {
     public let name: String
@@ -181,7 +181,7 @@ public struct WhiskerCommandComponent: WhiskerViewDefinitionComponent {
 }
 
 /// Resolved inherited text-style consumer for a native View.
-public typealias WhiskerTextStyleHandler = (_ view: AnyObject, _ style: WhiskerTextStyle) -> Void
+public typealias WhiskerTextStyleHandler = (_ view: AnyObject, _ style: WhiskerTextStyle) throws -> Void
 
 public struct WhiskerTextStyleComponent: WhiskerViewDefinitionComponent {
     public let handler: WhiskerTextStyleHandler
@@ -506,12 +506,12 @@ public func OnStopObserving(
 /// silently no-ops on a view-type mismatch (debug-build log).
 public func Prop<V: AnyObject>(
     _ name: String,
-    clear: @escaping (V) -> Void = { _ in },
-    _ setter: @escaping (V, WhiskerValue) -> Void
+    clear: @escaping (V) throws -> Void = { _ in },
+    _ setter: @escaping (V, WhiskerValue) throws -> Void
 ) -> WhiskerViewDefinitionComponent {
     WhiskerPropComponent(
         name: name,
-        clearer: { uiAny in if let ui = uiAny as? V { clear(ui) } }
+        clearer: { uiAny in if let ui = uiAny as? V { try clear(ui) } }
     ) { uiAny, value in
         guard let ui = uiAny as? V else {
             #if DEBUG
@@ -519,16 +519,16 @@ public func Prop<V: AnyObject>(
             #endif
             return
         }
-        setter(ui, value)
+        try setter(ui, value)
     }
 }
 
 /// Receives the resolved inherited text style for a native View.
 public func TextStyle<V: AnyObject>(
-    _ handler: @escaping (V, WhiskerTextStyle) -> Void
+    _ handler: @escaping (V, WhiskerTextStyle) throws -> Void
 ) -> WhiskerViewDefinitionComponent {
     WhiskerTextStyleComponent { view, style in
-        if let typed = view as? V { handler(typed, style) }
+        if let typed = view as? V { try handler(typed, style) }
     }
 }
 
@@ -548,11 +548,11 @@ public func Measurement(
 /// One-way command on a mounted View.
 public func Command<V: AnyObject>(
     _ name: String,
-    _ handler: @escaping (V, WhiskerValue) -> Void
+    _ handler: @escaping (V, WhiskerValue) throws -> Void
 ) -> WhiskerViewDefinitionComponent {
     WhiskerCommandComponent(name: name) { viewAny, parameters in
         guard let view = viewAny as? V else { return }
-        handler(view, parameters)
+        try handler(view, parameters)
     }
 }
 

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -234,25 +234,29 @@ public final class WhiskerMountedElement {
     public let registration: WhiskerElementRegistration
     public let view: UIView
     private let eventSource: WhiskerEventSource?
-    private let textUpdater: ((UIView, WhiskerTextContent) -> Void)?
-    private let textStyleUpdater: ((UIView, WhiskerTextStyle) -> Void)?
-    private let childrenHostProvider: ((UIView) -> UIView)?
+    private let textUpdater: ((UIView, WhiskerTextContent) throws -> Void)?
+    private let textStyleUpdater: ((UIView, WhiskerTextStyle) throws -> Void)?
+    private let childrenHostProvider: ((UIView) throws -> UIView)?
     private let properties: [Int: WhiskerPropComponent]
     private let commands: [Int: WhiskerCommandComponent]
     private let eventsByName: [String: WhiskerEventBinding]
     private var eventSink: WhiskerElementEventSink
     private var eventMask: UInt64 = 0
+    private let isolatesFailures: Bool
+    private var failed: Bool
 
     fileprivate init(
         registration: WhiskerElementRegistration,
         view: UIView,
-        textUpdater: ((UIView, WhiskerTextContent) -> Void)?,
-        textStyleUpdater: ((UIView, WhiskerTextStyle) -> Void)?,
-        childrenHost: ((UIView) -> UIView)?,
+        textUpdater: ((UIView, WhiskerTextContent) throws -> Void)?,
+        textStyleUpdater: ((UIView, WhiskerTextStyle) throws -> Void)?,
+        childrenHost: ((UIView) throws -> UIView)?,
         properties: [Int: WhiskerPropComponent],
         commands: [Int: WhiskerCommandComponent],
         eventsByName: [String: WhiskerEventBinding],
-        eventSink: @escaping WhiskerElementEventSink
+        eventSink: @escaping WhiskerElementEventSink,
+        isolatesFailures: Bool,
+        initiallyFailed: Bool = false
     ) {
         self.registration = registration
         self.view = view
@@ -264,6 +268,8 @@ public final class WhiskerMountedElement {
         self.commands = commands
         self.eventsByName = eventsByName
         self.eventSink = eventSink
+        self.isolatesFailures = isolatesFailures
+        self.failed = initiallyFailed
         installEventSink()
     }
 
@@ -275,13 +281,19 @@ public final class WhiskerMountedElement {
         }
     }
 
-    public func setProperty(_ id: Int, value: WhiskerValue) { properties[id]?.setter(view, value) }
+    public func setProperty(_ id: Int, value: WhiskerValue) {
+        runElementOperation("set property", member: id) { try properties[id]?.setter(view, value) }
+    }
 
     /// Clear is a distinct protocol operation; it is not converted to `.null`.
-    public func clearProperty(_ id: Int) { properties[id]?.clearer(view) }
+    public func clearProperty(_ id: Int) {
+        runElementOperation("clear property", member: id) { try properties[id]?.clearer(view) }
+    }
 
     public func invokeCommand(_ id: Int, parameters: WhiskerValue) {
-        commands[id]?.handler(view, parameters)
+        runElementOperation("invoke command", member: id) {
+            try commands[id]?.handler(view, parameters)
+        }
     }
 
     public func setEventMask(_ mask: UInt64) { eventMask = mask }
@@ -289,46 +301,91 @@ public final class WhiskerMountedElement {
     @discardableResult
     public func setText(_ content: WhiskerTextContent) -> Bool {
         guard let textUpdater else { return false }
-        textUpdater(view, content)
+        runElementOperation("set text") { try textUpdater(view, content) }
         return true
     }
 
     @discardableResult
     public func setTextStyle(_ style: WhiskerTextStyle) -> Bool {
         guard let textStyleUpdater else { return false }
-        textStyleUpdater(view, style)
+        runElementOperation("set text style") { try textStyleUpdater(view, style) }
         return true
     }
 
-    public func childrenHost() -> UIView? { childrenHostProvider?(view) }
+    public func childrenHost() -> UIView? {
+        guard !failed else { return nil }
+        if !isolatesFailures {
+            do { return try childrenHostProvider?(view) } catch {
+                preconditionFailure("Built-in element failed to resolve children host: \(error)")
+            }
+        }
+        do {
+            return try childrenHostProvider?(view)
+        } catch {
+            failed = true
+            NSLog(
+                "[Whisker] Disabled `%@` after it failed to resolve children host; common presentation remains active: %@",
+                registration.name,
+                String(describing: error)
+            )
+            return nil
+        }
+    }
 
     /** Resets protocol-owned state before a built-in presentation is reused. */
     public func prepareForReuse(eventSink: @escaping WhiskerElementEventSink) {
-        properties.values.forEach { $0.clearer(view) }
+        properties.values.forEach { try? $0.clearer(view) }
+        view.isHidden = false
         eventMask = 0
         self.eventSink = eventSink
         installEventSink()
     }
 
     public func dispose() { eventSource?.installWhiskerEventSink(nil) }
+
+    private func runElementOperation(
+        _ label: StaticString,
+        member: Int? = nil,
+        _ operation: () throws -> Void
+    ) {
+        guard !failed else { return }
+        if !isolatesFailures {
+            do { try operation() } catch {
+                preconditionFailure("Built-in element failed to \(label): \(error)")
+            }
+            return
+        }
+        do {
+            try operation()
+        } catch {
+            failed = true
+            let operationName = member.map { "\(label) \($0)" } ?? "\(label)"
+            NSLog(
+                "[Whisker] Disabled `%@` after it failed to %@; common presentation remains active: %@",
+                registration.name,
+                operationName,
+                String(describing: error)
+            )
+        }
+    }
 }
 
 /** Host-owned declaration. It contains names and behavior, never Rust IDs. */
 public struct WhiskerElementFactory {
     public let name: String
-    fileprivate let textUpdater: ((UIView, WhiskerTextContent) -> Void)?
-    fileprivate let textStyleUpdater: ((UIView, WhiskerTextStyle) -> Void)?
-    fileprivate let childrenHost: ((UIView) -> UIView)?
+    fileprivate let textUpdater: ((UIView, WhiskerTextContent) throws -> Void)?
+    fileprivate let textStyleUpdater: ((UIView, WhiskerTextStyle) throws -> Void)?
+    fileprivate let childrenHost: ((UIView) throws -> UIView)?
     fileprivate let measurer: ((WhiskerMeasureRequest) -> WhiskerMeasuredSize?)?
-    fileprivate let makeView: () -> UIView
+    fileprivate let makeView: () throws -> UIView
 
     public init(
         name: String,
-        textUpdater: ((UIView, WhiskerTextContent) -> Void)? = nil,
-        textStyleUpdater: ((UIView, WhiskerTextStyle) -> Void)? = nil,
-        childrenHost: ((UIView) -> UIView)? = nil,
+        textUpdater: ((UIView, WhiskerTextContent) throws -> Void)? = nil,
+        textStyleUpdater: ((UIView, WhiskerTextStyle) throws -> Void)? = nil,
+        childrenHost: ((UIView) throws -> UIView)? = nil,
         measurer: ((WhiskerMeasureRequest) -> WhiskerMeasuredSize?)? = nil,
-        makeView: @escaping () -> UIView
+        makeView: @escaping () throws -> UIView
     ) {
         precondition(!name.isEmpty && !name.contains("@"))
         self.name = name
@@ -340,7 +397,7 @@ public struct WhiskerElementFactory {
     }
 
     fileprivate func withTextStyleUpdater(
-        _ updater: ((UIView, WhiskerTextStyle) -> Void)?
+        _ updater: ((UIView, WhiskerTextStyle) throws -> Void)?
     ) -> WhiskerElementFactory {
         WhiskerElementFactory(
             name: name,
@@ -495,16 +552,44 @@ public enum WhiskerElementRegistry {
         eventSink: @escaping WhiskerElementEventSink
     ) -> WhiskerMountedElement? {
         guard let element = boundByType[elementType] else { return nil }
+        let isolatesFailures: Bool
+        switch element.registration.name {
+        case "whisker.ui/View", "whisker.ui/Text", "whisker.ui/ScrollView":
+            isolatesFailures = false
+        default:
+            isolatesFailures = true
+        }
+        let view: UIView
+        let factoryFailed: Bool
+        do {
+            view = try element.factory.makeView()
+            factoryFailed = false
+        } catch {
+            guard isolatesFailures else {
+                preconditionFailure(
+                    "Built-in element `\(element.registration.name)` factory failed: \(error)"
+                )
+            }
+            NSLog(
+                "[Whisker] Disabled `%@` after its View factory failed; common presentation remains active: %@",
+                element.registration.name,
+                String(describing: error)
+            )
+            view = UIView(frame: .zero)
+            factoryFailed = true
+        }
         return WhiskerMountedElement(
             registration: element.registration,
-            view: element.factory.makeView(),
+            view: view,
             textUpdater: element.factory.textUpdater,
             textStyleUpdater: element.factory.textStyleUpdater,
             childrenHost: element.factory.childrenHost,
             properties: element.properties,
             commands: element.commands,
             eventsByName: Dictionary(uniqueKeysWithValues: element.registration.events.map { ($0.name, $0) }),
-            eventSink: eventSink
+            eventSink: eventSink,
+            isolatesFailures: isolatesFailures,
+            initiallyFailed: factoryFailed
         )
     }
 

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -130,10 +130,32 @@ final class HostScene {
                 stagedParents.removeValue(forKey: operation.child)
             case UInt32(WHISKER_OP_MOVE):
                 guard stagedParents[operation.child] == operation.parent else { return false }
-            case UInt32(WHISKER_OP_LAYOUT), UInt32(WHISKER_OP_PAINT),
-                 UInt32(WHISKER_OP_PROPERTY), UInt32(WHISKER_OP_COMMAND),
-                 UInt32(WHISKER_OP_ACCESSIBILITY):
+            case UInt32(WHISKER_OP_LAYOUT), UInt32(WHISKER_OP_PAINT):
                 guard existing.contains(operation.node), operation.payload != nil else { return false }
+            case UInt32(WHISKER_OP_PROPERTY):
+                guard existing.contains(operation.node),
+                      let registration = elementTypes[operation.node]
+                        .flatMap({ WhiskerElementRegistry.registration($0) }),
+                      let property = registration.property(Int(operation.member)),
+                      let payload = operation.payload?
+                        .assumingMemoryBound(to: WhiskerValueRaw.self).pointee,
+                      property.value.accepts(WhiskerValue.from(raw: payload))
+                else { return false }
+            case UInt32(WHISKER_OP_COMMAND):
+                guard existing.contains(operation.node),
+                      let registration = elementTypes[operation.node]
+                        .flatMap({ WhiskerElementRegistry.registration($0) }),
+                      let command = registration.command(Int(operation.member)),
+                      let payload = operation.payload?
+                        .assumingMemoryBound(to: WhiskerValueRaw.self).pointee,
+                      command.arguments.accepts(WhiskerValue.from(raw: payload))
+                else { return false }
+            case UInt32(WHISKER_OP_ACCESSIBILITY):
+                guard existing.contains(operation.node),
+                      let payload = operation.payload?
+                        .assumingMemoryBound(to: WhiskerValueRaw.self).pointee,
+                      case .map = WhiskerValue.from(raw: payload)
+                else { return false }
             case UInt32(WHISKER_OP_TEXT), UInt32(WHISKER_OP_TEXT_STYLE):
                 guard existing.contains(operation.node),
                       let registration = elementTypes[operation.node]
@@ -244,8 +266,14 @@ final class HostScene {
             case UInt32(WHISKER_OP_VISIBILITY):
                 guard existing.contains(operation.node),
                       operation.integer == 0 || operation.integer == 1 else { return false }
+            case UInt32(WHISKER_OP_CLEAR_PROPERTY):
+                guard existing.contains(operation.node),
+                      let registration = elementTypes[operation.node]
+                        .flatMap({ WhiskerElementRegistry.registration($0) }),
+                      registration.property(Int(operation.member)) != nil
+                else { return false }
             case UInt32(WHISKER_OP_CLIP), UInt32(WHISKER_OP_Z_ORDER),
-                 UInt32(WHISKER_OP_CLEAR_PROPERTY), UInt32(WHISKER_OP_EVENT_MASK):
+                 UInt32(WHISKER_OP_EVENT_MASK):
                 guard existing.contains(operation.node) else { return false }
             default:
                 return false

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -20,11 +20,50 @@ private final class EventLifecycleTestModule: Module {
     }
 }
 
+private enum ExpectedElementFailure: Error {
+    case property
+}
+
+private final class FailingElementModule: Module {
+    override func definition() -> ModuleDefinition {
+        ModuleDefinition {
+            Name("FailingElement")
+            View(WhiskerElementFactory(name: "whisker.test/Failing") {
+                UIView(frame: .zero)
+            }) {
+                Prop("checked") { (_: UIView, _: WhiskerValue) throws in
+                    throw ExpectedElementFailure.property
+                }
+            }
+        }
+    }
+}
+
 @MainActor
 final class HostConformanceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
         WhiskerModuleKernel.install(BuiltInElementModule())
+    }
+
+    func testThrowingModulePropertyDisablesOnlyTheMountedElement() throws {
+        WhiskerModuleKernel.install(FailingElementModule())
+        let registration = WhiskerElementRegistration(
+            elementType: 20,
+            name: "whisker.test/Failing",
+            childPolicy: .none,
+            measurement: .none,
+            properties: [
+                WhiskerPropertyBinding(id: 1, name: "checked", value: .bool)
+            ]
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+        let mounted = try XCTUnwrap(WhiskerElementRegistry.mount(20) { _, _ in })
+
+        mounted.setProperty(1, value: .bool(true))
+        mounted.setProperty(1, value: .bool(false))
+
+        XCTAssertFalse(mounted.view.isHidden)
     }
 
     func testPointerCaptureOperationsReachTheUIKitSurface() {

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -33,7 +33,7 @@ pub(crate) struct DomFrameSink {
     box_paints: HashMap<NodeId, whisker_protocol::BoxPaint>,
     resources: WebResourceStore,
     text_nodes: HashMap<NodeId, web_sys::Element>,
-    native_nodes: HashMap<NodeId, Box<dyn WebNativeElement>>,
+    native_nodes: HashMap<NodeId, WebNativeNode>,
     presentation_pool: HashMap<ElementTypeId, Vec<PooledWebPresentation>>,
     event_masks: HashMap<NodeId, Rc<Cell<u64>>>,
     scroll_listeners: HashMap<NodeId, Vec<ScrollListener>>,
@@ -44,6 +44,11 @@ pub(crate) struct DomFrameSink {
 struct PooledWebPresentation {
     element: web_sys::Element,
     native: Option<Box<dyn WebNativeElement>>,
+}
+
+enum WebNativeNode {
+    Active(Box<dyn WebNativeElement>),
+    Failed,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -267,6 +272,7 @@ impl DomFrameSink {
                     .presentation_pool
                     .get_mut(element_type)
                     .and_then(Vec::pop);
+                let mut native_failed = false;
                 let (element, native) = if let Some(pooled) = pooled {
                     reset_pooled_element(&pooled.element)?;
                     (pooled.element, pooled.native)
@@ -279,11 +285,23 @@ impl DomFrameSink {
                             None,
                         ),
                         WebElementFactoryKind::Native(create) => {
-                            let native =
-                                create(&self.document, emitter.clone()).map_err(|error| {
-                                    js_error("create native Whisker DOM node", error)
-                                })?;
-                            (native.element(), Some(native))
+                            match create(&self.document, emitter.clone()) {
+                                Ok(native) => (native.element(), Some(native)),
+                                Err(error) => {
+                                    Self::log_native_failure(
+                                        &binding.registration.name,
+                                        "create element",
+                                        &error,
+                                    );
+                                    native_failed = true;
+                                    (
+                                        self.document.create_element("div").map_err(|error| {
+                                            js_error("create failed-element placeholder", error)
+                                        })?,
+                                        None,
+                                    )
+                                }
+                            }
                         }
                         WebElementFactoryKind::Declared(_) => {
                             unreachable!("DOM declared factory was not bound at bootstrap")
@@ -360,7 +378,10 @@ impl DomFrameSink {
                 self.node_types.insert(*node, *element_type);
                 self.event_masks.insert(*node, event_mask);
                 if let Some(native) = native {
-                    self.native_nodes.insert(*node, native);
+                    self.native_nodes
+                        .insert(*node, WebNativeNode::Active(native));
+                } else if native_failed {
+                    self.native_nodes.insert(*node, WebNativeNode::Failed);
                 }
             }
             Operation::DeleteNode { node } => self.delete_subtree(*node),
@@ -474,11 +495,16 @@ impl DomFrameSink {
                         node.get()
                     )));
                 }
-                self.native_nodes
-                    .get_mut(node)
-                    .ok_or_else(|| WebError(format!("DOM node {} is not native", node.get())))?
-                    .set_text_style(style)
-                    .map_err(|error| js_error("set native DOM text style", error))?;
+                let result = match self.native_nodes.get_mut(node) {
+                    Some(WebNativeNode::Active(native)) => native.set_text_style(style),
+                    Some(WebNativeNode::Failed) => return Ok(()),
+                    None => {
+                        return Err(WebError(format!("DOM node {} is not native", node.get())));
+                    }
+                };
+                if let Err(error) = result {
+                    self.disable_native_node(*node, element_type, "set text style", error);
+                }
             }
             Operation::SetAccessibility {
                 node,
@@ -525,11 +551,16 @@ impl DomFrameSink {
                         schema.name, schema.value
                     )));
                 }
-                self.native_nodes
-                    .get_mut(node)
-                    .ok_or_else(|| WebError(format!("DOM node {} is not native", node.get())))?
-                    .set_property(*property, value)
-                    .map_err(|error| js_error("set native DOM property", error))?;
+                let result = match self.native_nodes.get_mut(node) {
+                    Some(WebNativeNode::Active(native)) => native.set_property(*property, value),
+                    Some(WebNativeNode::Failed) => return Ok(()),
+                    None => {
+                        return Err(WebError(format!("DOM node {} is not native", node.get())));
+                    }
+                };
+                if let Err(error) = result {
+                    self.disable_native_node(*node, element_type, "set property", error);
+                }
             }
             Operation::ClearProperty { node, property } => {
                 let element_type = *self.node_types.get(node).ok_or_else(|| {
@@ -543,11 +574,16 @@ impl DomFrameSink {
                         property.get()
                     ))
                 })?;
-                self.native_nodes
-                    .get_mut(node)
-                    .ok_or_else(|| WebError(format!("DOM node {} is not native", node.get())))?
-                    .clear_property(*property)
-                    .map_err(|error| js_error("clear native DOM property", error))?;
+                let result = match self.native_nodes.get_mut(node) {
+                    Some(WebNativeNode::Active(native)) => native.clear_property(*property),
+                    Some(WebNativeNode::Failed) => return Ok(()),
+                    None => {
+                        return Err(WebError(format!("DOM node {} is not native", node.get())));
+                    }
+                };
+                if let Err(error) = result {
+                    self.disable_native_node(*node, element_type, "clear property", error);
+                }
             }
             Operation::SetEventMask { node, event_mask } => {
                 self.event_masks
@@ -580,11 +616,18 @@ impl DomFrameSink {
                         schema.name, schema.arguments
                     )));
                 }
-                self.native_nodes
-                    .get_mut(node)
-                    .ok_or_else(|| WebError(format!("DOM node {} is not native", node.get())))?
-                    .invoke_command(*command, arguments)
-                    .map_err(|error| js_error("invoke native DOM command", error))?;
+                let result = match self.native_nodes.get_mut(node) {
+                    Some(WebNativeNode::Active(native)) => {
+                        native.invoke_command(*command, arguments)
+                    }
+                    Some(WebNativeNode::Failed) => return Ok(()),
+                    None => {
+                        return Err(WebError(format!("DOM node {} is not native", node.get())));
+                    }
+                };
+                if let Err(error) = result {
+                    self.disable_native_node(*node, element_type, "invoke command", error);
+                }
             }
             Operation::SetPointerCapture { node, pointer } => {
                 let element = self.node(*node)?;
@@ -614,6 +657,31 @@ impl DomFrameSink {
             .get(&node)
             .cloned()
             .ok_or_else(|| WebError(format!("DOM projection is missing node {}", node.get())))
+    }
+
+    fn disable_native_node(
+        &mut self,
+        node: NodeId,
+        element_type: ElementTypeId,
+        action: &str,
+        error: wasm_bindgen::JsValue,
+    ) {
+        let element_name = self
+            .elements
+            .binding(element_type)
+            .map_or("unknown", |binding| binding.registration.name.as_str());
+        Self::log_native_failure(element_name, action, &error);
+        self.native_nodes.insert(node, WebNativeNode::Failed);
+    }
+
+    fn log_native_failure(element_name: &str, action: &str, error: &wasm_bindgen::JsValue) {
+        web_sys::console::error_2(
+            &format!(
+                "Disabled `{element_name}` after it failed to {action}; common presentation remains active"
+            )
+            .into(),
+            error,
+        );
     }
 
     fn sync_layout(&self, node: NodeId) -> Result<(), WebError> {
@@ -754,7 +822,13 @@ impl DomFrameSink {
             self.layouts.remove(&node);
             self.box_paints.remove(&node);
             self.text_nodes.remove(&node);
-            let native = self.native_nodes.remove(&node);
+            let native = self
+                .native_nodes
+                .remove(&node)
+                .and_then(|native| match native {
+                    WebNativeNode::Active(native) => Some(native),
+                    WebNativeNode::Failed => None,
+                });
             self.event_masks.remove(&node);
             self.scroll_listeners.remove(&node);
             if let (Some(element), Some(element_type)) = (element, element_type)

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -26,16 +26,18 @@ use whisker_host_conformance::{
 use whisker_protocol::{
     Accessibility, AccessibilityChecked, AccessibilityRole, AccessibilityState, AvailableSpace,
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
-    BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
-    LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily, MeasureFontStyle,
-    MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak,
-    MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    PathCommand, PointerKind, ProtocolVersion, RadialGradientExtent, RadialGradientShape,
-    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest,
-    ResourceSource, SurfaceId, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint,
-    TextShadow, Transform, Visibility, WhiskerValue,
+    BoxPaint, ClipShape, ElementMeasurement, ElementPropertySchema, ElementRegistration,
+    ElementTypeId, ElementValueKind, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop,
+    ImageRepeat, LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily,
+    MeasureFontStyle, MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow,
+    MeasureTextWordBreak, MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
+    PaintLengthPercentage, PaintPosition, PathCommand, PointerKind, ProtocolVersion,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent,
+    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent,
+    TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
+    WhiskerValue,
 };
 use whisker_style::StyleEnvironment;
 
@@ -45,7 +47,9 @@ use crate::input::{
 use crate::measure::text::DomMeasurementProvider;
 use crate::module_api::built_in_element_factories;
 use crate::scene::frame_sink::DomFrameSink;
-use crate::{WebResourceService, WebResourceState, WebResourceStore};
+use crate::{
+    WebElementFactory, WebNativeElement, WebResourceService, WebResourceState, WebResourceStore,
+};
 
 const MANIFEST: &str = include_str!("../../../../tests/host-conformance/manifest.json");
 const RASTER_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAF0lEQVR4nAXBAQEAAACCIKb33EBkQpUOQdYIeRyCeLsAAAAASUVORK5CYII=";
@@ -64,6 +68,135 @@ fn browser_pointer_metadata_maps_to_protocol_values() {
     assert_ne!(stable_pointer_id(-1), 0);
     assert_ne!(stable_pointer_id(0), stable_pointer_id(-1));
     assert_eq!(stable_pointer_id(-1), stable_pointer_id(-1));
+}
+
+#[derive(Debug)]
+struct FailingWebElement(web_sys::Element);
+
+impl WebNativeElement for FailingWebElement {
+    fn element(&self) -> web_sys::Element {
+        self.0.clone()
+    }
+
+    fn set_property(
+        &mut self,
+        _property: whisker_protocol::PropertyId,
+        _value: &WhiskerValue,
+    ) -> Result<(), wasm_bindgen::JsValue> {
+        Err(wasm_bindgen::JsValue::from_str("module property failure"))
+    }
+
+    fn clear_property(
+        &mut self,
+        _property: whisker_protocol::PropertyId,
+    ) -> Result<(), wasm_bindgen::JsValue> {
+        Err(wasm_bindgen::JsValue::from_str("module clear failure"))
+    }
+
+    fn invoke_command(
+        &mut self,
+        _command: whisker_protocol::CommandId,
+        _arguments: &WhiskerValue,
+    ) -> Result<(), wasm_bindgen::JsValue> {
+        Err(wasm_bindgen::JsValue::from_str("module command failure"))
+    }
+}
+
+#[wasm_bindgen_test]
+fn native_failure_does_not_abort_common_dom_presentation() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let root = document.create_element("div").unwrap();
+    document.body().unwrap().append_child(&root).unwrap();
+    let element_type = ElementTypeId::new(20).unwrap();
+    let property = whisker_protocol::PropertyId::new(1).unwrap();
+    let mut registrations = ElementRegistry::standard().registrations().to_vec();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/Failing".into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![ElementPropertySchema {
+            property,
+            name: "checked".into(),
+            value: ElementValueKind::Bool,
+        }],
+        events: vec![],
+        commands: vec![],
+    });
+    let mut factories = built_in_element_factories();
+    factories.push(WebElementFactory::native(
+        "whisker.test/Failing",
+        |document, _| {
+            Ok(Box::new(FailingWebElement(
+                document.create_element("button")?,
+            )))
+        },
+    ));
+    let mut sink = DomFrameSink::new_with_resources(
+        document,
+        root.clone(),
+        SurfaceId::new(1).unwrap(),
+        &registrations,
+        &factories,
+        WebResourceStore::new(),
+        crate::capabilities::detect_host_capabilities(),
+    )
+    .unwrap();
+    let node = NodeId::new(1).unwrap();
+    let result = sink
+        .present(&FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 1,
+                base_revision: 0,
+                target_revision: 1,
+                viewport_epoch: 1,
+                mode: FrameMode::Snapshot,
+            },
+            operations: vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetProperty {
+                    node,
+                    property,
+                    value: WhiskerValue::Bool(true),
+                },
+                Operation::SetLayout {
+                    node,
+                    geometry: LayoutGeometry {
+                        border_box: LayoutRect {
+                            x: 12.0,
+                            y: 8.0,
+                            width: 40.0,
+                            height: 20.0,
+                        },
+                        content_box: LayoutRect::default(),
+                    },
+                },
+            ],
+        })
+        .unwrap();
+
+    assert!(matches!(
+        result,
+        whisker_protocol::ApplyResult::Accepted { revision: 1 }
+    ));
+    let element = root
+        .query_selector("[data-whisker-node='1']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        element
+            .dyn_ref::<web_sys::HtmlElement>()
+            .unwrap()
+            .style()
+            .get_property_value("left")
+            .unwrap(),
+        "12px"
+    );
+    root.remove();
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- validate module property, command, text, and accessibility inputs before Host mutation
- isolate custom element factory/callback failures to the affected mounted element while preserving common layout, paint, clip, accessibility, and tree presentation
- reset pooled Android/iOS built-in visibility and add symmetric Host regression coverage
- document the failure boundary in the native module RFC

## Performance
- built-in View/Text/ScrollView keep the direct callback path
- failed custom nodes reuse the existing native-node slot/state instead of adding another per-node map
- no custom factory is executed during Desktop validation

## Validation
- cargo test -p whisker-desktop --lib
- cargo clippy -p whisker-desktop -p whisker-web --all-targets -- -D warnings
- cargo xtask host-conformance web
- platforms/android/gradle-plugin/gradlew --project-dir platforms/android :runtime:compileDebugAndroidTestKotlin
- swift build --package-path platforms/ios --triple arm64-apple-ios13.0-simulator --sdk "$(xcrun --sdk iphonesimulator --show-sdk-path)" --target WhiskerRuntime
- cargo test --workspace --all-targets (running locally; no failures observed before PR creation)