### PR TITLE
fix(ci): check the canonical iOS SDK pin

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           fail=0
           if ! grep -q "WHISKER_IOS_SPM_VERSION: &str = \"$VERSION\"" \
-               crates/whisker-build/src/ios.rs; then
-            echo "::error file=crates/whisker-build/src/ios.rs::WHISKER_IOS_SPM_VERSION is not $VERSION"
+               crates/whisker-cng/src/ios_modules.rs; then
+            echo "::error file=crates/whisker-cng/src/ios_modules.rs::WHISKER_IOS_SPM_VERSION is not $VERSION"
             fail=1
           fi
           for manifest in packages/*/Package.swift; do


### PR DESCRIPTION
## Summary
- make the iOS publish gate inspect the canonical CNG-owned SDK version
- report release annotation errors against the actual source file

## Root cause
`WHISKER_IOS_SPM_VERSION` moved to `whisker-cng`, while the workflow continued grepping its `whisker-build` re-export. A release therefore failed even when the canonical pin was correct.

## Runtime impact
None. This only repairs the release workflow.

## Validation
- confirmed the old-path grep fails for the current 0.1.12 pin
- confirmed the canonical-owner grep succeeds
- git diff --check

`actionlint` is not installed locally; GitHub Actions will validate workflow syntax.