### PR TITLE
fix(hosts): render radial gradient variants

### DIFF
--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 29
+#define WHISKER_MOBILE_ABI_MINOR 30
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -65,6 +65,8 @@
 #define WHISKER_CAPABILITY_BACKGROUND_IMAGE_RESOURCES 8192
 
 #define WHISKER_CAPABILITY_BACKDROP_BLUR 16384
+
+#define WHISKER_CAPABILITY_RADIAL_GRADIENT_VARIANTS 32768
 
 #define WHISKER_POINTER_DOWN 0
 
@@ -161,6 +163,20 @@
 #define WHISKER_BACKGROUND_CONIC 2
 
 #define WHISKER_BACKGROUND_RESOURCE 3
+
+#define WHISKER_RADIAL_SHAPE_CIRCLE 0
+
+#define WHISKER_RADIAL_SHAPE_ELLIPSE 1
+
+#define WHISKER_RADIAL_EXTENT_CLOSEST_SIDE 0
+
+#define WHISKER_RADIAL_EXTENT_FARTHEST_SIDE 1
+
+#define WHISKER_RADIAL_EXTENT_CLOSEST_CORNER 2
+
+#define WHISKER_RADIAL_EXTENT_FARTHEST_CORNER 3
+
+#define WHISKER_RADIAL_EXTENT_EXPLICIT 4
 
 #define WHISKER_BACKGROUND_SIZE_AUTO 0
 
@@ -667,9 +683,11 @@ typedef struct WhiskerMobileGradientStop {
 } WhiskerMobileGradientStop;
 
 /**
- * One explicit, non-repeating elliptical radial gradient.
+ * One resolved, non-repeating radial gradient.
  */
 typedef struct WhiskerMobileRadialGradient {
+  uint32_t shape;
+  uint32_t extent;
   struct WhiskerMobileLengthPercentage center_x;
   struct WhiskerMobileLengthPercentage center_y;
   struct WhiskerMobileLengthPercentage radius_x;

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -451,9 +451,13 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                             ok = false; break;
                         }
                         const WhiskerMobileRadialGradient* radial = layer->image.payload;
+                        if (radial->shape > WHISKER_RADIAL_SHAPE_ELLIPSE ||
+                            radial->extent > WHISKER_RADIAL_EXTENT_EXPLICIT) {
+                            ok = false; break;
+                        }
                         stops = radial->stops;
                         stop_count = radial->stop_count;
