### PR TITLE
fix(desktop): reclaim stale prepared text buffers

### DIFF
--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -10,8 +10,8 @@ use whisker_protocol::{
     BoxClip, BoxPaint, ClipShape, Cursor, ElementTypeId, FillRule, FrameMode, FramePacket,
     HitTestBehavior, ImageRepeat, LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip,
     PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand, PointerId,
-    RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
-    ValidationError, Visibility, VisualEffects, WhiskerValue,
+    PreparedContentId, RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent,
+    Transform, ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
 
 use crate::DesktopTextInputEvent;
@@ -343,6 +343,8 @@ pub(crate) struct DesktopScene {
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,
     raster_resources: HashSet<ResourceId>,
+    prepared_content_references: HashMap<PreparedContentId, usize>,
+    prepared_content_revision: u64,
 }
 
 impl fmt::Display for DesktopPresentError {

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -10,7 +10,8 @@ use whisker_protocol::{
     ElementMeasurement, ElementPropertySchema, ElementRegistration, ElementValueKind, EventId,
     FrameHeader, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
     MeasureTextOverflow, MeasureTextWrap, PaintCorners, PaintEdges, PaintLengthPercentage,
-    PropertyId, ProtocolVersion, TextMeasurePayload, TextMeasureStyle, TextPaint,
+    PreparedContentId, PropertyId, ProtocolVersion, TextMeasurePayload, TextMeasureStyle,
+    TextPaint,
 };
 
 fn element_type(name: &str) -> ElementTypeId {
@@ -108,6 +109,13 @@ fn text() -> TextContent {
         },
         paint: TextPaint::default(),
         prepared_content: None,
+    }
+}
+
+fn prepared_text(id: u64) -> TextContent {
+    TextContent {
+        prepared_content: PreparedContentId::new(id),
+        ..text()
     }
 }
 
@@ -1246,6 +1254,82 @@ fn text_content_operation_is_dispatched_by_registered_element_type() {
         scene.paint_commands().as_slice(),
         [PaintCommand::Box { .. }, PaintCommand::Text { node, .. }] if *node == root
     ));
+}
+
+#[test]
+fn prepared_text_references_follow_committed_scene_content() {
+    let node = id(1);
+    let first = PreparedContentId::new(11).unwrap();
+    let second = PreparedContentId::new(12).unwrap();
+    let rejected = PreparedContentId::new(13).unwrap();
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node,
+                    element_type: element_type(whisker::TEXT_ELEMENT_NAME),
+                },
+                Operation::SetText {
+                    node,
+                    content: prepared_text(first.get()),
+                },
+            ],
+        ))
+        .unwrap();
+    let first_revision = scene.prepared_content_revision();
+    assert!(scene.references_prepared_content(first));
+
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::SetText {
+                node,
+                content: prepared_text(second.get()),
+            }],
+        ))
+        .unwrap();
+    assert!(scene.prepared_content_revision() > first_revision);
+    assert!(!scene.references_prepared_content(first));
+    assert!(scene.references_prepared_content(second));
+
+    assert!(
+        scene
+            .present(&packet(
+                FrameMode::Delta,
+                2,
+                3,
+                vec![
+                    Operation::SetText {
+                        node,
+                        content: prepared_text(rejected.get()),
+                    },
+                    Operation::SetOpacity {
+                        node,
+                        opacity: f32::NAN,
+                    },
+                ],
+            ))
+            .is_err()
+    );
+    assert!(!scene.references_prepared_content(rejected));
+    assert!(scene.references_prepared_content(second));
+
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            2,
+            3,
+            vec![Operation::DeleteNode { node }],
+        ))
+        .unwrap();
+    assert!(!scene.references_prepared_content(second));
 }
 
 #[test]

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -21,7 +21,17 @@ impl DesktopScene {
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
             raster_resources: HashSet::new(),
+            prepared_content_references: HashMap::new(),
+            prepared_content_revision: 0,
         }
