### PR TITLE
fix(protocol): reject error values in frame data

### DIFF
--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -147,6 +147,11 @@ pub enum ValidationError {
         /// Stable invalid-input category.
         error: TextContentError,
     },
+    /// A property or command payload contained the reserved error variant.
+    InvalidDataValue {
+        /// Target node of the rejected operation.
+        node: NodeId,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -358,14 +363,18 @@ impl SceneProjection {
                     .validate()
                     .map_err(|error| ValidationError::InvalidText { error })?;
             }
-            Operation::InvokeCommand { node, .. } => {
+            Operation::InvokeCommand {
+                node, arguments, ..
+            } => {
                 self.require_node(*node)?;
+                if !arguments.is_data() {
+                    return Err(ValidationError::InvalidDataValue { node: *node });
+                }
             }
             Operation::SetClip { node, .. }
             | Operation::SetVisibility { node, .. }
             | Operation::SetZOrder { node, .. }
             | Operation::SetAccessibility { node, .. }
-            | Operation::SetProperty { node, .. }
             | Operation::ClearProperty { node, .. }
             | Operation::SetEventMask { node, .. }
             | Operation::SetHitTest { node, .. }
@@ -373,6 +382,12 @@ impl SceneProjection {
             | Operation::SetPointerCapture { node, .. }
             | Operation::ReleasePointerCapture { node, .. } => {
                 self.require_node(*node)?;
+            }
+            Operation::SetProperty { node, value, .. } => {
+                self.require_node(*node)?;
+                if !value.is_data() {
+                    return Err(ValidationError::InvalidDataValue { node: *node });
+                }
             }
         }
         Ok(())
@@ -744,6 +759,48 @@ mod tests {
         assert_eq!(scene.node_count(), 2);
         assert_eq!(scene.node(root).expect("root").children(), &[child]);
         assert_eq!(scene.node(new_child), None);
+    }
+
+    #[test]
+    fn property_and_command_payloads_reject_error_values_recursively() {
+        let property = PropertyId::new(1).expect("test property");
+        let command = CommandId::new(1).expect("test command");
+        let invalid_values = [
+            WhiskerValue::Error("top-level failure".to_owned()),
+            WhiskerValue::Array(vec![WhiskerValue::Error("nested failure".to_owned())]),
+            WhiskerValue::map([("nested", WhiskerValue::Error("nested failure".to_owned()))]),
+        ];
+
+        for value in invalid_values {
+            let (mut scene, root, _) = initial_tree();
+            let property_error = apply_next(
+                &mut scene,
+                vec![Operation::SetProperty {
+                    node: root,
+                    property,
+                    value: value.clone(),
+                }],
+            );
+            assert_eq!(
+                property_error,
+                Err(ValidationError::InvalidDataValue { node: root })
+            );
+            assert_eq!(scene.revision(), 1);
+
+            let command_error = apply_next(
+                &mut scene,
+                vec![Operation::InvokeCommand {
+                    node: root,
+                    command,
+                    arguments: value,
+                }],
+            );
+            assert_eq!(
+                command_error,
+                Err(ValidationError::InvalidDataValue { node: root })
+            );
+            assert_eq!(scene.revision(), 1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject `WhiskerValue::Error` in element property and command payloads
- reject nested error variants in arrays and maps
- preserve transactional frame state when such payloads are rejected

## Root cause
The runtime schema path rejected the reserved failure variant, but the frame protocol validator only checked that the target node existed. This left alternate packet producers able to put call failures into ordinary data slots.

## Performance
Scalar payloads add one constant-time enum check. Composite payloads are traversed only at the Host validation boundary, using the existing allocation-free `is_data` walk.

## Verification
- `cargo test -p whisker-protocol`
- `cargo clippy -p whisker-protocol --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`