### PR TITLE
fix(style): resolve logical margin and padding

### DIFF
--- a/crates/whisker-css/src/prop/box_model.rs
+++ b/crates/whisker-css/src/prop/box_model.rs
@@ -94,6 +94,16 @@ impl Css {
         self.push_typed(crate::StyleProperty::PaddingLeft, v.into())
     }
 
+    /// Sets `padding-inline-start` on the logical start edge.
+    pub fn padding_inline_start(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::PaddingInlineStart, v.into())
+    }
+
+    /// Sets `padding-inline-end` on the logical end edge.
+    pub fn padding_inline_end(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::PaddingInlineEnd, v.into())
+    }
+
     // ---------- Margin longhand ----------
 
     /// Sets `margin-top`. Lynx allows negative values and `auto`.
@@ -118,6 +128,16 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/margin-left>
     pub fn margin_left(self, v: impl Into<MarginValue>) -> Self {
         self.push_typed(crate::StyleProperty::MarginLeft, v.into())
+    }
+
+    /// Sets `margin-inline-start` on the logical start edge.
+    pub fn margin_inline_start(self, v: impl Into<MarginValue>) -> Self {
+        self.push_typed(crate::StyleProperty::MarginInlineStart, v.into())
+    }
+
+    /// Sets `margin-inline-end` on the logical end edge.
+    pub fn margin_inline_end(self, v: impl Into<MarginValue>) -> Self {
+        self.push_typed(crate::StyleProperty::MarginInlineEnd, v.into())
     }
 
     // ---------- Gap ----------
@@ -145,11 +165,11 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
-    use crate::Css;
     use crate::data_type::{FitContent, MaxContent};
     use crate::ext::*;
     use crate::keyword::BoxSizing;
     use crate::value::Size;