-                        image_prefix_count = 8;
+                        image_prefix_count = 10;
                     } else if (layer->image.kind == WHISKER_BACKGROUND_CONIC) {
                         if (layer->image.payload == NULL || layer->image.payload_count != 1) {
                             ok = false; break;
@@ -509,7 +513,7 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                         radial = layer->image.payload;
                         stops = radial->stops;
                         stop_count = radial->stop_count;
-                        image_prefix_count = 8;
+                        image_prefix_count = 10;
                     } else if (layer->image.kind == WHISKER_BACKGROUND_CONIC) {
                         conic = layer->image.payload;
                         stops = conic->stops;
@@ -541,6 +545,8 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
                     values[cursor++] = (float)layer->attachment;
                     values[cursor++] = (float)layer->blend_mode;
                     if (radial != NULL) {
+                        values[cursor++] = (float)radial->shape;
+                        values[cursor++] = (float)radial->extent;
                         const WhiskerMobileLengthPercentage* coordinates[] = {
                             &radial->center_x, &radial->center_y,
                             &radial->radius_x, &radial->radius_y

--- a/crates/whisker-driver-sys/src/mobile.rs
+++ b/crates/whisker-driver-sys/src/mobile.rs
@@ -8,7 +8,7 @@ use std::ffi::c_void;
 use crate::{WhiskerBytesRef, WhiskerStringRef, WhiskerValueRaw};
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 29;
+pub const MOBILE_ABI_MINOR: u16 = 30;
 pub const FRAME_PROTOCOL_MAJOR: u16 = 1;
 pub const FRAME_PROTOCOL_MINOR: u16 = 4;
 
@@ -26,6 +26,7 @@ pub const CAPABILITY_BACKGROUND_GEOMETRY: u64 = 0x0800;
 pub const CAPABILITY_BACKGROUND_LAYER_STACKING: u64 = 0x1000;
 pub const CAPABILITY_BACKGROUND_IMAGE_RESOURCES: u64 = 0x2000;
 pub const CAPABILITY_BACKDROP_BLUR: u64 = 0x4000;
+pub const CAPABILITY_RADIAL_GRADIENT_VARIANTS: u64 = 0x8000;
 
 pub const POINTER_DOWN: u32 = 0;
 pub const POINTER_MOVE: u32 = 1;
@@ -80,6 +81,14 @@ pub const BACKGROUND_LINEAR: u32 = 0;
 pub const BACKGROUND_RADIAL: u32 = 1;
 pub const BACKGROUND_CONIC: u32 = 2;
 pub const BACKGROUND_RESOURCE: u32 = 3;
+
+pub const RADIAL_SHAPE_CIRCLE: u32 = 0;
+pub const RADIAL_SHAPE_ELLIPSE: u32 = 1;
+pub const RADIAL_EXTENT_CLOSEST_SIDE: u32 = 0;
+pub const RADIAL_EXTENT_FARTHEST_SIDE: u32 = 1;
+pub const RADIAL_EXTENT_CLOSEST_CORNER: u32 = 2;
+pub const RADIAL_EXTENT_FARTHEST_CORNER: u32 = 3;
+pub const RADIAL_EXTENT_EXPLICIT: u32 = 4;
 
 pub const BACKGROUND_SIZE_AUTO: u32 = 0;
 pub const BACKGROUND_SIZE_EXPLICIT: u32 = 1;
@@ -281,10 +290,12 @@ pub struct MobileGradientStop {
     pub position: MobileLengthPercentage,
 }
 
-/// One explicit, non-repeating elliptical radial gradient.
+/// One resolved, non-repeating radial gradient.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct MobileRadialGradient {
+    pub shape: u32,
+    pub extent: u32,
     pub center_x: MobileLengthPercentage,
     pub center_y: MobileLengthPercentage,
     pub radius_x: MobileLengthPercentage,
@@ -674,7 +685,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileClipPathCommands>(), 24);
             assert_eq!(std::mem::size_of::<MobileClipPath>(), 24);
             assert_eq!(std::mem::size_of::<MobileGradientStop>(), 40);
-            assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 48);
+            assert_eq!(std::mem::size_of::<MobileRadialGradient>(), 56);
             assert_eq!(std::mem::size_of::<MobileConicGradient>(), 32);
             assert_eq!(std::mem::size_of::<MobileBackgroundImage>(), 24);
             assert_eq!(std::mem::size_of::<MobileBackgroundLayer>(), 88);

--- a/crates/whisker-driver/src/ffi_runtime/frame.rs
+++ b/crates/whisker-driver/src/ffi_runtime/frame.rs
@@ -370,21 +370,43 @@ impl MobileFrameOwned {
                                     }
                                 }
                                 PaintImage::RadialGradient {
-                                    shape: RadialGradientShape::Ellipse,
-                                    extent: RadialGradientExtent::Explicit,
+                                    shape,
+                                    extent,
                                     center,
-                                    radii: Some((radius_x, radius_y)),
+                                    radii,
                                     repeating: false,
                                     stops,
                                 } => {
                                     let stops = mobile_gradient_stops(stops, &mut strings)?;
                                     gradient_stops.push(stops);
                                     let stops = gradient_stops.last().unwrap();
+                                    let (radius_x, radius_y) = radii.unwrap_or_default();
                                     radial_gradients.push(Box::new(MobileRadialGradient {
+                                        shape: match shape {
+                                            RadialGradientShape::Circle => RADIAL_SHAPE_CIRCLE,
+                                            RadialGradientShape::Ellipse => RADIAL_SHAPE_ELLIPSE,
+                                        },
+                                        extent: match extent {
+                                            RadialGradientExtent::ClosestSide => {
+                                                RADIAL_EXTENT_CLOSEST_SIDE
+                                            }
+                                            RadialGradientExtent::FarthestSide => {
+                                                RADIAL_EXTENT_FARTHEST_SIDE
+                                            }
+                                            RadialGradientExtent::ClosestCorner => {
+                                                RADIAL_EXTENT_CLOSEST_CORNER
+                                            }
+                                            RadialGradientExtent::FarthestCorner => {
+                                                RADIAL_EXTENT_FARTHEST_CORNER
+                                            }
+                                            RadialGradientExtent::Explicit => {
+                                                RADIAL_EXTENT_EXPLICIT
+                                            }
+                                        },
                                         center_x: mobile_coordinate(center.x),
                                         center_y: mobile_coordinate(center.y),
-                                        radius_x: mobile_length(*radius_x),
-                                        radius_y: mobile_length(*radius_y),
+                                        radius_x: mobile_length(radius_x),
+                                        radius_y: mobile_length(radius_y),
                                         stops: stops.as_ptr(),
                                         stop_count: stops.len(),
                                     }));

--- a/crates/whisker-driver/src/ffi_runtime/tests.rs
+++ b/crates/whisker-driver/src/ffi_runtime/tests.rs
@@ -149,6 +149,10 @@ fn mobile_capability_constants_match_the_semantic_protocol() {
             CAPABILITY_BACKGROUND_IMAGE_RESOURCES,
         ),
         (RenderCapability::BackdropBlur, CAPABILITY_BACKDROP_BLUR),
+        (
+            RenderCapability::RadialGradientVariants,
+            CAPABILITY_RADIAL_GRADIENT_VARIANTS,
+        ),
     ];
 
     assert_eq!(expected.len(), RenderCapability::ALL.len());
@@ -667,6 +671,48 @@ fn mobile_frame_exposes_background_layers_as_one_contiguous_slice() {
         unsafe { *layers[2].image.payload.cast::<u64>() },
         resource.get()
     );
+}
+
+#[test]
+fn mobile_frame_preserves_radial_shape_and_keyword_extent() {
+    let node = NodeId::new(1).unwrap();
+    let mut layer = linear_background("red");
+    layer.image = PaintImage::RadialGradient {
+        shape: RadialGradientShape::Circle,
+        extent: RadialGradientExtent::FarthestCorner,
+        center: PaintPosition::default(),
+        radii: None,
+        repeating: false,
+        stops: match linear_background("red").image {
+            PaintImage::LinearGradient { stops, .. } => stops,
+            _ => unreachable!(),
+        },
+    };
+    let packet = FramePacket {
+        header: FrameHeader {
+            version: ProtocolVersion::CURRENT,
+            surface: SurfaceId::new(1).unwrap(),
+            scene_epoch: 1,
+            frame_id: 1,
+            base_revision: 0,
+            target_revision: 1,
+            viewport_epoch: 1,
+            mode: FrameMode::Snapshot,
+        },
+        operations: vec![Operation::SetBackgroundLayers {
+            node,
+            layers: vec![layer],
+        }],
+    };
+
+    let frame = MobileFrameOwned::new(&packet).unwrap();
+    let operation = &frame._operations[0];
+    let layer = unsafe { &*operation.payload.cast::<MobileBackgroundLayer>() };
+    let radial = unsafe { &*layer.image.payload.cast::<MobileRadialGradient>() };
+    assert_eq!(radial.shape, RADIAL_SHAPE_CIRCLE);
+    assert_eq!(radial.extent, RADIAL_EXTENT_FARTHEST_CORNER);
+    assert_eq!(radial.radius_x.length, 0.0);
+    assert_eq!(radial.radius_y.length, 0.0);
 }
 
 #[test]

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -27,8 +27,8 @@ pub enum RenderCapability {
     /// One resolved, non-repeating linear-gradient background image using the
     /// initial layer geometry and explicit color-stop positions.
     LinearGradients = 8,
-    /// One resolved, non-repeating explicit radial-gradient background image
-    /// using the initial layer geometry and explicit color-stop positions.
+    /// One resolved, non-repeating radial-gradient background image using the
+    /// initial layer geometry and explicit color-stop positions.
     RadialGradients = 9,
     /// One resolved, non-repeating conic-gradient background image using the
     /// initial layer geometry and explicit fractional color-stop positions.
@@ -42,11 +42,13 @@ pub enum RenderCapability {
     BackgroundImageResources = 13,
     /// Blur applied to pixels already painted behind a node.
     BackdropBlur = 14,
+    /// Circle shapes and keyword extents for otherwise supported radial gradients.
+    RadialGradientVariants = 15,
 }
 
 impl RenderCapability {
     /// Every optional capability in stable declaration order.
-    pub const ALL: [Self; 14] = [
+    pub const ALL: [Self; 15] = [
         Self::EllipticalBorderRadius,
         Self::BackgroundLayers,
         Self::VisualEffects,
@@ -61,6 +63,7 @@ impl RenderCapability {
         Self::BackgroundLayerStacking,
         Self::BackgroundImageResources,
         Self::BackdropBlur,
+        Self::RadialGradientVariants,
     ];
 
     /// Stable diagnostic spelling shared by Host errors and checklists.
@@ -80,6 +83,7 @@ impl RenderCapability {
             Self::BackgroundLayerStacking => "background-layer-stacking",
             Self::BackgroundImageResources => "background-image-resources",
             Self::BackdropBlur => "backdrop-blur",
+            Self::RadialGradientVariants => "radial-gradient-variants",
         }
     }
 
@@ -348,7 +352,7 @@ impl FramePacket {
     }
 }
 
-fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 6] {
+fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 7] {
     if let Operation::SetBackgroundLayers { layers, .. } = operation {
         return background_capabilities(layers);
     }
@@ -386,10 +390,10 @@ fn operation_capabilities(operation: &Operation) -> [Option<RenderCapability>; 6
         }
         _ => None,
     };
-    [first, second, None, None, None, None]
+    [first, second, None, None, None, None, None]
 }
 
-fn visual_effect_capabilities(effects: &crate::VisualEffects) -> [Option<RenderCapability>; 6] {
+fn visual_effect_capabilities(effects: &crate::VisualEffects) -> [Option<RenderCapability>; 7] {
     let backdrop = effects.backdrop_blur.is_some_and(|radius| radius > 0.0);
     let mut remainder = effects.clone();
     remainder.backdrop_blur = None;
@@ -400,18 +404,20 @@ fn visual_effect_capabilities(effects: &crate::VisualEffects) -> [Option<RenderC
         None,
         None,
         None,
+        None,
     ]
 }
 
-fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderCapability>; 6] {
+fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderCapability>; 7] {
     if layers.is_empty() {
-        return [None; 6];
+        return [None; 7];
     }
     let mut linear = false;
     let mut radial = false;
     let mut conic = false;
     let mut resource = false;
     let mut geometry = false;
+    let mut radial_variants = false;
     for layer in layers {
         match background_image_capability(layer) {
             Some(RenderCapability::LinearGradients) => linear = true,
@@ -426,13 +432,28 @@ fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderC
                     None,
                     None,
                     None,
+                    None,
                 ];
             }
         }
