### PR TITLE
ci: enforce the actual Rust 1.88 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,16 @@ jobs:
           RUSTFLAGS: ""
 
   msrv:
-    name: MSRV (rust 1.85)
+    name: MSRV (rust 1.88)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       # The version here must match `rust-version` in the root
       # Cargo.toml's `[workspace.package]`. If you bump one, bump both.
-      - uses: dtolnay/rust-toolchain@1.85.0
+      - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --workspace --all-targets
+      # `+version` takes precedence over the repository's stable toolchain file.
+      - run: cargo +1.88.0 check --workspace --all-targets
 
   deny:
     name: cargo deny (advisories / bans / sources)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ exclude = [
 [workspace.package]
 version = "0.12.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/whiskerrs/whisker"
 homepage = "https://whisker.rs"

--- a/crates/whisker-macros/src/component.rs
+++ b/crates/whisker-macros/src/component.rs
@@ -840,12 +840,13 @@ fn option_inner_type(ty: &Type) -> Option<&Type> {
 /// matches bare-ident path types (`T`, not `Option<T>` or
 /// `Vec<T>`).
 fn is_generic_type_param(ty: &Type, generic_type_params: &[Ident]) -> bool {
-    if let Type::Path(tp) = ty {
-        if tp.qself.is_none() && tp.path.segments.len() == 1 {
-            let seg = &tp.path.segments[0];
-            if seg.arguments.is_empty() {
-                return generic_type_params.contains(&seg.ident);
-            }
+    if let Type::Path(tp) = ty
+        && tp.qself.is_none()
+        && tp.path.segments.len() == 1
+    {
+        let seg = &tp.path.segments[0];
+        if seg.arguments.is_empty() {
+            return generic_type_params.contains(&seg.ident);
         }
     }
     false

--- a/deny.toml
+++ b/deny.toml
@@ -25,7 +25,7 @@ yanked = "deny"
 #     macOS text shaping and rasterization. Both advisories report
 #     unmaintained crates, not vulnerabilities. glyphon 0.10 moves to
 #     harfrust/skrifa through cosmic-text 0.15, but also requires wgpu 28
-#     (Rust 1.92), beyond the workspace's Rust 1.85 floor. Revisit when a
+#     (Rust 1.92), beyond the workspace's Rust 1.88 floor. Revisit when a
 #     compatible glyphon/wgpu release lets us remove both exceptions.
 #
 # Vulnerability accepted with rationale (no compatible fixed version):
@@ -40,10 +40,8 @@ yanked = "deny"
 #     zbus-xml 5.1 <- zbus-lockstep <- AccessKit's Linux AT-SPI backend.
 #     This path parses only the upstream AT-SPI crate's checked-in interface
 #     XML from cfg(test) lockstep checks; Whisker's runtime does not feed it
-#     external XML. quick-xml 0.41 is available only through zbus releases
-#     requiring Rust 1.87, above the workspace's Rust 1.85 floor. Revisit when
-#     zbus ships a fixed release that preserves Rust 1.85 support, or when the
-#     workspace MSRV is raised.
+#     external XML. The current AccessKit dependency graph still resolves
+#     zbus-lockstep to quick-xml 0.38; revisit when that graph upgrades.
 #   RUSTSEC-2026-0002 / RUSTSEC-2026-0253  lru 0.12.5 <- glyphon 0.9 and
 #     ratatui 0.29. Whisker's own image cache uses fixed lru >=0.18.2.
 #     The remaining transitive callers do not use the affected IterMut or


### PR DESCRIPTION
## Summary
- raise the workspace MSRV from 1.85 to 1.88 to match used language features
- pin the MSRV job to Rust 1.88.0 explicitly
- invoke Cargo with `+1.88.0` so `rust-toolchain.toml` cannot silently select stable
- refresh dependency exception rationale for the new floor

## Runtime impact
None. This changes compiler compatibility declarations and CI only.

## Validation
- `cargo +1.88.0 check --workspace --all-targets` (passed locally in 30m02s)
- `cargo +1.88.0 check -p whisker-protocol`
- `cargo +1.88.0 metadata --no-deps --format-version 1` reports `rust_version: 1.88`
- cargo fmt --all --check
- git diff --check