+    use crate::{Css, MarginValue};
 
     #[test]
     fn width_height_basic() {
@@ -218,6 +238,19 @@ mod tests {
         assert_eq!(
             s.to_string(),
             "margin-top: -4px; margin-right: 0%; margin-bottom: 8px; margin-left: -50%;"
+        );
+    }
+
+    #[test]
+    fn logical_margin_and_padding_builders_remain_typed() {
+        let style = Css::new()
+            .margin_inline_start(px(-4))
+            .margin_inline_end(MarginValue::Auto)
+            .padding_inline_start(px(6))
+            .padding_inline_end(percent(8));
+        assert_eq!(
+            style.to_string(),
+            "margin-inline-start: -4px; margin-inline-end: auto; padding-inline-start: 6px; padding-inline-end: 8%;"
         );
     }
 

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -476,7 +476,8 @@ pub(crate) fn resolve_layout_style(
         direction: inherited_direction,
         ..ComputedLayoutStyle::default()
     };
-    let declarations = LayoutDeclarations::from_specified(specified);
+    let resolved_declarations = specified.resolved();
+    let declarations = LayoutDeclarations::from_resolved(&resolved_declarations);
 
     style.display = copied(
         declarations.display,
@@ -596,67 +597,32 @@ pub(crate) fn resolve_layout_style(
         StyleProperty::MaxHeight,
     )?;
 
-    style.margin.top = resolve_optional_auto(
-        declarations.margin_top,
-        style.margin.top,
+    style.margin = resolve_margins(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::MarginTop,
     )?;
-    style.margin.right = resolve_optional_auto(
-        declarations.margin_right,
-        style.margin.right,
+    style.padding = resolve_paddings(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::MarginRight,
-    )?;
-    style.margin.bottom = resolve_optional_auto(
-        declarations.margin_bottom,
-        style.margin.bottom,
-        font_size,
-        environment,
-        StyleProperty::MarginBottom,
-    )?;
-    style.margin.left = resolve_optional_auto(
-        declarations.margin_left,
-        style.margin.left,
-        font_size,
-        environment,
-        StyleProperty::MarginLeft,
     )?;
 
-    style.padding.top = resolve_optional_length_percentage(
-        declarations.padding_top,
-        style.padding.top,
+    style.border = resolve_borders(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::PaddingTop,
-    )?;
-    style.padding.right = resolve_optional_length_percentage(
-        declarations.padding_right,
-        style.padding.right,
-        font_size,
-        environment,
-        StyleProperty::PaddingRight,
-    )?;
-    style.padding.bottom = resolve_optional_length_percentage(
-        declarations.padding_bottom,
-        style.padding.bottom,
-        font_size,
-        environment,
-        StyleProperty::PaddingBottom,
-    )?;
-    style.padding.left = resolve_optional_length_percentage(
-        declarations.padding_left,
-        style.padding.left,
-        font_size,
-        environment,
-        StyleProperty::PaddingLeft,
     )?;
 
-    style.border = resolve_borders(specified, style.direction, font_size, environment)?;
-
-    style.inset = resolve_insets(specified, style.direction, font_size, environment)?;
+    style.inset = resolve_insets(
+        &resolved_declarations,
+        style.direction,
+        font_size,
+        environment,
+    )?;
 
     style.flex_direction = copied(
         declarations.flex_direction,

--- a/crates/whisker-style/src/layout/resolution.rs
+++ b/crates/whisker-style/src/layout/resolution.rs
@@ -274,13 +274,13 @@ pub(super) fn resolve_non_negative_length_percentage(
 }
 
 pub(super) fn resolve_insets(
-    specified: &SpecifiedStyle,
+    declarations: &[&crate::StyleDeclaration],
     direction: DirectionValue,
     font_size: f32,
     environment: StyleEnvironment,
 ) -> Result<Edges<ComputedLengthPercentageAuto>, StyleResolutionError> {
     let mut inset = Edges::all(ComputedLengthPercentageAuto::Auto);
-    for declaration in specified.resolved() {
+    for declaration in declarations {
         let (edge, property) = match declaration.property() {
             StyleProperty::Top => (&mut inset.top, StyleProperty::Top),
             StyleProperty::Right => (&mut inset.right, StyleProperty::Right),
@@ -312,14 +312,88 @@ pub(super) fn resolve_insets(
     Ok(inset)
 }
 
+pub(super) fn resolve_margins(
+    declarations: &[&crate::StyleDeclaration],
+    direction: DirectionValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+) -> Result<Edges<ComputedLengthPercentageAuto>, StyleResolutionError> {
+    let mut margin = Edges::all(ComputedLengthPercentageAuto::Value(
+        ComputedLengthPercentage::ZERO,
+    ));
+    for declaration in declarations {
+        let (edge, property) = match declaration.property() {
+            StyleProperty::MarginTop => (&mut margin.top, StyleProperty::MarginTop),
+            StyleProperty::MarginRight => (&mut margin.right, StyleProperty::MarginRight),
+            StyleProperty::MarginBottom => (&mut margin.bottom, StyleProperty::MarginBottom),
+            StyleProperty::MarginLeft => (&mut margin.left, StyleProperty::MarginLeft),
+            StyleProperty::MarginInlineStart if direction == DirectionValue::Ltr => {
+                (&mut margin.left, StyleProperty::MarginInlineStart)
+            }
+            StyleProperty::MarginInlineStart => {
+                (&mut margin.right, StyleProperty::MarginInlineStart)
+            }
+            StyleProperty::MarginInlineEnd if direction == DirectionValue::Ltr => {
+                (&mut margin.right, StyleProperty::MarginInlineEnd)
+            }
+            StyleProperty::MarginInlineEnd => (&mut margin.left, StyleProperty::MarginInlineEnd),
+            _ => continue,
+        };
+        *edge = resolve_optional_auto(
+            Some(declaration.value()),
+            *edge,
+            font_size,
+            environment,
+            property,
+        )?;
+    }
+    Ok(margin)
+}
+
+pub(super) fn resolve_paddings(
+    declarations: &[&crate::StyleDeclaration],
+    direction: DirectionValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+) -> Result<Edges<ComputedLengthPercentage>, StyleResolutionError> {
+    let mut padding = Edges::all(ComputedLengthPercentage::ZERO);
+    for declaration in declarations {
+        let (edge, property) = match declaration.property() {
+            StyleProperty::PaddingTop => (&mut padding.top, StyleProperty::PaddingTop),
+            StyleProperty::PaddingRight => (&mut padding.right, StyleProperty::PaddingRight),
+            StyleProperty::PaddingBottom => (&mut padding.bottom, StyleProperty::PaddingBottom),
+            StyleProperty::PaddingLeft => (&mut padding.left, StyleProperty::PaddingLeft),
+            StyleProperty::PaddingInlineStart if direction == DirectionValue::Ltr => {
+                (&mut padding.left, StyleProperty::PaddingInlineStart)
+            }
+            StyleProperty::PaddingInlineStart => {
+                (&mut padding.right, StyleProperty::PaddingInlineStart)
+            }
+            StyleProperty::PaddingInlineEnd if direction == DirectionValue::Ltr => {
+                (&mut padding.right, StyleProperty::PaddingInlineEnd)
+            }
+            StyleProperty::PaddingInlineEnd => (&mut padding.left, StyleProperty::PaddingInlineEnd),
+            _ => continue,
+        };
+        *edge = resolve_optional_length_percentage(
+            Some(declaration.value()),
+            *edge,
+            font_size,
+            environment,
+            property,
+        )?;
+    }
+    Ok(padding)
+}
+
 pub(super) fn resolve_borders(
-    specified: &SpecifiedStyle,
+    declarations: &[&crate::StyleDeclaration],
     direction: DirectionValue,
     font_size: f32,
     environment: StyleEnvironment,
 ) -> Result<Edges<ComputedLengthPercentage>, StyleResolutionError> {
     let mut border = Edges::all(ComputedLengthPercentage::ZERO);
-    for declaration in specified.resolved() {
+    for declaration in declarations {
         let (edge, property) = match declaration.property() {
             StyleProperty::BorderTopWidth => (&mut border.top, StyleProperty::BorderTopWidth),
             StyleProperty::BorderRightWidth => (&mut border.right, StyleProperty::BorderRightWidth),
@@ -569,14 +643,6 @@ pub(super) struct LayoutDeclarations<'a> {
     pub(super) min_height: Option<&'a StyleValue>,
     pub(super) max_width: Option<&'a StyleValue>,
     pub(super) max_height: Option<&'a StyleValue>,
-    pub(super) margin_top: Option<&'a StyleValue>,
-    pub(super) margin_right: Option<&'a StyleValue>,
-    pub(super) margin_bottom: Option<&'a StyleValue>,
-    pub(super) margin_left: Option<&'a StyleValue>,
-    pub(super) padding_top: Option<&'a StyleValue>,
-    pub(super) padding_right: Option<&'a StyleValue>,
-    pub(super) padding_bottom: Option<&'a StyleValue>,
-    pub(super) padding_left: Option<&'a StyleValue>,
     pub(super) flex_direction: Option<&'a StyleValue>,
     pub(super) flex_wrap: Option<&'a StyleValue>,
     pub(super) flex_grow: Option<&'a StyleValue>,
@@ -605,9 +671,9 @@ pub(super) struct LayoutDeclarations<'a> {
 }
 
 impl<'a> LayoutDeclarations<'a> {
-    pub(super) fn from_specified(specified: &'a SpecifiedStyle) -> Self {
+    pub(super) fn from_resolved(declarations: &'a [&'a crate::StyleDeclaration]) -> Self {
         let mut values = Self::default();
-        for declaration in specified.resolved() {
+        for declaration in declarations {
             let slot = match declaration.property() {
                 StyleProperty::Display => &mut values.display,
                 StyleProperty::Float => &mut values.float,
@@ -623,14 +689,6 @@ impl<'a> LayoutDeclarations<'a> {
                 StyleProperty::MinHeight => &mut values.min_height,
                 StyleProperty::MaxWidth => &mut values.max_width,
                 StyleProperty::MaxHeight => &mut values.max_height,
-                StyleProperty::MarginTop => &mut values.margin_top,
-                StyleProperty::MarginRight => &mut values.margin_right,
-                StyleProperty::MarginBottom => &mut values.margin_bottom,
-                StyleProperty::MarginLeft => &mut values.margin_left,
-                StyleProperty::PaddingTop => &mut values.padding_top,
-                StyleProperty::PaddingRight => &mut values.padding_right,
-                StyleProperty::PaddingBottom => &mut values.padding_bottom,
-                StyleProperty::PaddingLeft => &mut values.padding_left,
                 StyleProperty::FlexDirection => &mut values.flex_direction,
                 StyleProperty::FlexWrap => &mut values.flex_wrap,
                 StyleProperty::FlexGrow => &mut values.flex_grow,

--- a/crates/whisker-style/src/layout/tests.rs
+++ b/crates/whisker-style/src/layout/tests.rs
@@ -759,6 +759,106 @@ fn logical_insets_resolve_in_final_write_order_for_both_directions() {
 }
 
 #[test]
+fn logical_margin_and_padding_resolve_in_final_write_order_for_both_directions() {
+    let ltr = SpecifiedStyle::new()
+        .push(
+            StyleProperty::MarginLeft,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(1.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineStart,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(2.0))),
+        )
+        .push(
+            StyleProperty::MarginRight,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(3.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineEnd,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::Auto),
+        )
+        .push(
+            StyleProperty::PaddingLeft,
+            StyleValue::LengthPercentage(px(5.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineStart,
+            StyleValue::LengthPercentage(px(6.0)),
+        )
+        .push(
+            StyleProperty::PaddingRight,
+            StyleValue::LengthPercentage(px(7.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineEnd,
+            StyleValue::LengthPercentage(px(8.0)),
+        );
+    let style = resolve(&ltr).unwrap();
+    assert_eq!(
+        style.margin.left,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(2.0, 0.0))
+    );
+    assert_eq!(style.margin.right, ComputedLengthPercentageAuto::Auto);
+    assert_eq!(style.padding.left, ComputedLengthPercentage::new(6.0, 0.0));
+    assert_eq!(style.padding.right, ComputedLengthPercentage::new(8.0, 0.0));
+
+    let rtl = SpecifiedStyle::new()
+        .push(
+            StyleProperty::Direction,
+            StyleValue::Direction(DirectionValue::Rtl),
+        )
+        .push(
+            StyleProperty::MarginInlineStart,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(9.0))),
+        )
+        .push(
+            StyleProperty::MarginRight,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(10.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineEnd,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(11.0))),
+        )
+        .push(
+            StyleProperty::PaddingInlineStart,
+            StyleValue::LengthPercentage(px(12.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineEnd,
+            StyleValue::LengthPercentage(px(13.0)),
+        );
+    let style = resolve(&rtl).unwrap();
+    assert_eq!(
+        style.margin.right,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(10.0, 0.0))
+    );
+    assert_eq!(
+        style.margin.left,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(11.0, 0.0))
+    );
+    assert_eq!(
+        style.padding.right,
+        ComputedLengthPercentage::new(12.0, 0.0)
+    );
+    assert_eq!(style.padding.left, ComputedLengthPercentage::new(13.0, 0.0));
+
+    for property in [
+        StyleProperty::MarginInlineStart,
+        StyleProperty::MarginInlineEnd,
+        StyleProperty::PaddingInlineStart,
+        StyleProperty::PaddingInlineEnd,
+    ] {
+        assert_eq!(
+            resolve(&declaration(
+                property,
+                StyleValue::Color(crate::ColorValue::Named("red".into())),
+            )),
+            Err(StyleResolutionError::InvalidPropertyValue(property))
+        );
+    }
+}
+
+#[test]
 fn relative_units_become_logical_pixel_components() {
     let environment = StyleEnvironment::new(750.0, 400.0, 2.0, 10.0);
     let cases = [


### PR DESCRIPTION
## Summary
- add typed margin-inline-start/end and padding-inline-start/end builders
- resolve logical edges against the computed LTR/RTL direction
- preserve final-write order between logical and physical edge declarations
- share one resolved declaration list across layout edge resolution to avoid repeated cascade allocations

## Validation
- cargo test -p whisker-style
- cargo test -p whisker-css --lib
- cargo clippy -p whisker-style -p whisker-css --all-targets -- -D warnings
- git diff --check