+        radial_variants |= matches!(
+            layer.image,
+            crate::PaintImage::RadialGradient {
+                shape: crate::RadialGradientShape::Circle,
+                ..
+            } | crate::PaintImage::RadialGradient {
+                extent: crate::RadialGradientExtent::ClosestSide
+                    | crate::RadialGradientExtent::FarthestSide
+                    | crate::RadialGradientExtent::ClosestCorner
+                    | crate::RadialGradientExtent::FarthestCorner,
+                ..
+            }
+        );
         if !has_initial_background_geometry(layer) {
             if !has_explicit_background_geometry(layer) {
                 return [
                     Some(RenderCapability::BackgroundLayers),
+                    None,
                     None,
                     None,
                     None,
@@ -450,6 +471,7 @@ fn background_capabilities(layers: &[crate::BackgroundLayer]) -> [Option<RenderC
         resource.then_some(RenderCapability::BackgroundImageResources),
         geometry.then_some(RenderCapability::BackgroundGeometry),
         (layers.len() > 1).then_some(RenderCapability::BackgroundLayerStacking),
+        radial_variants.then_some(RenderCapability::RadialGradientVariants),
     ]
 }
 
@@ -470,15 +492,10 @@ fn background_image_capability(layer: &crate::BackgroundLayer) -> Option<RenderC
     if matches!(
         &layer.image,
         crate::PaintImage::RadialGradient {
-            shape: crate::RadialGradientShape::Ellipse,
-            extent: crate::RadialGradientExtent::Explicit,
-            radii: Some(_),
             repeating: false,
             stops,
             ..
-        } if stops.iter().all(|stop| {
-            stop.position.is_some_and(|position| position.length == 0.0)
-        })
+        } if stops.iter().all(|stop| stop.position.is_some())
     ) {
         return Some(RenderCapability::RadialGradients);
     }
@@ -633,6 +650,53 @@ mod tests {
             repeating: false,
             stops: basic_gradient_stops(),
         })
