### PR TITLE
fix(style): validate composite colors consistently

### DIFF
--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -558,7 +558,7 @@ fn resolve_box_shadow(
             environment,
             property,
         )?),
-        color: component(&value.color).clone(),
+        color: crate::resolution::normalize_color_for(component(&value.color), property)?,
         inset: value.inset,
     })
 }
@@ -813,7 +813,8 @@ pub(crate) fn resolve_paint_style(
                 let StyleValue::Background(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_color = component(&value.color).clone();
+                paint.background_color =
+                    crate::resolution::normalize_color_for(component(&value.color), property)?;
                 paint.background_images = value
                     .layers
                     .iter()

--- a/crates/whisker-style/src/paint/tests.rs
+++ b/crates/whisker-style/src/paint/tests.rs
@@ -167,6 +167,18 @@ fn box_shadow_resolves_every_component_and_rejects_invalid_values() {
         }
         assert_eq!(resolve(StyleValue::BoxShadows(vec![invalid])), expected);
     }
+
+    let mut invalid_color = shadow;
+    invalid_color.color = ComponentValue::Value(ColorValue::Rgba {
+        red: 0,
+        green: 0,
+        blue: 0,
+        alpha: number(f32::NAN),
+    });
+    assert_eq!(
+        resolve(StyleValue::BoxShadows(vec![invalid_color])),
+        expected
+    );
 }
 
 #[test]
@@ -1454,6 +1466,29 @@ fn background_shorthand_resolves_layer_lists_and_empty_initials() {
     .unwrap();
     assert!(empty.computed().paint().background_images.is_empty());
     assert_eq!(empty.computed().paint().background_layers.len(), 1);
+
+    assert_eq!(
+        crate::resolve_style(
+            &SpecifiedStyle::new().push(
+                StyleProperty::Background,
+                StyleValue::Background(BackgroundValue {
+                    layers: Vec::new(),
+                    color: ColorValue::Rgba {
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                        alpha: number(f32::NAN),
+                    }
+                    .into(),
+                }),
+            ),
+            None,
+            StyleEnvironment::default(),
+        ),
+        Err(StyleResolutionError::InvalidPropertyValue(
+            StyleProperty::Background
+        ))
+    );
 
     let mut invalid_position = layer(
         "invalid-position",

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -818,7 +818,9 @@ fn resolve_style_once(
             style: *style,
             color: decoration_color
                 .as_ref()
-                .map(|color| normalize_color(resolved_component(color)))
+                .map(|color| {
+                    normalize_color_for(resolved_component(color), StyleProperty::TextDecoration)
+                })
                 .transpose()?
                 .unwrap_or_else(|| color.clone()),
         },
@@ -860,7 +862,7 @@ fn resolve_style_once(
                 offset_x: StyleNumber::new(offset_x),
                 offset_y: StyleNumber::new(offset_y),
                 blur_radius: StyleNumber::new(blur_radius),
-                color: normalize_color(resolved_component(color))?,
+                color: normalize_color_for(resolved_component(color), StyleProperty::TextShadow)?,
             })
         }
         Some(_) => return Err(wrong_type(StyleProperty::TextShadow)),

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -795,7 +795,7 @@ fn text_shadow_resolves_inherits_clears_and_rejects_negative_blur() {
     );
     assert_eq!(
         resolve_text_style(&invalid_color, None, environment).unwrap_err(),
-        StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
     );
 }
 
@@ -847,7 +847,7 @@ fn text_decoration_resolves_current_color_and_inherits() {
     );
     assert_eq!(
         resolve_text_style(&invalid_color, None, environment).unwrap_err(),
-        StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::TextDecoration)
     );
 }
 


### PR DESCRIPTION
## Summary
- normalize background shorthand and box-shadow colors before Host lowering
- attribute text-shadow and text-decoration color failures to their owning property
- add regressions for non-finite alpha values in composite colors

## Performance
Uses the existing allocation-free color validation path during style resolution. Frame sampling and Host hot paths are unchanged.

## Validation
- cargo test -p whisker-style
- cargo clippy -p whisker-style --all-targets -- -D warnings
- git diff --check