### PR TITLE
fix(style): sample jump-start boundaries correctly

### DIFF
--- a/crates/whisker-style/src/motion.rs
+++ b/crates/whisker-style/src/motion.rs
@@ -80,7 +80,9 @@ impl MotionEasing {
             Self::Steps { count, position } => {
                 let count = count as f32;
                 match position {
-                    MotionStepPosition::JumpStart => (progress * count).ceil() / count,
+                    MotionStepPosition::JumpStart => {
+                        ((progress * count).floor() + 1.0).min(count) / count
+                    }
                     MotionStepPosition::JumpEnd => (progress * count).floor() / count,
                     MotionStepPosition::JumpNone => {
                         ((progress * count).floor() / (count - 1.0)).clamp(0.0, 1.0)
@@ -925,8 +927,32 @@ mod tests {
                 count: 4,
                 position: MotionStepPosition::JumpStart,
             }
+            .sample(0.0),
+            0.25
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
             .sample(0.49),
             0.5
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
+            .sample(0.5),
+            0.75
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
+            .sample(1.0),
+            1.0
         );
         assert_eq!(
             MotionEasing::Steps {


### PR DESCRIPTION
## Summary
- implement CSS `steps(n, jump-start)` boundary semantics
- preserve the terminal value at progress 1
- add coverage for start, interior boundary, and end samples

## Performance
Replaces `ceil` with `floor`, one addition, and a clamp; no allocation or state is added.

## Validation
- cargo test -p whisker-style
- cargo clippy -p whisker-style --all-targets -- -D warnings
- git diff --check