### PR TITLE
fix(protocol): honor complete background capability

### DIFF
--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -306,9 +306,17 @@ impl RenderCapabilities {
     /// Returns how the Host implements a feature; omitted features are unsupported.
     pub fn support(&self, capability: RenderCapability) -> CapabilitySupport {
         let bit = capability.mask();
+        let background_subset = is_background_layer_subset(capability);
         if self.native & bit != 0 {
             CapabilitySupport::Native
         } else if self.emulated & bit != 0 {
+            CapabilitySupport::Emulated
+        } else if background_subset && self.native & RenderCapability::BackgroundLayers.mask() != 0
+        {
+            CapabilitySupport::Native
+        } else if background_subset
+            && self.emulated & RenderCapability::BackgroundLayers.mask() != 0
+        {
             CapabilitySupport::Emulated
         } else {
             CapabilitySupport::Unsupported
@@ -331,6 +339,18 @@ impl RenderCapabilities {
         }
         None
     }
+}
+
+const fn is_background_layer_subset(capability: RenderCapability) -> bool {
+    matches!(
+        capability,
+        RenderCapability::LinearGradients
+            | RenderCapability::RadialGradients
+            | RenderCapability::ConicGradients
+            | RenderCapability::BackgroundGeometry
+            | RenderCapability::BackgroundLayerStacking
+            | RenderCapability::BackgroundImageResources
+    )
 }
 
 impl FramePacket {
@@ -866,6 +886,65 @@ mod tests {
             }])
             .required_capabilities()
             .is_empty()
+        );
+    }
+
+    #[test]
+    fn complete_background_layer_support_satisfies_granular_requirements() {
+        let node = NodeId::new(1).unwrap();
+        let profile = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [CapabilityEntry {
+                capability: RenderCapability::BackgroundLayers,
+                support: CapabilitySupport::Native,
+            }],
+        )
+        .unwrap();
+        let packet = packet(vec![Operation::SetBackgroundLayers {
+            node,
+            layers: vec![explicit_no_repeat(basic_linear_layer())],
+        }]);
+
+        assert_eq!(
+            profile.support(RenderCapability::LinearGradients),
+            CapabilitySupport::Native
+        );
+        assert_eq!(
+            profile.support(RenderCapability::BackgroundGeometry),
+            CapabilitySupport::Native
+        );
+        assert_eq!(profile.first_unsupported(&packet), None);
+
+        let emulated = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [CapabilityEntry {
+                capability: RenderCapability::BackgroundLayers,
+                support: CapabilitySupport::Emulated,
+            }],
+        )
+        .unwrap();
+        assert_eq!(
+            emulated.support(RenderCapability::ConicGradients),
+            CapabilitySupport::Emulated
+        );
+
+        let granular_override = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [
+                CapabilityEntry {
+                    capability: RenderCapability::BackgroundLayers,
+                    support: CapabilitySupport::Emulated,
+                },
+                CapabilityEntry {
+                    capability: RenderCapability::LinearGradients,
+                    support: CapabilitySupport::Native,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            granular_override.support(RenderCapability::LinearGradients),
+            CapabilitySupport::Native
         );
     }
 


### PR DESCRIPTION
## Summary
- treat `BackgroundLayers` as the complete superset of granular background capabilities
- preserve an explicitly declared granular support mode when present
- cover native, emulated, and explicit-override negotiation

## Root cause
Capability lookup tested only an exact bit. A Host advertising the complete background-layer protocol was therefore rejected for a packet whose requirement was represented by a narrower gradient or geometry bit.

## Performance
Negotiation adds one enum match and, only when the exact bit is absent, one broad-capability mask check. No allocations or packet rescans are added.

## Verification
- `cargo test -p whisker-protocol`
- `cargo clippy -p whisker-protocol --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`