+    }
+
+    pub(crate) fn prepared_content_revision(&self) -> u64 {
+        self.prepared_content_revision
+    }
+
+    pub(crate) fn references_prepared_content(&self, id: PreparedContentId) -> bool {
+        self.prepared_content_references.contains_key(&id)
     }
 
     pub(crate) fn register_raster_resource(&mut self, resource: ResourceId) {
@@ -915,6 +925,10 @@ impl DesktopScene {
             for (_, node) in nodes {
                 self.recycle_presentation(node);
             }
+            if !self.prepared_content_references.is_empty() {
+                self.prepared_content_references.clear();
+                self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
+            }
             self.pending_events.lock().unwrap().clear();
             self.pointer_captures.clear();
         }
@@ -1066,12 +1080,19 @@ impl DesktopScene {
                         .z_order = *z_order;
                 }
                 Operation::SetText { node, content } => {
+                    let previous = self
+                        .nodes
+                        .get(node)
+                        .and_then(|state| state.content.text())
+                        .and_then(|content| content.prepared_content);
+                    let next = content.prepared_content;
                     self.nodes
                         .get_mut(node)
                         .expect("validated node")
                         .content
                         .set_text(*node, content.clone())
                         .expect("element content operation was validated before commit");
+                    self.replace_prepared_content_reference(previous, next);
                 }
                 Operation::SetTextStyle { node, style } => {
                     self.nodes
@@ -1188,7 +1209,39 @@ impl DesktopScene {
         for child in children {
             self.delete_subtree(child);
         }
+        self.replace_prepared_content_reference(
+            removed
+                .content
+                .text()
+                .and_then(|content| content.prepared_content),
+            None,
+        );
         self.recycle_presentation(removed);
+    }
+
+    fn replace_prepared_content_reference(
+        &mut self,
+        previous: Option<PreparedContentId>,
+        next: Option<PreparedContentId>,
+    ) {
+        if previous == next {
+            return;
+        }
+        if let Some(previous) = previous {
+            let remove = if let Some(count) = self.prepared_content_references.get_mut(&previous) {
+                *count -= 1;
+                *count == 0
+            } else {
+                false
+            };
+            if remove {
+                self.prepared_content_references.remove(&previous);
+            }
+        }
+        if let Some(next) = next {
+            *self.prepared_content_references.entry(next).or_default() += 1;
+        }
+        self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
     }
 
     fn recycle_presentation(&mut self, mut node: RenderNode) {

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -14,6 +14,8 @@ use crate::text::NativeTextHost;
 pub(crate) struct DesktopSurface {
     scene: DesktopScene,
     gpu: GpuRenderer,
+    last_preparation_generation: u64,
+    last_prepared_content_revision: u64,
 }
 
 impl DesktopSurface {
@@ -28,6 +30,8 @@ impl DesktopSurface {
         Ok(Self {
             scene: DesktopScene::new_with_wake(surface, elements, event_wake),
             gpu: GpuRenderer::new(target, physical_size, background_rgb).await?,
+            last_preparation_generation: 0,
+            last_prepared_content_revision: 0,
         })
     }
 
@@ -55,6 +59,15 @@ impl DesktopSurface {
         logical_size: [f32; 2],
         scale: f32,
     ) -> Result<(), GpuError> {
+        let preparation_generation = text.preparation_generation();
+        let prepared_content_revision = self.scene.prepared_content_revision();
+        if preparation_generation != self.last_preparation_generation
+            || prepared_content_revision != self.last_prepared_content_revision
+        {
+            text.retain_prepared(|id| self.scene.references_prepared_content(id));
+            self.last_preparation_generation = preparation_generation;
+            self.last_prepared_content_revision = prepared_content_revision;
+        }
         self.gpu
             .render(&self.scene.paint_commands(), text, logical_size, scale)
     }

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -25,6 +25,7 @@ pub(crate) struct NativeTextHost {
     pub(crate) font_system: FontSystem,
     pub(crate) swash_cache: SwashCache,
     pub(crate) prepared: HashMap<PreparedContentId, PreparedText>,
+    preparation_generation: u64,
 }
 
 fn cosmic_alignment(value: whisker_protocol::MeasureTextAlignment) -> Option<Align> {
@@ -59,7 +60,19 @@ impl NativeTextHost {
             font_system: FontSystem::new(),
             swash_cache: SwashCache::new(),
             prepared: HashMap::new(),
+            preparation_generation: 0,
         }
+    }
+
+    pub(crate) fn preparation_generation(&self) -> u64 {
+        self.preparation_generation
+    }
+
+    pub(crate) fn retain_prepared(
+        &mut self,
+        mut referenced: impl FnMut(PreparedContentId) -> bool,
+    ) {
+        self.prepared.retain(|id, _| referenced(*id));
     }
 
     fn shape_text(
@@ -306,6 +319,7 @@ impl MeasurementProvider for NativeTextHost {
                     let id = PreparedContentId::new(request.key.get())
                         .expect("measurement keys are always non-zero");
                     self.prepared.insert(id, prepared);
+                    self.preparation_generation = self.preparation_generation.wrapping_add(1);
                     metrics.prepared_content = Some(id);
                     MeasurementResponse::Ready {
                         key: request.key,
@@ -437,6 +451,40 @@ mod tests {
         assert!(metrics.last_baseline.is_some());
         let prepared = metrics.prepared_content.unwrap();
         assert!(host.prepared.contains_key(&prepared));
+    }
+
+    #[test]
+    fn prepared_text_cache_discards_content_not_referenced_by_the_scene() {
+        let payload = MeasurementPayload::Text(TextMeasurePayload {
+            text: "Whisker".into(),
+            style: whisker_protocol::TextMeasureStyle::default(),
+            locale: None,
+            direction: whisker_protocol::MeasureTextDirection::Auto,
+            alignment: whisker_protocol::MeasureTextAlignment::Start,
+            indent: Default::default(),
+            wrap: MeasureTextWrap::Wrap,
+            word_break: Default::default(),
+            max_lines: None,
+            overflow: whisker_protocol::MeasureTextOverflow::Clip,
+        });
+        let mut host = NativeTextHost::new(registry());
+        let mut responses = Vec::new();
+        host.measure_batch(
+            SurfaceId::new(1).unwrap(),
+            &[request(7, payload.clone()), request(8, payload)],
+            &mut responses,
+        )
+        .unwrap();
+        let generation = host.preparation_generation();
+
+        host.retain_prepared(|id| id == PreparedContentId::new(8).unwrap());
+
+        assert_eq!(host.prepared.len(), 1);
+        assert!(
+            host.prepared
+                .contains_key(&PreparedContentId::new(8).unwrap())
+        );
+        assert_eq!(host.preparation_generation(), generation);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- track prepared text IDs referenced by the committed Desktop scene
- reclaim superseded, deleted, and uncommitted cosmic-text buffers
- skip cache scans on steady-state frames by comparing measurement and scene generations

## Performance
- SetText/delete update one refcount in O(1)
- ordinary paint adds only two integer comparisons
- cleanup performs one allocation-free HashMap retain only after text preparation or reference changes

## Tests
- cargo test -p whisker-desktop --lib
- cargo clippy -p whisker-desktop --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check