### PR TITLE
fix(web): preserve ScrollView overflow state

### DIFF
--- a/platforms/web/src/paint/clip.rs
+++ b/platforms/web/src/paint/clip.rs
@@ -7,18 +7,15 @@ pub(crate) fn apply(
     clip: BoxClip,
     scroll_content: bool,
 ) -> Result<(), WebError> {
-    let [horizontal, vertical] = overflow(clip, scroll_content);
+    if scroll_content {
+        return Ok(());
+    }
+    let [horizontal, vertical] = overflow(clip);
     set_style(element, "overflow-x", horizontal)?;
     set_style(element, "overflow-y", vertical)
 }
 
-fn overflow(clip: BoxClip, scroll_content: bool) -> [&'static str; 2] {
-    if scroll_content {
-        // A built-in ScrollView is a vertical native scroll container. Its
-        // base style clips overflowing content, but that clip must not replace
-        // the Host's scrolling mechanism with CSS `overflow: hidden`.
-        return ["hidden", "auto"];
-    }
+fn overflow(clip: BoxClip) -> [&'static str; 2] {
     [overflow_axis(clip.horizontal), overflow_axis(clip.vertical)]
 }
 
@@ -34,20 +31,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn scroll_container_keeps_vertical_native_scrolling_enabled() {
-        let hidden = BoxClip {
-            horizontal: OverflowClip::Hidden,
-            vertical: OverflowClip::Hidden,
-        };
-        assert_eq!(overflow(hidden, true), ["hidden", "auto"]);
-    }
-
-    #[test]
     fn ordinary_elements_follow_the_protocol_clip() {
         let mixed = BoxClip {
             horizontal: OverflowClip::Hidden,
             vertical: OverflowClip::Visible,
         };
-        assert_eq!(overflow(mixed, false), ["clip", "visible"]);
+        assert_eq!(overflow(mixed), ["clip", "visible"]);
     }
 }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -188,6 +188,14 @@ async fn scroll_view_emits_geometry_and_honors_scroll_behavior() {
         .command_named("scrollTo")
         .unwrap()
         .command;
+    let scroll_orientation = scroll_registration
+        .property_named("scroll-orientation")
+        .unwrap()
+        .property;
+    let enable_scroll = scroll_registration
+        .property_named("enable-scroll")
+        .unwrap()
+        .property;
     let view_type = registry
         .registration_for_builtin(whisker::ElementTag::View)
         .unwrap()
@@ -330,6 +338,70 @@ async fn scroll_view_emits_geometry_and_honors_scroll_behavior() {
         wait_ms(50).await;
     }
     assert_eq!(element.scroll_top(), 200);
+
+    driver
+        .sink
+        .present(&FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 4,
+                base_revision: 3,
+                target_revision: 4,
+                viewport_epoch: 1,
+                mode: FrameMode::Delta,
+            },
+            operations: vec![
+                Operation::SetProperty {
+                    node: scroll,
+                    property: scroll_orientation,
+                    value: WhiskerValue::String("horizontal".into()),
+                },
+                Operation::SetClip {
+                    node: scroll,
+                    clip: BoxClip {
+                        horizontal: OverflowClip::Hidden,
+                        vertical: OverflowClip::Hidden,
+                    },
+                },
+            ],
+        })
+        .unwrap();
+    assert_style(&element.style(), "overflow-x", "auto");
+    assert_style(&element.style(), "overflow-y", "hidden");
+
+    driver
+        .sink
+        .present(&FramePacket {
+            header: FrameHeader {
+                version: ProtocolVersion::CURRENT,
+                surface: SurfaceId::new(1).unwrap(),
+                scene_epoch: 1,
+                frame_id: 5,
+                base_revision: 4,
+                target_revision: 5,
+                viewport_epoch: 1,
+                mode: FrameMode::Delta,
+            },
+            operations: vec![
+                Operation::SetProperty {
+                    node: scroll,
+                    property: enable_scroll,
+                    value: WhiskerValue::Bool(false),
+                },
+                Operation::SetClip {
+                    node: scroll,
+                    clip: BoxClip {
+                        horizontal: OverflowClip::Visible,
+                        vertical: OverflowClip::Visible,
+                    },
+                },
+            ],
+        })
+        .unwrap();
+    assert_style(&element.style(), "overflow-x", "hidden");
+    assert_style(&element.style(), "overflow-y", "hidden");
 }
 
 async fn wait_ms(milliseconds: i32) {


### PR DESCRIPTION
## Summary
- keep common SetClip from overwriting a Web ScrollView native overflow mechanism
- preserve horizontal orientation and disabled scrolling after later clip updates
- extend the browser ScrollView test across both states

ScrollView clipping is owned by its element implementation; ordinary elements continue to map BoxClip to CSS overflow per axis.

## Tests
- cargo xtask host-conformance web
- cargo clippy -p whisker-web --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check