### PR TITLE
fix(style): require length-only border widths

### DIFF
--- a/crates/whisker-style/src/layout/resolution.rs
+++ b/crates/whisker-style/src/layout/resolution.rs
@@ -257,22 +257,6 @@ pub(super) fn resolve_optional_length_percentage(
     }
 }
 
-pub(super) fn resolve_non_negative_length_percentage(
-    value: Option<&StyleValue>,
-    initial: ComputedLengthPercentage,
-    font_size: f32,
-    environment: StyleEnvironment,
-    property: StyleProperty,
-) -> Result<ComputedLengthPercentage, StyleResolutionError> {
-    let resolved =
-        resolve_optional_length_percentage(value, initial, font_size, environment, property)?;
-    if resolved.length() < 0.0 || resolved.fraction() < 0.0 {
-        Err(invalid(property))
-    } else {
-        Ok(resolved)
-    }
-}
-
 pub(super) fn resolve_insets(
     specified: &SpecifiedStyle,
     direction: DirectionValue,
@@ -341,15 +325,45 @@ pub(super) fn resolve_borders(
             }
             _ => continue,
         };
-        *edge = resolve_non_negative_length_percentage(
-            Some(declaration.value()),
-            *edge,
-            font_size,
-            environment,
-            property,
-        )?;
+        let resolved = match declaration.value() {
+            StyleValue::Length(value) => resolve_affine(
+                &LengthPercentageValue::Length(*value),
+                font_size,
+                environment,
+                property,
+            )?,
+            StyleValue::LengthPercentage(value) if is_length_only(value) => {
+                resolve_affine(value, font_size, environment, property)?
+            }
+            _ => return Err(invalid(property)),
+        };
+        if resolved.length() < 0.0 {
+            return Err(invalid(property));
+        }
+        *edge = resolved;
     }
     Ok(border)
+}
+
+fn is_length_only(value: &LengthPercentageValue) -> bool {
+    match value {
+        LengthPercentageValue::Length(_) => true,
+        LengthPercentageValue::Percentage(_) => false,
+        LengthPercentageValue::Calc(expression) => calc_is_length_only(expression),
+    }
+}
+
+fn calc_is_length_only(expression: &CalcExpression) -> bool {
+    match expression {
+        CalcExpression::Value(value) => is_length_only(value),
+        CalcExpression::Number(_) | CalcExpression::Variable(_) => true,
+        CalcExpression::Add(left, right)
+        | CalcExpression::Sub(left, right)
+        | CalcExpression::Mul(left, right)
+        | CalcExpression::Div(left, right) => {
+            calc_is_length_only(left) && calc_is_length_only(right)
+        }
+    }
 }
 
 pub(super) fn resolve_non_negative_number(

--- a/crates/whisker-style/src/layout/tests.rs
+++ b/crates/whisker-style/src/layout/tests.rs
@@ -579,7 +579,7 @@ fn complete_box_and_flex_style_resolves_without_backend_types() {
         )
         .push(
             StyleProperty::BorderBottomWidth,
-            StyleValue::LengthPercentage(percent(3.0)),
+            StyleValue::LengthPercentage(px(3.0)),
         )
         .push(
             StyleProperty::BorderLeftWidth,
@@ -649,7 +649,7 @@ fn complete_box_and_flex_style_resolves_without_backend_types() {
     assert_eq!(style.padding.bottom.fraction(), 0.07);
     assert_eq!(style.border.top.length(), 1.0);
     assert_eq!(style.border.right.length(), 2.0);
-    assert_eq!(style.border.bottom.fraction(), 0.03);
+    assert_eq!(style.border.bottom.length(), 3.0);
     assert_eq!(style.border.left.length(), 4.0);
     assert_eq!(style.flex_direction, FlexDirectionValue::Column);
     assert_eq!(style.flex_wrap, FlexWrapValue::Wrap);
@@ -972,6 +972,43 @@ fn invalid_numbers_are_rejected_or_clamped_by_property_semantics() {
     }
     assert_eq!(AspectRatioValue::new(4.0, 3.0).width(), 4.0);
     assert_eq!(AspectRatioValue::new(4.0, 3.0).height(), 3.0);
+}
+
+#[test]
+fn border_width_accepts_lengths_and_rejects_percentage_components() {
+    let property = StyleProperty::BorderTopWidth;
+    let pure_length = LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+        Box::new(CalcExpression::Value(Box::new(px(2.0)))),
+        Box::new(CalcExpression::Value(Box::new(px(3.0)))),
+    )));
+    assert_eq!(
+        resolve(&declaration(
+            property,
+            StyleValue::LengthPercentage(pure_length),
+        ))
+        .unwrap()
+        .border
+        .top
+        .length(),
+        5.0
+    );
+
+    for value in [
+        percent(10.0),
+        LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+            Box::new(CalcExpression::Value(Box::new(px(2.0)))),
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+        ))),
+        LengthPercentageValue::Calc(Box::new(CalcExpression::Sub(
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+        ))),
+    ] {
+        assert_eq!(
+            resolve(&declaration(property, StyleValue::LengthPercentage(value),)),
+            Err(StyleResolutionError::InvalidPropertyValue(property))
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- reject percentage components in border-width declarations
- retain typed calc support when the entire expression is length-only
- reject percentages even when arithmetic would cancel their final coefficient
- remove the now-unused generic non-negative length-percentage helper

## Performance
Direct lengths keep a constant-time, allocation-free path. Only calc expressions receive a recursive type check, with no cloning or allocation.

## Validation
- cargo test -p whisker-style
- cargo clippy -p whisker-style --all-targets -- -D warnings
- git diff --check