### PR TITLE
fix(style): align calc length semantics

### DIFF
--- a/crates/whisker-engine/src/text.rs
+++ b/crates/whisker-engine/src/text.rs
@@ -134,6 +134,13 @@ pub fn lower_plain_text(input: &PlainTextInput, style: &ComputedStyle) -> Lowere
                 logical_pixels: 0.0,
                 percentage: value.get(),
             },
+            ComputedTextIndent::LengthPercentage {
+                logical_pixels,
+                percentage,
+            } => MeasureTextIndent {
+                logical_pixels: logical_pixels.get(),
+                percentage: percentage.get(),
+            },
         },
         wrap: match style.white_space() {
             WhiteSpaceValue::Normal => MeasureTextWrap::Wrap,
@@ -250,10 +257,10 @@ mod tests {
     use super::*;
     use whisker_protocol::PaintColor;
     use whisker_style::{
-        ColorValue, FontFeatureValue, FontOpticalSizingValue, FontVariationValue, FontWeightValue,
-        LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, OpenTypeTagValue,
-        SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber, StyleProperty, StyleValue,
-        TextDecorationValue, TextShadowValue, resolve_style,
+        CalcExpression, ColorValue, FontFeatureValue, FontOpticalSizingValue, FontVariationValue,
+        FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
+        OpenTypeTagValue, SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber,
+        StyleProperty, StyleValue, TextDecorationValue, TextShadowValue, resolve_style,
     };
 
     fn resolved(declarations: Vec<StyleDeclaration>) -> whisker_style::ResolvedNodeStyle {
@@ -514,6 +521,26 @@ mod tests {
         let percentage = lower_plain_text(&input, percentage.computed());
         assert_eq!(percentage.content().payload.indent.logical_pixels, 0.0);
         assert_eq!(percentage.content().payload.indent.percentage, 15.0);
+
+        let calculated = resolved(vec![StyleDeclaration::new(
+            StyleProperty::TextIndent,
+            StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                CalcExpression::Add(
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Length(LengthValue::Dimension {
+                            value: StyleNumber::new(4.0),
+                            unit: LengthUnit::Px,
+                        }),
+                    ))),
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Percentage(StyleNumber::new(10.0)),
+                    ))),
+                ),
+            ))),
+        )]);
+        let calculated = lower_plain_text(&input, calculated.computed());
+        assert_eq!(calculated.content().payload.indent.logical_pixels, 4.0);
+        assert_eq!(calculated.content().payload.indent.percentage, 10.0);
     }
 
     #[test]

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -107,6 +107,13 @@ pub enum ComputedTextIndent {
     LogicalPixels(StyleNumber),
     /// Percentage number before the `%` suffix.
     Percentage(StyleNumber),
+    /// Mixed fixed and percentage components produced by `calc()`.
+    LengthPercentage {
+        /// Fixed logical-pixel component.
+        logical_pixels: StyleNumber,
+        /// Percentage number before the `%` suffix.
+        percentage: StyleNumber,
+    },
 }
 
 impl Default for ComputedTextIndent {
@@ -887,9 +894,27 @@ fn resolve_style_once(
                 StyleProperty::TextIndent,
             )?))
         }
