### PR TITLE
perf(protocol): bound retired node tracking

### DIFF
--- a/crates/whisker-protocol/src/id.rs
+++ b/crates/whisker-protocol/src/id.rs
@@ -28,7 +28,7 @@ define_id!(
 define_id!(
     NodeId,
     u64,
-    "Identifies one scene node within a scene epoch"
+    "Identifies one scene node; allocations strictly increase within a scene epoch"
 );
 define_id!(
     ElementTypeId,

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -1,6 +1,6 @@
 //! Transactional reference validation for semantic frame packets.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
@@ -88,10 +88,12 @@ pub enum ValidationError {
         /// Reused scene epoch.
         epoch: u32,
     },
-    /// Node identifier was created more than once in one epoch.
-    DuplicateNode {
-        /// Duplicate identifier.
-        node: NodeId,
+    /// A created node identifier did not strictly advance within its epoch.
+    NodeIdDidNotAdvance {
+        /// Highest identifier accepted in this epoch.
+        previous: NodeId,
+        /// Non-advancing identifier received next.
+        received: NodeId,
     },
     /// An operation referenced a node that does not exist at that point.
     UnknownNode {
@@ -168,7 +170,7 @@ pub struct SceneProjection {
     scene_epoch: Option<u32>,
     revision: u64,
     nodes: HashMap<NodeId, NodeProjection>,
-    allocated_nodes: HashSet<NodeId>,
+    last_allocated_node: Option<NodeId>,
 }
 
 impl SceneProjection {
@@ -179,7 +181,7 @@ impl SceneProjection {
             scene_epoch: None,
             revision: 0,
             nodes: HashMap::new(),
-            allocated_nodes: HashSet::new(),
+            last_allocated_node: None,
         }
     }
 
@@ -210,7 +212,7 @@ impl SceneProjection {
 
     #[cfg(test)]
     fn allocation_tracking_entries(&self) -> usize {
-        self.allocated_nodes.len()
+        usize::from(self.last_allocated_node.is_some())
     }
 
     /// Validates and atomically applies a packet.
@@ -296,9 +298,15 @@ impl SceneProjection {
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), ValidationError> {
         match operation {
             Operation::CreateNode { node, element_type } => {
-                if !self.allocated_nodes.insert(*node) {
-                    return Err(ValidationError::DuplicateNode { node: *node });
+                if let Some(previous) = self.last_allocated_node
+                    && *node <= previous
+                {
+                    return Err(ValidationError::NodeIdDidNotAdvance {
+                        previous,
+                        received: *node,
+                    });
                 }
+                self.last_allocated_node = Some(*node);
                 self.nodes.insert(
                     *node,
                     NodeProjection {
@@ -528,27 +536,24 @@ impl SceneProjection {
 struct ProjectionTransaction<'a> {
     projection: &'a mut SceneProjection,
     original_nodes: HashMap<NodeId, Option<NodeProjection>>,
-    newly_allocated: Vec<NodeId>,
+    initial_last_allocated_node: Option<NodeId>,
 }
 
 impl<'a> ProjectionTransaction<'a> {
     fn new(projection: &'a mut SceneProjection) -> Self {
+        let initial_last_allocated_node = projection.last_allocated_node;
         Self {
             projection,
             original_nodes: HashMap::new(),
-            newly_allocated: Vec::new(),
+            initial_last_allocated_node,
         }
     }
 
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), ValidationError> {
         match operation {
             Operation::CreateNode { node, .. } => {
-                if self.projection.allocated_nodes.contains(node) {
-                    return Err(ValidationError::DuplicateNode { node: *node });
-                }
                 self.remember(*node);
                 self.projection.apply_operation(operation)?;
-                self.newly_allocated.push(*node);
             }
             Operation::DeleteNode { node } => {
                 self.remember_subtree(*node)?;
@@ -601,9 +606,7 @@ impl<'a> ProjectionTransaction<'a> {
                 }
             }
         }
-        for node in self.newly_allocated {
-            self.projection.allocated_nodes.remove(&node);
-        }
+        self.projection.last_allocated_node = self.initial_last_allocated_node;
     }
 
     fn commit(self, scene_epoch: u32, revision: u64) {
@@ -926,7 +929,13 @@ mod tests {
                 }],
             ))
             .expect_err("retired ID must remain unavailable");
-        assert_eq!(error, ValidationError::DuplicateNode { node: child });
+        assert_eq!(
+            error,
+            ValidationError::NodeIdDidNotAdvance {
+                previous: child,
+                received: child,
+            }
+        );
         assert_eq!(scene.revision(), 2);
         assert!(scene.node(child).is_none());
     }
@@ -947,6 +956,39 @@ mod tests {
 
         assert_eq!(scene.node_count(), 2);
         assert_eq!(scene.allocation_tracking_entries(), 1);
+    }
+
+    #[test]
+    fn node_allocations_must_strictly_increase_within_an_epoch() {
+        let mut scene = SceneProjection::new(surface());
+        let error = scene
+            .apply(&packet(
+                FrameMode::Snapshot,
+                1,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: node(2),
+                        element_type: element_type(),
+                    },
+                    Operation::CreateNode {
+                        node: node(1),
+                        element_type: element_type(),
+                    },
+                ],
+            ))
+            .expect_err("out-of-order node IDs must be rejected");
+
+        assert_eq!(
+            error,
+            ValidationError::NodeIdDidNotAdvance {
+                previous: node(2),
+                received: node(1),
+            }
+        );
+        assert_eq!(scene.revision(), 0);
+        assert_eq!(scene.node_count(), 0);
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -208,6 +208,11 @@ impl SceneProjection {
         self.nodes.get(&node)
     }
 
+    #[cfg(test)]
+    fn allocation_tracking_entries(&self) -> usize {
+        self.allocated_nodes.len()
+    }
+
     /// Validates and atomically applies a packet.
     ///
     /// Revision or epoch drift on a delta returns [`ApplyResult::NeedSnapshot`]
@@ -924,6 +929,24 @@ mod tests {
         assert_eq!(error, ValidationError::DuplicateNode { node: child });
         assert_eq!(scene.revision(), 2);
         assert!(scene.node(child).is_none());
+    }
+
+    #[test]
+    fn retired_node_tracking_is_constant_space() {
+        let (mut scene, _, _) = initial_tree();
+        let mut operations = Vec::new();
+        for raw in 3..259 {
+            let retired = node(raw);
+            operations.push(Operation::CreateNode {
+                node: retired,
+                element_type: element_type(),
+            });
+            operations.push(Operation::DeleteNode { node: retired });
+        }
+        apply_next(&mut scene, operations).expect("monotonic allocation sequence");
+
+        assert_eq!(scene.node_count(), 2);
+        assert_eq!(scene.allocation_tracking_entries(), 1);
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -520,7 +520,6 @@ impl SceneProjection {
                 .children;
             siblings.retain(|candidate| *candidate != node);
         }
-
         let mut pending = vec![node];
         while let Some(current) = pending.pop() {
             let state = self

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -887,8 +887,9 @@ resource channel once and are not embedded into every frame transaction.
 
 Structural operations must establish a node before later operations reference
 it. Deleting a subtree invalidates its Host handles, subscriptions, pending
-commands, and element-instance state. A `NodeId` is not reused within the same
-scene epoch.
+commands, and element-instance state. `CreateNode` identifiers strictly
+increase within one scene epoch, so a `NodeId` is never reused and receivers
+can validate retirement with a constant-space high-water mark.
 
 ### Incremental updates
 


### PR DESCRIPTION
## Summary
- formalize strictly increasing `CreateNode` IDs within a scene epoch
- replace the unbounded retired-ID HashSet with one high-water mark
- restore the watermark when a delta transaction is rejected
- diagnose out-of-order IDs explicitly

## Root cause
The reference projection retained every created ID until the epoch ended, so memory grew with lifetime allocation count rather than live scene size. Whisker Engine already allocates monotonically.

## Performance
Retired-ID tracking is constant space and creation validation is one integer comparison. The per-create transaction Vec introduced by #585 is also removed.

## Dependency
Stacked on #585 because both change `SceneProjection` transaction handling. After #585 merges this PR can be retargeted to `next-architecture` without carrying unrelated changes.

## Validation
- red/green regression: `cargo test -p whisker-protocol validation::tests::retired_node_tracking_is_constant_space -- --exact` (258 entries before, 1 after)
- cargo test -p whisker-protocol
- cargo clippy -p whisker-protocol --all-targets -- -D warnings
- git diff --check