### PR TITLE
fix(style): collapse non-painting border widths

### DIFF
--- a/crates/whisker-style/src/paint/tests.rs
+++ b/crates/whisker-style/src/paint/tests.rs
@@ -1309,6 +1309,10 @@ fn logical_borders_resolve_to_physical_edges_and_corners() {
 fn logical_and_physical_border_declarations_share_final_write_order() {
     let resolved = crate::resolve_style(
         &SpecifiedStyle::new()
+            .push(
+                StyleProperty::BorderLeftStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
             .push(StyleProperty::BorderInlineStartWidth, px(2.0))
             .push(StyleProperty::BorderLeftWidth, px(4.0))
             .push(
@@ -1331,6 +1335,10 @@ fn logical_and_physical_border_declarations_share_final_write_order() {
 
     let resolved = crate::resolve_style(
         &SpecifiedStyle::new()
+            .push(
+                StyleProperty::BorderLeftStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
             .push(StyleProperty::BorderLeftWidth, px(4.0))
             .push(StyleProperty::BorderInlineStartWidth, px(6.0))
             .push(

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -4,11 +4,12 @@ use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    CalcExpression, ColorValue, ComponentValue, ComputedLayoutStyle, ComputedMotionStyle,
-    ComputedPaintStyle, CursorValue, CustomPropertyName, CustomPropertyReference, DirectionValue,
-    FontFamilyValue, FontFeatureValue, FontOpticalSizingValue, FontStyleValue, FontVariationValue,
-    FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
-    PointerEventsValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextAlignValue,
+    BorderStyleValue, CalcExpression, ColorValue, ComponentValue, ComputedLayoutStyle,
+    ComputedLengthPercentage, ComputedMotionStyle, ComputedPaintStyle, CursorValue,
+    CustomPropertyName, CustomPropertyReference, DirectionValue, FontFamilyValue, FontFeatureValue,
+    FontOpticalSizingValue, FontStyleValue, FontVariationValue, FontWeightValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, PointerEventsValue,
+    SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextAlignValue,
     TextDecorationLineValue, TextDecorationStyleValue, TextDecorationValue, TextOverflowValue,
     TextShadowValue, WhiteSpaceValue, WordBreakValue,
 };
@@ -916,7 +917,7 @@ fn resolve_style_once(
         None => TextOverflowValue::default(),
     };
 
-    let layout = crate::layout::resolve_layout_style(
+    let mut layout = crate::layout::resolve_layout_style(
         specified,
         font_size.get(),
         base.direction,
@@ -947,6 +948,30 @@ fn resolve_style_once(
         layout.direction,
         environment,
     )?;
+    if matches!(
+        paint.border_styles.top,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.top = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.right,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.right = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.bottom,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.bottom = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.left,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.left = ComputedLengthPercentage::ZERO;
+    }
     let motion = crate::motion::resolve_motion_style(specified)?;
 
     Ok(ResolvedNodeStyle {

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -1350,6 +1350,49 @@ fn direct_invalid_values_remain_resolution_errors() {
 }
 
 #[test]
+fn none_and_hidden_border_styles_zero_the_corresponding_layout_widths() {
+    let border_width =
+        |value| StyleValue::LengthPercentage(LengthPercentageValue::Length(px(value)));
+    let resolved = resolve_style(
+        &SpecifiedStyle::new()
+            .push(StyleProperty::BorderTopWidth, border_width(1.0))
+            .push(StyleProperty::BorderRightWidth, border_width(2.0))
+            .push(StyleProperty::BorderBottomWidth, border_width(3.0))
+            .push(StyleProperty::BorderLeftWidth, border_width(4.0))
+            .push(
+                StyleProperty::BorderTopStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
+            .push(
+                StyleProperty::BorderRightStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Hidden),
+            )
+            .push(
+                StyleProperty::BorderBottomStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Dashed),
+            ),
+        None,
+        StyleEnvironment::default(),
+    )
+    .unwrap();
+
+    let border = &resolved.computed().layout().border;
+    assert_eq!(border.top.length(), 1.0);
+    assert_eq!(border.right, ComputedLengthPercentage::ZERO);
+    assert_eq!(border.bottom.length(), 3.0);
+    assert_eq!(border.left, ComputedLengthPercentage::ZERO);
+    assert_eq!(
+        resolved.computed().paint().border_styles,
+        crate::Edges {
+            top: BorderStyleValue::Solid,
+            right: BorderStyleValue::Hidden,
+            bottom: BorderStyleValue::Dashed,
+            left: BorderStyleValue::None,
+        }
+    );
+}
+
+#[test]
 fn custom_properties_support_forward_references() {
     let a = CustomPropertyName::new("--a").unwrap();
     let b = CustomPropertyName::new("--b").unwrap();


### PR DESCRIPTION
## Summary
- make border-style none and hidden contribute zero width to Taffy layout
- reuse the already-computed paint border styles instead of rewalking declarations
- preserve declared widths for solid/dashed/dotted/double borders and logical edge ordering
- update regression coverage to distinguish declared widths from used layout widths

## Performance
- four branch checks per resolved node
- no allocation, Host protocol change, or additional declaration pass

## Validation
- cargo test -p whisker-style
- cargo test -p whisker --test surface_render_pipeline
- cargo clippy -p whisker-style -p whisker --all-targets -- -D warnings
- git diff --check