-        Some(StyleValue::LengthPercentage(LengthPercentageValue::Calc(_))) | Some(_) => {
-            return Err(wrong_type(StyleProperty::TextIndent));
+        Some(StyleValue::LengthPercentage(value @ LengthPercentageValue::Calc(_))) => {
+            let value = crate::layout::resolve_affine(
+                value,
+                font_size.get(),
+                environment,
+                StyleProperty::TextIndent,
+            )?;
+            let logical_pixels = value.length();
+            let percentage = value.fraction() * 100.0;
+            if percentage == 0.0 {
+                ComputedTextIndent::LogicalPixels(StyleNumber::new(logical_pixels))
+            } else if logical_pixels == 0.0 {
+                ComputedTextIndent::Percentage(StyleNumber::new(percentage))
+            } else {
+                ComputedTextIndent::LengthPercentage {
+                    logical_pixels: StyleNumber::new(logical_pixels),
+                    percentage: StyleNumber::new(percentage),
+                }
+            }
         }
+        Some(_) => return Err(wrong_type(StyleProperty::TextIndent)),
         None => ComputedTextIndent::default(),
     };
     let local_text_value = |property| {

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -416,7 +416,6 @@ fn calc_evaluates_scalar_branches_and_rejects_invalid_dimensions() {
         CalcExpression::Sub(Box::new(scalar(3.0)), Box::new(scalar(1.0))),
         CalcExpression::Mul(Box::new(scalar(2.0)), Box::new(scalar(3.0))),
         CalcExpression::Div(Box::new(scalar(6.0)), Box::new(scalar(2.0))),
-        CalcExpression::Div(Box::new(length()), Box::new(length())),
     ] {
         evaluate_calc(
             &expression,
@@ -431,6 +430,7 @@ fn calc_evaluates_scalar_branches_and_rejects_invalid_dimensions() {
         CalcExpression::Add(Box::new(scalar(1.0)), Box::new(length())),
         CalcExpression::Sub(Box::new(length()), Box::new(scalar(1.0))),
         CalcExpression::Mul(Box::new(length()), Box::new(length())),
+        CalcExpression::Div(Box::new(length()), Box::new(length())),
         CalcExpression::Div(Box::new(scalar(1.0)), Box::new(length())),
         CalcExpression::Div(Box::new(length()), Box::new(scalar(0.0))),
         CalcExpression::Div(
@@ -586,7 +586,7 @@ fn direction_resolves_and_inherits_into_layout_and_text_context() {
 }
 
 #[test]
-fn text_indent_resolves_length_and_percentage_without_inheriting() {
+fn text_indent_resolves_length_percentage_and_calc_without_inheriting() {
     let environment = StyleEnvironment::default();
     let length = resolve_text_style(
         &declaration(
@@ -618,6 +618,31 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
         percentage.computed().text_indent(),
         ComputedTextIndent::Percentage(number(-15.0))
     );
+    let calculated = resolve_text_style(
+        &declaration(
+            StyleProperty::TextIndent,
+            StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                CalcExpression::Add(
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Length(px(4.0)),
+                    ))),
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Percentage(number(10.0)),
+                    ))),
+                ),
+            ))),
+        ),
+        Some(length.inherited_for_children()),
+        environment,
+    )
+    .unwrap();
+    assert_eq!(
+        calculated.computed().text_indent(),
+        ComputedTextIndent::LengthPercentage {
+            logical_pixels: number(4.0),
+            percentage: number(10.0),
+        }
+    );
     let child = resolve_text_style(
         &SpecifiedStyle::new(),
         Some(length.inherited_for_children()),
@@ -635,7 +660,6 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
             unit: LengthUnit::Em,
         }),
         LengthPercentageValue::Percentage(number(f32::NAN)),
-        LengthPercentageValue::Calc(Box::new(CalcExpression::Number(number(1.0)))),
     ] {
         assert_eq!(
             resolve_text_style(
@@ -650,6 +674,20 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
             StyleResolutionError::InvalidPropertyValue(StyleProperty::TextIndent)
         );
     }
+    assert_eq!(
+        resolve_text_style(
+            &declaration(
+                StyleProperty::TextIndent,
+                StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                    CalcExpression::Number(number(1.0)),
+                ))),
+            ),
+            None,
+            environment,
+        )
+        .unwrap_err(),
+        StyleResolutionError::InvalidCalculation(StyleProperty::TextIndent)
+    );
 }
 
 #[test]

--- a/crates/whisker-style/src/resolution/values.rs
+++ b/crates/whisker-style/src/resolution/values.rs
@@ -193,17 +193,13 @@ pub(super) fn evaluate_calc(
             let left = evaluate_calc(left, percentage_basis, em_basis, environment, property)?;
             let right = evaluate_calc(right, percentage_basis, em_basis, environment, property)?;
             match (left, right) {
-                (_, Quantity::Number(0.0)) | (_, Quantity::Length(0.0)) => Err(invalid()),
+                (_, Quantity::Number(0.0)) | (_, Quantity::Length(_)) => Err(invalid()),
                 (Quantity::Number(left), Quantity::Number(right)) => {
                     Ok(Quantity::Number(left / right))
                 }
                 (Quantity::Length(left), Quantity::Number(right)) => {
                     Ok(Quantity::Length(left / right))
                 }
-                (Quantity::Length(left), Quantity::Length(right)) => {
-                    Ok(Quantity::Number(left / right))
-                }
-                (Quantity::Number(_), Quantity::Length(_)) => Err(invalid()),
             }
         }
     }


### PR DESCRIPTION
## Summary
- reject dimension-divisor expressions consistently across calc evaluators
- accept typed calc expressions for text-indent
- preserve mixed length/percentage indent components through text measurement
- keep direct length and percentage paths unchanged

## Performance
Plain length and percentage values retain their existing branches. Only calc-based text-indent evaluates an affine expression; no per-frame work or allocation is added.

## Validation
- cargo test -p whisker-style
- cargo test -p whisker-engine
- cargo clippy -p whisker-style -p whisker-engine --all-targets -- -D warnings
- git diff --check