+    }
+
+    #[test]
+    fn radial_gradient_capability_covers_shapes_and_keyword_extents() {
+        for (shape, extent, radii) in [
+            (
+                crate::RadialGradientShape::Circle,
+                crate::RadialGradientExtent::FarthestCorner,
+                None,
+            ),
+            (
+                crate::RadialGradientShape::Ellipse,
+                crate::RadialGradientExtent::ClosestSide,
+                None,
+            ),
+            (
+                crate::RadialGradientShape::Circle,
+                crate::RadialGradientExtent::Explicit,
+                Some((
+                    PaintLengthPercentage {
+                        length: 10.0,
+                        fraction: 0.0,
+                    },
+                    PaintLengthPercentage {
+                        length: 10.0,
+                        fraction: 0.0,
+                    },
+                )),
+            ),
+        ] {
+            let mut layer = basic_radial_layer();
+            layer.image = crate::PaintImage::RadialGradient {
+                shape,
+                extent,
+                center: PaintPosition::default(),
+                radii,
+                repeating: false,
+                stops: basic_gradient_stops(),
+            };
+            let required = packet(vec![Operation::SetBackgroundLayers {
+                node: NodeId::new(1).unwrap(),
+                layers: vec![layer],
+            }])
+            .required_capabilities();
+            assert!(required.contains(&RenderCapability::RadialGradients));
+            assert!(required.contains(&RenderCapability::RadialGradientVariants));
+        }
     }
 
     fn conic_layer(repeating: bool, first_stop_length: f32) -> BackgroundLayer {
@@ -1125,6 +1189,7 @@ mod tests {
                 "background-layer-stacking",
                 "background-image-resources",
                 "backdrop-blur",
+                "radial-gradient-variants",
             ]
         );
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/HostCapabilities.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/HostCapabilities.kt
@@ -34,7 +34,8 @@ internal object AndroidHostCapabilities {
             MobileAbi.CAPABILITY_CONIC_GRADIENTS or
             MobileAbi.CAPABILITY_BACKGROUND_GEOMETRY or
             MobileAbi.CAPABILITY_BACKGROUND_LAYER_STACKING or
-            MobileAbi.CAPABILITY_BACKGROUND_IMAGE_RESOURCES
+            MobileAbi.CAPABILITY_BACKGROUND_IMAGE_RESOURCES or
+            MobileAbi.CAPABILITY_RADIAL_GRADIENT_VARIANTS
 
     fun current(): HostRenderProfile = forApiLevel(Build.VERSION.SDK_INT)
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
@@ -12,7 +12,7 @@ internal object MobileAbi {
     const val VALUE_MAP: Int = 7
     const val VALUE_ERROR: Int = 8
     const val MOBILE_ABI_MAJOR: Int = 2
-    const val MOBILE_ABI_MINOR: Int = 29
+    const val MOBILE_ABI_MINOR: Int = 30
     const val FRAME_PROTOCOL_MAJOR: Int = 1
     const val FRAME_PROTOCOL_MINOR: Int = 4
     const val CAPABILITY_ELLIPTICAL_BORDER_RADIUS: Long = 0x0001
@@ -29,6 +29,7 @@ internal object MobileAbi {
     const val CAPABILITY_BACKGROUND_LAYER_STACKING: Long = 0x1000
     const val CAPABILITY_BACKGROUND_IMAGE_RESOURCES: Long = 0x2000
     const val CAPABILITY_BACKDROP_BLUR: Long = 0x4000
+    const val CAPABILITY_RADIAL_GRADIENT_VARIANTS: Long = 0x8000
     const val POINTER_DOWN: Int = 0
     const val POINTER_MOVE: Int = 1
     const val POINTER_UP: Int = 2
@@ -77,6 +78,13 @@ internal object MobileAbi {
     const val BACKGROUND_RADIAL: Int = 1
     const val BACKGROUND_CONIC: Int = 2
     const val BACKGROUND_RESOURCE: Int = 3
+    const val RADIAL_SHAPE_CIRCLE: Int = 0
+    const val RADIAL_SHAPE_ELLIPSE: Int = 1
+    const val RADIAL_EXTENT_CLOSEST_SIDE: Int = 0
+    const val RADIAL_EXTENT_FARTHEST_SIDE: Int = 1
+    const val RADIAL_EXTENT_CLOSEST_CORNER: Int = 2
+    const val RADIAL_EXTENT_FARTHEST_CORNER: Int = 3
+    const val RADIAL_EXTENT_EXPLICIT: Int = 4
     const val BACKGROUND_SIZE_AUTO: Int = 0
     const val BACKGROUND_SIZE_EXPLICIT: Int = 1
     const val BACKGROUND_SIZE_COVER: Int = 2

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BackgroundLayers.kt
@@ -11,9 +11,12 @@ import android.graphics.RectF
 import android.graphics.RadialGradient
 import android.graphics.Shader
 import android.graphics.SweepGradient
+import rs.whisker.runtime.bridge.MobileAbi
 import kotlin.math.abs
 import kotlin.math.cos
+import kotlin.math.hypot
 import kotlin.math.sin
+import kotlin.math.sqrt
 
 internal data class HostGradientStop(
     val color: Int,
@@ -34,12 +37,39 @@ internal data class HostPaintCoordinate(
 }
 
 internal data class HostRadialGradient(
+    val shape: HostRadialShape,
+    val extent: HostRadialExtent,
     val centerX: HostPaintCoordinate,
     val centerY: HostPaintCoordinate,
     val radiusX: HostPaintCoordinate,
     val radiusY: HostPaintCoordinate,
     val stops: List<HostGradientStop>,
 )
+
+internal enum class HostRadialShape(val wireValue: Int) {
+    Circle(MobileAbi.RADIAL_SHAPE_CIRCLE),
+    Ellipse(MobileAbi.RADIAL_SHAPE_ELLIPSE);
+
+    companion object {
+        fun fromWire(value: Int): HostRadialShape? = entries.firstOrNull {
+            it.wireValue == value
+        }
+    }
+}
+
+internal enum class HostRadialExtent(val wireValue: Int) {
+    ClosestSide(MobileAbi.RADIAL_EXTENT_CLOSEST_SIDE),
+    FarthestSide(MobileAbi.RADIAL_EXTENT_FARTHEST_SIDE),
+    ClosestCorner(MobileAbi.RADIAL_EXTENT_CLOSEST_CORNER),
+    FarthestCorner(MobileAbi.RADIAL_EXTENT_FARTHEST_CORNER),
+    Explicit(MobileAbi.RADIAL_EXTENT_EXPLICIT);
+
+    companion object {
+        fun fromWire(value: Int): HostRadialExtent? = entries.firstOrNull {
+            it.wireValue == value
+        }
+    }
+}
 
 internal data class HostConicGradient(
     val fromDegrees: Float,
@@ -214,8 +244,9 @@ private fun drawRadialGradient(
     if (gradient.stops.size < 2) return
     val centerX = box.left + gradient.centerX.resolve(box.width())
     val centerY = box.top + gradient.centerY.resolve(box.height())
-    val radiusX = gradient.radiusX.resolve(box.width())
-    val radiusY = gradient.radiusY.resolve(box.height())
+    val radii = resolveRadialRadii(box.width(), box.height(), gradient)
+    val radiusX = radii.x
+    val radiusY = radii.y
     if (radiusX <= 0f || radiusY <= 0f) return
     var previousPosition = 0f
     val positions = gradient.stops.mapIndexed { index, stop ->
@@ -239,6 +270,61 @@ private fun drawRadialGradient(
     }
     canvas.drawPath(clip, paint)
     paint.shader = null
+}
+
+@JvmInline
+internal value class HostRadialRadii private constructor(private val packed: Long) {
+    val x: Float get() = Float.fromBits((packed ushr 32).toInt())
+    val y: Float get() = Float.fromBits(packed.toInt())
+
+    companion object {
+        fun of(x: Float, y: Float): HostRadialRadii = HostRadialRadii(
+            (x.toRawBits().toLong() shl 32) or (y.toRawBits().toLong() and 0xffff_ffffL),
+        )
+    }
+}
+
+internal fun resolveRadialRadii(
+    width: Float,
+    height: Float,
+    gradient: HostRadialGradient,
+): HostRadialRadii {
+    val centerX = gradient.centerX.resolve(width)
+    val centerY = gradient.centerY.resolve(height)
+    if (gradient.extent == HostRadialExtent.Explicit) {
+        val radiusX = gradient.radiusX.resolve(width)
+        val radiusY = if (gradient.shape == HostRadialShape.Circle) {
+            radiusX
+        } else {
+            gradient.radiusY.resolve(height)
+        }
+        return HostRadialRadii.of(radiusX, radiusY)
+    }
+
+    val nearX = minOf(centerX, width - centerX).coerceAtLeast(0f)
+    val farX = maxOf(centerX, width - centerX).coerceAtLeast(0f)
+    val nearY = minOf(centerY, height - centerY).coerceAtLeast(0f)
+    val farY = maxOf(centerY, height - centerY).coerceAtLeast(0f)
+    val x = if (
+        gradient.extent == HostRadialExtent.ClosestSide ||
+        gradient.extent == HostRadialExtent.ClosestCorner
+    ) nearX else farX
+    val y = if (
+        gradient.extent == HostRadialExtent.ClosestSide ||
+        gradient.extent == HostRadialExtent.ClosestCorner
+    ) nearY else farY
+    val corner = gradient.extent == HostRadialExtent.ClosestCorner ||
+        gradient.extent == HostRadialExtent.FarthestCorner
+    if (gradient.shape == HostRadialShape.Circle) {
+        val radius = when {
+            corner -> hypot(x.toDouble(), y.toDouble()).toFloat()
+            gradient.extent == HostRadialExtent.ClosestSide -> minOf(x, y)
+            else -> maxOf(x, y)
+        }
+        return HostRadialRadii.of(radius, radius)
+    }
+    val scale = if (corner) sqrt(2f) else 1f
+    return HostRadialRadii.of(x * scale, y * scale)
 }
 
 private fun drawConicGradient(

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/PaintDecoding.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/PaintDecoding.kt
@@ -48,6 +48,8 @@ import rs.whisker.runtime.paint.HostPathCommand
 import rs.whisker.runtime.paint.HostLinearGradient
 import rs.whisker.runtime.paint.HostPaintCoordinate
 import rs.whisker.runtime.paint.HostRadialGradient
+import rs.whisker.runtime.paint.HostRadialExtent
+import rs.whisker.runtime.paint.HostRadialShape
 import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.paint.applyBoxPaint
 import rs.whisker.runtime.paint.parseNamedColor
@@ -122,7 +124,7 @@ internal fun decodeBackgroundLayer(
     val names = requireNotNull(operation.names)
     val imageOffset = BACKGROUND_GEOMETRY_PACKED_SIZE
     val stopOffset = imageOffset + when (operation.flags) {
-        BACKGROUND_RADIAL -> 8
+        BACKGROUND_RADIAL -> RADIAL_GRADIENT_PACKED_SIZE
         BACKGROUND_CONIC -> 4
         BACKGROUND_RESOURCE -> BACKGROUND_RESOURCE_ID_WORDS
         else -> 0
@@ -175,10 +177,12 @@ internal fun decodeBackgroundLayer(
         HostBackgroundLayer(
             linearGradient = null,
             radialGradient = HostRadialGradient(
-                centerX = coordinate(imageOffset),
-                centerY = coordinate(imageOffset + 2),
-                radiusX = coordinate(imageOffset + 4),
-                radiusY = coordinate(imageOffset + 6),
+                shape = requireNotNull(HostRadialShape.fromWire(numbers[imageOffset].toInt())),
+                extent = requireNotNull(HostRadialExtent.fromWire(numbers[imageOffset + 1].toInt())),
+                centerX = coordinate(imageOffset + 2),
+                centerY = coordinate(imageOffset + 4),
+                radiusX = coordinate(imageOffset + 6),
+                radiusY = coordinate(imageOffset + 8),
                 stops = stops,
             ),
             geometry = geometry,
@@ -224,7 +228,7 @@ internal fun projectedBackgroundLayerOperations(
         val values = packed.copyOfRange(cursor, cursor + valueCount)
         cursor += valueCount
         val imagePrefix = when (kind) {
-            BACKGROUND_RADIAL -> 8
+            BACKGROUND_RADIAL -> RADIAL_GRADIENT_PACKED_SIZE
             BACKGROUND_CONIC -> 4
             BACKGROUND_RESOURCE -> BACKGROUND_RESOURCE_ID_WORDS
             else -> 0
@@ -340,7 +344,7 @@ internal fun validBackgroundLayer(
         return false
     }
     val stopOffset = BACKGROUND_GEOMETRY_PACKED_SIZE + when (operation.flags) {
-        BACKGROUND_RADIAL -> 8
+        BACKGROUND_RADIAL -> RADIAL_GRADIENT_PACKED_SIZE
         BACKGROUND_CONIC -> 4
         BACKGROUND_RESOURCE -> BACKGROUND_RESOURCE_ID_WORDS
         else -> 0
@@ -427,6 +431,7 @@ internal const val OP_RELEASE_CAPTURE = MobileAbi.OP_RELEASE_CAPTURE
 internal const val OP_TEXT_STYLE = MobileAbi.OP_TEXT_STYLE
 internal const val OP_ACCESSIBILITY = MobileAbi.OP_ACCESSIBILITY
 internal const val BACKGROUND_GEOMETRY_PACKED_SIZE = 15
+internal const val RADIAL_GRADIENT_PACKED_SIZE = 10
 internal const val BOX_SHADOW_PACKED_SIZE = 10
 internal const val CLIP_PATH_INSET_PACKED_SIZE = 26
 internal const val CLIP_PATH_CIRCLE_PACKED_SIZE = 8

--- a/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/paint/BackgroundLayersTest.kt
+++ b/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/paint/BackgroundLayersTest.kt
@@ -1,0 +1,60 @@
+package rs.whisker.runtime.paint
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackgroundLayersTest {
+    private val center = HostPaintCoordinate(length = 0f, fraction = 0.5f)
+    private val zero = HostPaintCoordinate(length = 0f, fraction = 0f)
+
+    @Test
+    fun `farthest corner resolves circle and ellipse against the image box`() {
+        val circle = resolveRadialRadii(
+            200f,
+            100f,
+            gradient(HostRadialShape.Circle, HostRadialExtent.FarthestCorner),
+        )
+        assertEquals(circle.x, circle.y, 0f)
+        assertEquals(111.8034f, circle.x, 0.001f)
+
+        val ellipse = resolveRadialRadii(
+            200f,
+            100f,
+            gradient(HostRadialShape.Ellipse, HostRadialExtent.FarthestCorner),
+        )
+        assertEquals(141.42136f, ellipse.x, 0.001f)
+        assertEquals(70.71068f, ellipse.y, 0.001f)
+    }
+
+    @Test
+    fun `explicit circle uses one radius on both axes`() {
+        val radius = HostPaintCoordinate(length = 40f, fraction = 0f)
+        val radii = resolveRadialRadii(
+            200f,
+            100f,
+            HostRadialGradient(
+                shape = HostRadialShape.Circle,
+                extent = HostRadialExtent.Explicit,
+                centerX = center,
+                centerY = center,
+                radiusX = radius,
+                radiusY = zero,
+                stops = emptyList(),
+            ),
+        )
+        assertTrue(radii.x > 0f)
+        assertEquals(40f, radii.x, 0f)
+        assertEquals(40f, radii.y, 0f)
+    }
+
+    private fun gradient(shape: HostRadialShape, extent: HostRadialExtent) = HostRadialGradient(
+        shape = shape,
+        extent = extent,
+        centerX = center,
+        centerY = center,
+        radiusX = zero,
+        radiusY = zero,
+        stops = emptyList(),
+    )
+}

--- a/platforms/desktop/src/capabilities.rs
+++ b/platforms/desktop/src/capabilities.rs
@@ -19,6 +19,7 @@ pub(crate) fn host_capabilities() -> RenderCapabilities {
             RenderCapability::BackgroundLayerStacking,
             RenderCapability::BackgroundImageResources,
             RenderCapability::BackdropBlur,
+            RenderCapability::RadialGradientVariants,
         ]
         .map(|capability| CapabilityEntry {
             capability,

--- a/platforms/desktop/src/gpu.rs
+++ b/platforms/desktop/src/gpu.rs
@@ -943,22 +943,22 @@ pub(crate) fn linear_gradient_draw(
 
 pub(crate) fn radial_gradient_draw(
     positioning_rect: LayoutRect,
+    shape: whisker_protocol::RadialGradientShape,
+    extent: whisker_protocol::RadialGradientExtent,
     center: whisker_protocol::PaintPosition,
-    radii: (
+    explicit_radii: Option<(
         whisker_protocol::PaintLengthPercentage,
         whisker_protocol::PaintLengthPercentage,
-    ),
+    )>,
     stops: &[GradientStop],
     opacity: f32,
 ) -> LinearGradientDraw {
+    let radii = radial_gradient_radii(positioning_rect, center, shape, extent, explicit_radii);
     let center = [
         positioning_rect.x + center.x.length + center.x.fraction * positioning_rect.width,
         positioning_rect.y + center.y.length + center.y.fraction * positioning_rect.height,
     ];
-    let radii = [
-        radii.0.length + radii.0.fraction * positioning_rect.width,
-        radii.1.length + radii.1.fraction * positioning_rect.height,
-    ];
+    let line_length = radii[0].max(0.0001);
     LinearGradientDraw {
         start_end: [center[0], center[1], radii[0], radii[1]],
         tile_rect: [
@@ -977,13 +977,70 @@ pub(crate) fn radial_gradient_draw(
         stops: stops
             .iter()
             .map(|stop| LinearGradientStopGpu {
-                position: stop.position.map_or(0.0, |position| position.fraction),
+                position: stop.position.map_or(0.0, |position| {
+                    position.fraction + position.length / line_length
+                }),
                 padding: [0.0; 3],
                 color: gpu_color(&stop.color, opacity),
             })
             .collect(),
         kind: 2,
         geometry_flags: 0,
+    }
+}
+
+fn radial_gradient_radii(
+    bounds: LayoutRect,
+    center: whisker_protocol::PaintPosition,
+    shape: whisker_protocol::RadialGradientShape,
+    extent: whisker_protocol::RadialGradientExtent,
+    explicit: Option<(
+        whisker_protocol::PaintLengthPercentage,
+        whisker_protocol::PaintLengthPercentage,
+    )>,
+) -> [f32; 2] {
+    use whisker_protocol::{RadialGradientExtent, RadialGradientShape};
+
+    let center_x = center.x.length + center.x.fraction * bounds.width;
+    let center_y = center.y.length + center.y.fraction * bounds.height;
+    if extent == RadialGradientExtent::Explicit {
+        let (x, y) = explicit.expect("validated explicit radial gradient has radii");
+        let radius_x = x.length + x.fraction * bounds.width;
+        let radius_y = if shape == RadialGradientShape::Circle {
+            radius_x
+        } else {
+            y.length + y.fraction * bounds.height
+        };
+        return [radius_x, radius_y];
+    }
+
+    let near_x = center_x.min(bounds.width - center_x).max(0.0);
+    let far_x = center_x.max(bounds.width - center_x).max(0.0);
+    let near_y = center_y.min(bounds.height - center_y).max(0.0);
+    let far_y = center_y.max(bounds.height - center_y).max(0.0);
+    let (x, y, corner) = match extent {
+        RadialGradientExtent::ClosestSide => (near_x, near_y, false),
+        RadialGradientExtent::FarthestSide => (far_x, far_y, false),
+        RadialGradientExtent::ClosestCorner => (near_x, near_y, true),
+        RadialGradientExtent::FarthestCorner => (far_x, far_y, true),
+        RadialGradientExtent::Explicit => unreachable!(),
+    };
+    if shape == RadialGradientShape::Circle {
+        let radius = if corner {
+            x.hypot(y)
+        } else if extent == RadialGradientExtent::ClosestSide {
+            x.min(y)
+        } else {
+            x.max(y)
+        };
+        [radius, radius]
+    } else {
+        let scale = if corner {
+            std::f32::consts::SQRT_2
+        } else {
+            1.0
+        };
+        [x * scale, y * scale]
     }
 }
 

--- a/platforms/desktop/src/gpu/geometry.rs
+++ b/platforms/desktop/src/gpu/geometry.rs
@@ -193,11 +193,13 @@ pub(crate) fn background_gradient_draw(
             stops,
         } => linear_gradient_draw(tile.rect, *angle_degrees, *repeating, stops, opacity),
         PaintImage::RadialGradient {
+            shape,
+            extent,
             center,
-            radii: Some(radii),
+            radii,
             stops,
-            ..
-        } => radial_gradient_draw(tile.rect, *center, *radii, stops, opacity),
+            repeating: false,
+        } => radial_gradient_draw(tile.rect, *shape, *extent, *center, *radii, stops, opacity),
         PaintImage::ConicGradient {
             from_degrees,
             center,

--- a/platforms/desktop/src/gpu/tests.rs
+++ b/platforms/desktop/src/gpu/tests.rs
@@ -3,7 +3,8 @@ use glyphon::Color as TextColor;
 use whisker_protocol::{
     BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxPaint,
     ImageRepeat, LayoutRect, PaintBox, PaintColor, PaintCoordinate, PaintCornerRadius,
-    PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition, ResourceId,
+    PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
+    RadialGradientExtent, RadialGradientShape, ResourceId,
 };
 
 use crate::paint::box_paint::{ResolvedRadii, resolve_box_geometry, resolve_radii};
@@ -51,6 +52,69 @@ fn paint(background_color: PaintColor) -> BoxPaint {
             bottom_left: PaintCornerRadius::default(),
         },
     }
+}
+
+#[test]
+fn radial_gradient_keyword_extents_resolve_against_the_image_box() {
+    let bounds = LayoutRect {
+        x: 10.0,
+        y: 20.0,
+        width: 200.0,
+        height: 100.0,
+    };
+    let center = PaintPosition {
+        x: PaintCoordinate {
+            length: 0.0,
+            fraction: 0.5,
+        },
+        y: PaintCoordinate {
+            length: 0.0,
+            fraction: 0.5,
+        },
+    };
+
+    let circle = radial_gradient_radii(
+        bounds,
+        center,
+        RadialGradientShape::Circle,
+        RadialGradientExtent::FarthestCorner,
+        None,
+    );
+    assert!((circle[0] - 111.8034).abs() < 0.001);
+    assert_eq!(circle[0], circle[1]);
+
+    let ellipse = radial_gradient_radii(
+        bounds,
+        center,
+        RadialGradientShape::Ellipse,
+        RadialGradientExtent::FarthestCorner,
+        None,
+    );
+    assert!((ellipse[0] - 141.42136).abs() < 0.001);
+    assert!((ellipse[1] - 70.71068).abs() < 0.001);
+}
+
+#[test]
+fn explicit_circle_uses_one_radius_on_both_axes() {
+    let radius = PaintLengthPercentage {
+        length: 40.0,
+        fraction: 0.0,
+    };
+    assert_eq!(
+        radial_gradient_radii(
+            LayoutRect {
+                x: 0.0,
+                y: 0.0,
+                width: 200.0,
+                height: 100.0,
+            },
+            PaintPosition::default(),
+            RadialGradientShape::Circle,
+            RadialGradientExtent::Explicit,
+            Some((radius, radius)),
+        ),
+        [40.0, 40.0]
+    );
 }
 
 fn resource_layer(size: BackgroundSize) -> BackgroundLayer {

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -10,8 +10,8 @@ use whisker_protocol::{
     BoxClip, BoxPaint, ClipShape, Cursor, ElementTypeId, FillRule, FrameMode, FramePacket,
     HitTestBehavior, ImageRepeat, LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip,
     PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand, PointerId,
-    RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
-    ValidationError, Visibility, VisualEffects, WhiskerValue,
+    ResourceId, SceneProjection, SurfaceId, TextContent, Transform, ValidationError, Visibility,
+    VisualEffects, WhiskerValue,
 };
 
 use crate::DesktopTextInputEvent;

--- a/platforms/desktop/src/scene/paint_support.rs
+++ b/platforms/desktop/src/scene/paint_support.rs
@@ -12,9 +12,6 @@ pub(super) fn supports_basic_background_layer(layer: &BackgroundLayer) -> bool {
     ) || matches!(
         &layer.image,
         PaintImage::RadialGradient {
-            shape: whisker_protocol::RadialGradientShape::Ellipse,
-            extent: RadialGradientExtent::Explicit,
-            radii: Some(_),
             repeating: false,
             stops,
             ..

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 29
+#define WHISKER_MOBILE_ABI_MINOR 30
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -65,6 +65,8 @@
 #define WHISKER_CAPABILITY_BACKGROUND_IMAGE_RESOURCES 8192
 
 #define WHISKER_CAPABILITY_BACKDROP_BLUR 16384
+
+#define WHISKER_CAPABILITY_RADIAL_GRADIENT_VARIANTS 32768
 
 #define WHISKER_POINTER_DOWN 0
 
@@ -161,6 +163,20 @@
 #define WHISKER_BACKGROUND_CONIC 2
 
 #define WHISKER_BACKGROUND_RESOURCE 3
+
+#define WHISKER_RADIAL_SHAPE_CIRCLE 0
+
+#define WHISKER_RADIAL_SHAPE_ELLIPSE 1
+
+#define WHISKER_RADIAL_EXTENT_CLOSEST_SIDE 0
+
+#define WHISKER_RADIAL_EXTENT_FARTHEST_SIDE 1
+
+#define WHISKER_RADIAL_EXTENT_CLOSEST_CORNER 2
+
+#define WHISKER_RADIAL_EXTENT_FARTHEST_CORNER 3
+
+#define WHISKER_RADIAL_EXTENT_EXPLICIT 4
 
 #define WHISKER_BACKGROUND_SIZE_AUTO 0
 
@@ -667,9 +683,11 @@ typedef struct WhiskerMobileGradientStop {
 } WhiskerMobileGradientStop;
 
 /**
- * One explicit, non-repeating elliptical radial gradient.
+ * One resolved, non-repeating radial gradient.
  */
 typedef struct WhiskerMobileRadialGradient {
+  uint32_t shape;
+  uint32_t extent;
   struct WhiskerMobileLengthPercentage center_x;
   struct WhiskerMobileLengthPercentage center_y;
   struct WhiskerMobileLengthPercentage radius_x;

--- a/platforms/ios/Sources/WhiskerRuntime/bridge/HostCapabilities.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/HostCapabilities.swift
@@ -40,6 +40,7 @@ enum IOSHostCapabilities {
             WHISKER_CAPABILITY_BACKGROUND_GEOMETRY,
             WHISKER_CAPABILITY_BACKGROUND_LAYER_STACKING,
             WHISKER_CAPABILITY_BACKGROUND_IMAGE_RESOURCES,
+            WHISKER_CAPABILITY_RADIAL_GRADIENT_VARIANTS,
         ].reduce(0) { $0 | UInt64($1) },
         // UIKit exposes material intensity, not an exact CSS blur radius.
         emulated: UInt64(WHISKER_CAPABILITY_BACKDROP_BLUR)

--- a/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/paint/BackgroundLayers.swift
@@ -18,11 +18,45 @@ struct HostLinearGradient {
 }
 
 struct HostRadialGradient {
+    let shape: HostRadialShape
+    let extent: HostRadialExtent
     let centerX: WhiskerMobileLengthPercentage
     let centerY: WhiskerMobileLengthPercentage
     let radiusX: WhiskerMobileLengthPercentage
     let radiusY: WhiskerMobileLengthPercentage
     let stops: [HostLinearGradientStop]
+}
+
+enum HostRadialShape {
+    case circle
+    case ellipse
+
+    init?(wireValue: UInt32) {
+        switch wireValue {
+        case UInt32(WHISKER_RADIAL_SHAPE_CIRCLE): self = .circle
+        case UInt32(WHISKER_RADIAL_SHAPE_ELLIPSE): self = .ellipse
+        default: return nil
+        }
+    }
+}
+
+enum HostRadialExtent {
+    case closestSide
+    case farthestSide
+    case closestCorner
+    case farthestCorner
+    case explicit
+
+    init?(wireValue: UInt32) {
+        switch wireValue {
+        case UInt32(WHISKER_RADIAL_EXTENT_CLOSEST_SIDE): self = .closestSide
+        case UInt32(WHISKER_RADIAL_EXTENT_FARTHEST_SIDE): self = .farthestSide
+        case UInt32(WHISKER_RADIAL_EXTENT_CLOSEST_CORNER): self = .closestCorner
+        case UInt32(WHISKER_RADIAL_EXTENT_FARTHEST_CORNER): self = .farthestCorner
+        case UInt32(WHISKER_RADIAL_EXTENT_EXPLICIT): self = .explicit
+        default: return nil
+        }
+    }
 }
 
 struct HostConicGradient {
@@ -412,8 +446,9 @@ final class HostBackgroundPainter {
             x: resolve(radialGradient.centerX, extent: bounds.width) + bounds.minX,
             y: resolve(radialGradient.centerY, extent: bounds.height) + bounds.minY
         )
-        let radiusX = resolve(radialGradient.radiusX, extent: bounds.width)
-        let radiusY = resolve(radialGradient.radiusY, extent: bounds.height)
+        let radii = resolveRadialRadii(radialGradient, in: bounds)
+        let radiusX = radii.width
+        let radiusY = radii.height
         guard radiusX > 0, radiusY > 0 else { return }
         let resolved = resolveStops(radialGradient.stops, lineLength: radiusX)
         guard let gradient = makeGradient(resolved) else { return }
@@ -431,6 +466,40 @@ final class HostBackgroundPainter {
             options: [.drawsBeforeStartLocation, .drawsAfterEndLocation]
         )
         context.restoreGState()
+    }
+
+    func resolveRadialRadii(_ gradient: HostRadialGradient, in bounds: CGRect) -> CGSize {
+        let centerX = resolve(gradient.centerX, extent: bounds.width)
+        let centerY = resolve(gradient.centerY, extent: bounds.height)
+        if gradient.extent == .explicit {
+            let radiusX = resolve(gradient.radiusX, extent: bounds.width)
+            let radiusY = gradient.shape == .circle
+                ? radiusX
+                : resolve(gradient.radiusY, extent: bounds.height)
+            return CGSize(width: radiusX, height: radiusY)
+        }
+
+        let nearX = max(0, min(centerX, bounds.width - centerX))
+        let farX = max(0, max(centerX, bounds.width - centerX))
+        let nearY = max(0, min(centerY, bounds.height - centerY))
+        let farY = max(0, max(centerY, bounds.height - centerY))
+        let closest = gradient.extent == .closestSide || gradient.extent == .closestCorner
+        let corner = gradient.extent == .closestCorner || gradient.extent == .farthestCorner
+        let x = closest ? nearX : farX
+        let y = closest ? nearY : farY
+        if gradient.shape == .circle {
+            let radius: CGFloat
+            if corner {
+                radius = hypot(x, y)
+            } else if closest {
+                radius = min(x, y)
+            } else {
+                radius = max(x, y)
+            }
+            return CGSize(width: radius, height: radius)
+        }
+        let scale = corner ? sqrt(2) : 1
+        return CGSize(width: x * scale, height: y * scale)
     }
 
     private func drawConic(

--- a/platforms/ios/Sources/WhiskerRuntime/scene/PaintDecoding.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/PaintDecoding.swift
@@ -259,7 +259,11 @@ func hostBackgroundLayer(
         guard let radial = layer.image.payload?.assumingMemoryBound(
             to: WhiskerMobileRadialGradient.self
         ).pointee, let stopPointer = radial.stops else { return nil }
+        guard let shape = HostRadialShape(wireValue: radial.shape),
+              let extent = HostRadialExtent(wireValue: radial.extent) else { return nil }
         image = .radial(HostRadialGradient(
+            shape: shape,
+            extent: extent,
             centerX: radial.center_x,
             centerY: radial.center_y,
             radiusX: radial.radius_x,

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -1743,6 +1743,8 @@ private final class Driver {
                                 gradientBuffer.baseAddress!.advanced(by: offset)
                             )
                             if case let .radial(radial) = layer.image {
+                                radialPayloads[index].shape = UInt32(WHISKER_RADIAL_SHAPE_ELLIPSE)
+                                radialPayloads[index].extent = UInt32(WHISKER_RADIAL_EXTENT_EXPLICIT)
                                 radialPayloads[index].center_x = WhiskerMobileLengthPercentage(
                                     length: radial.center[0], fraction: 0
                                 )

--- a/platforms/ios/Tests/WhiskerHostConformance/RadialGradientTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/RadialGradientTests.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import WhiskerCBridge
+@testable import WhiskerRuntime
+import XCTest
+
+final class RadialGradientTests: XCTestCase {
+    private let center = WhiskerMobileLengthPercentage(length: 0, fraction: 0.5)
+    private let zero = WhiskerMobileLengthPercentage()
+
+    func testFarthestCornerResolvesCircleAndEllipseAgainstImageBox() {
+        let painter = HostBackgroundPainter()
+        let bounds = CGRect(x: 0, y: 0, width: 200, height: 100)
+        let circle = painter.resolveRadialRadii(
+            gradient(shape: .circle, extent: .farthestCorner),
+            in: bounds
+        )
+        XCTAssertEqual(circle.width, circle.height)
+        XCTAssertEqual(circle.width, 111.8034, accuracy: 0.001)
+
+        let ellipse = painter.resolveRadialRadii(
+            gradient(shape: .ellipse, extent: .farthestCorner),
+            in: bounds
+        )
+        XCTAssertEqual(ellipse.width, 141.42136, accuracy: 0.001)
+        XCTAssertEqual(ellipse.height, 70.71068, accuracy: 0.001)
+    }
+
+    func testExplicitCircleUsesOneRadiusOnBothAxes() {
+        let radius = WhiskerMobileLengthPercentage(length: 40, fraction: 0)
+        let gradient = HostRadialGradient(
+            shape: .circle,
+            extent: .explicit,
+            centerX: center,
+            centerY: center,
+            radiusX: radius,
+            radiusY: zero,
+            stops: []
+        )
+        let radii = HostBackgroundPainter().resolveRadialRadii(
+            gradient,
+            in: CGRect(x: 0, y: 0, width: 200, height: 100)
+        )
+        XCTAssertEqual(radii, CGSize(width: 40, height: 40))
+    }
+
+    private func gradient(
+        shape: HostRadialShape,
+        extent: HostRadialExtent
+    ) -> HostRadialGradient {
+        HostRadialGradient(
+            shape: shape,
+            extent: extent,
+            centerX: center,
+            centerY: center,
+            radiusX: zero,
+            radiusY: zero,
+            stops: []
+        )
+    }
+}

--- a/platforms/web/src/capabilities.rs
+++ b/platforms/web/src/capabilities.rs
@@ -22,6 +22,7 @@ pub(crate) fn host_capabilities(backdrop_blur: bool) -> RenderCapabilities {
         RenderCapability::BackgroundGeometry,
         RenderCapability::BackgroundLayerStacking,
         RenderCapability::BackgroundImageResources,
+        RenderCapability::RadialGradientVariants,
     ];
     if backdrop_blur {
         entries.push(RenderCapability::BackdropBlur);

--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -21,9 +21,6 @@ fn supports_layer(layer: &BackgroundLayer) -> bool {
             ..
         } => stops.iter().all(|stop| stop.position.is_some()),
         PaintImage::RadialGradient {
-            shape: RadialGradientShape::Ellipse,
-            extent: RadialGradientExtent::Explicit,
-            radii: Some(_),
             repeating: false,
             stops,
             ..
@@ -129,13 +126,13 @@ fn background_image(
             stops,
         } => linear_gradient(*angle_degrees, stops),
         PaintImage::RadialGradient {
-            shape: RadialGradientShape::Ellipse,
-            extent: RadialGradientExtent::Explicit,
+            shape,
+            extent,
             center,
-            radii: Some(radii),
+            radii,
             repeating: false,
             stops,
-        } => radial_gradient(*center, *radii, stops),
+        } => radial_gradient(*shape, *extent, *center, *radii, stops),
         PaintImage::ConicGradient {
             from_degrees,
             center,
@@ -163,8 +160,10 @@ fn linear_gradient(angle_degrees: f32, stops: &[GradientStop]) -> Result<String,
 }
 
 fn radial_gradient(
+    shape: RadialGradientShape,
+    extent: RadialGradientExtent,
     center: PaintPosition,
-    radii: (PaintLengthPercentage, PaintLengthPercentage),
+    radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
     stops: &[GradientStop],
 ) -> Result<String, WebError> {
     let stops = stops
@@ -172,13 +171,40 @@ fn radial_gradient(
         .map(gradient_stop)
         .collect::<Result<Vec<_>, _>>()?
         .join(", ");
+    let sizing = match (shape, extent, radii) {
+        (RadialGradientShape::Circle, RadialGradientExtent::Explicit, Some((radius, _))) => {
+            format!("circle {}", length_percentage(radius))
+        }
+        (RadialGradientShape::Ellipse, RadialGradientExtent::Explicit, Some((x, y))) => {
+            format!("ellipse {} {}", length_percentage(x), length_percentage(y))
+        }
+        (shape, extent, None) if extent != RadialGradientExtent::Explicit => {
+            format!("{} {}", radial_shape(shape), radial_extent(extent))
+        }
+        _ => return Err(WebError("invalid DOM radial gradient".into())),
+    };
     Ok(format!(
-        "radial-gradient(ellipse {} {} at {} {}, {stops})",
-        length_percentage(radii.0),
-        length_percentage(radii.1),
+        "radial-gradient({sizing} at {} {}, {stops})",
         coordinate(center.x),
         coordinate(center.y),
     ))
+}
+
+fn radial_shape(shape: RadialGradientShape) -> &'static str {
+    match shape {
+        RadialGradientShape::Circle => "circle",
+        RadialGradientShape::Ellipse => "ellipse",
+    }
+}
+
+fn radial_extent(extent: RadialGradientExtent) -> &'static str {
+    match extent {
+        RadialGradientExtent::ClosestSide => "closest-side",
+        RadialGradientExtent::FarthestSide => "farthest-side",
+        RadialGradientExtent::ClosestCorner => "closest-corner",
+        RadialGradientExtent::FarthestCorner => "farthest-corner",
+        RadialGradientExtent::Explicit => unreachable!(),
+    }
 }
 
 fn conic_gradient(
@@ -293,5 +319,63 @@ fn background_box(value: PaintBox) -> &'static str {
         PaintBox::Content => "content-box",
         PaintBox::BorderArea => "border-area",
         _ => unreachable!("unsupported background box passed preflight"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker_protocol::PaintColor;
+
+    fn stops() -> Vec<GradientStop> {
+        [0.0, 1.0]
+            .into_iter()
+            .map(|fraction| GradientStop {
+                color: PaintColor::Srgba {
+                    red: (fraction * 255.0) as u8,
+                    green: 0,
+                    blue: 0,
+                    alpha: 1.0,
+                },
+                position: Some(PaintCoordinate {
+                    length: 0.0,
+                    fraction,
+                }),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn radial_gradient_preserves_keyword_shape_and_extent() {
+        assert_eq!(
+            radial_gradient(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::FarthestCorner,
+                PaintPosition::default(),
+                None,
+                &stops(),
+            )
+            .unwrap(),
+            "radial-gradient(circle farthest-corner at 0% 0%, rgba(0, 0, 0, 1) 0%, rgba(255, 0, 0, 1) 100%)"
+        );
+    }
+
+    #[test]
+    fn radial_gradient_preserves_explicit_circle_radius() {
+        let radius = PaintLengthPercentage {
+            length: 24.0,
+            fraction: 0.0,
+        };
+        assert!(
+            radial_gradient(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::Explicit,
+                PaintPosition::default(),
+                Some((radius, radius)),
+                &stops(),
+            )
+            .unwrap()
+            .starts_with("radial-gradient(circle 24px at")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- support circle/ellipse shapes and all protocol radial-gradient extents on Desktop, Web, Android, and iOS
- carry radial shape and extent through mobile ABI 2.30
- add `RadialGradientVariants` capability so new Runtime + old Host combinations reject safely during negotiation
- resolve keyword radii against the final background tile and preserve absolute stop offsets
- add focused tests for protocol negotiation, FFI encoding, and every Host implementation

## Root cause
The public CSS API emitted default `circle`/`ellipse` gradients as `FarthestCorner`, but every Host preflight only accepted `Ellipse + Explicit + Some(radii)`. A valid public style could therefore reject a core frame and leave the surface unable to present.

## Performance
- no scene copies or per-frame collections were added
- keyword resolution is constant-space arithmetic at paint time
- Android returns two radii through an inline packed value, avoiding a heap allocation
- Web delegates the retained shape/extent directly to CSS

## Verification
- `cargo xtask mobile-abi check`
- `cargo test -p whisker-protocol -p whisker-driver-sys -p whisker-driver -p whisker-desktop -p whisker-web -- --test-threads=1`
- `CARGO_BUILD_JOBS=1 cargo clippy -p whisker-protocol -p whisker-driver-sys -p whisker-driver -p whisker-desktop -p whisker-web --all-targets -- -D warnings`
- `platforms/android/gradle-plugin/gradlew --project-dir platforms/android :runtime:testDebugUnitTest`
- `swift build --package-path platforms/ios --build-tests --triple arm64-apple-ios-simulator --sdk $(xcrun --sdk iphonesimulator --show-sdk-path)`
- `cargo fmt --all -- --check`
- `git diff --check`