### PR TITLE
perf(web): batch DOM text measurements

### DIFF
--- a/platforms/web/src/measure/text.rs
+++ b/platforms/web/src/measure/text.rs
@@ -16,6 +16,16 @@ pub(crate) struct DomMeasurementProvider {
     module_measurements: HashMap<ElementTypeId, WebMeasurementHandler>,
 }
 
+enum PendingMeasurement {
+    Ready(MeasurementResponse),
+    Text {
+        probe: web_sys::Element,
+        key: whisker_protocol::MeasurementKey,
+        environment_epoch: u64,
+        baseline: f32,
+    },
+}
+
 impl DomMeasurementProvider {
     pub(crate) fn new(document: web_sys::Document) -> Self {
         Self {
@@ -69,9 +79,10 @@ impl MeasurementProvider for DomMeasurementProvider {
             .document
             .body()
             .ok_or_else(|| WebError("document body is unavailable".into()))?;
+        let mut pending = Vec::with_capacity(requests.len());
         for request in requests {
             if let Some(measure) = self.module_measurements.get(&request.element_type) {
-                responses.push(match measure(&request.into()) {
+                pending.push(PendingMeasurement::Ready(match measure(&request.into()) {
                     Some(size) => MeasurementResponse::Ready {
                         key: request.key,
                         environment_epoch: request.environment_epoch,
@@ -82,7 +93,7 @@ impl MeasurementProvider for DomMeasurementProvider {
                         environment_epoch: request.environment_epoch,
                         reason: UnsupportedMeasurementReason::Feature,
                     },
-                });
+                }));
                 continue;
             }
             let MeasurementPayload::Text(text) = &request.payload else {
@@ -94,11 +105,13 @@ impl MeasurementProvider for DomMeasurementProvider {
                 } else {
                     UnsupportedMeasurementReason::Element
                 };
-                responses.push(MeasurementResponse::Unsupported {
-                    key: request.key,
-                    environment_epoch: request.environment_epoch,
-                    reason,
-                });
+                pending.push(PendingMeasurement::Ready(
+                    MeasurementResponse::Unsupported {
+                        key: request.key,
+                        environment_epoch: request.environment_epoch,
+                        reason,
+                    },
+                ));
                 continue;
             };
             let probe = self
@@ -126,22 +139,54 @@ impl MeasurementProvider for DomMeasurementProvider {
                 set_style(&probe, "height", &px(height))?;
             }
             probe.set_text_content(Some(&text.text));
-            body.append_child(&probe)
-                .map_err(|error| js_error("attach text measurement probe", error))?;
-            let rect = probe.get_bounding_client_rect();
-            probe.remove();
-            let baseline = text.style.font_size * 0.8;
-            responses.push(MeasurementResponse::Ready {
+            pending.push(PendingMeasurement::Text {
+                probe,
                 key: request.key,
                 environment_epoch: request.environment_epoch,
-                metrics: MeasurementMetrics {
-                    size: MeasuredSize::new(rect.width() as f32, rect.height() as f32),
-                    first_baseline: Some(baseline),
-                    last_baseline: Some(baseline),
-                    overflow: None,
-                    prepared_content: PreparedContentId::new(request.key.get()),
-                },
+                baseline: text.style.font_size * 0.8,
             });
+        }
+        for measurement in &pending {
+            if let PendingMeasurement::Text { probe, .. } = measurement
+                && let Err(error) = body.append_child(probe)
+            {
+                for attached in &pending {
+                    if let PendingMeasurement::Text { probe, .. } = attached {
+                        probe.remove();
+                    }
+                }
+                return Err(js_error("attach text measurement probe", error));
+            }
+        }
+        responses.reserve(pending.len());
+        for measurement in &pending {
+            match measurement {
+                PendingMeasurement::Ready(response) => responses.push(response.clone()),
+                PendingMeasurement::Text {
+                    probe,
+                    key,
+                    environment_epoch,
+                    baseline,
+                } => {
+                    let rect = probe.get_bounding_client_rect();
+                    responses.push(MeasurementResponse::Ready {
+                        key: *key,
+                        environment_epoch: *environment_epoch,
+                        metrics: MeasurementMetrics {
+                            size: MeasuredSize::new(rect.width() as f32, rect.height() as f32),
+                            first_baseline: Some(*baseline),
+                            last_baseline: Some(*baseline),
+                            overflow: None,
+                            prepared_content: PreparedContentId::new(key.get()),
+                        },
+                    });
+                }
+            }
+        }
+        for measurement in pending {
+            if let PendingMeasurement::Text { probe, .. } = measurement {
+                probe.remove();
+            }
         }
         Ok(())
     }

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -67,6 +67,55 @@ fn browser_pointer_metadata_maps_to_protocol_values() {
 }
 
 #[wasm_bindgen_test]
+fn text_measurement_batch_preserves_response_order_and_cleans_up_probes() {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let body = document.body().unwrap();
+    let children_before = body.child_element_count();
+    let text_type = ElementRegistry::standard()
+        .registration_for_builtin(whisker::ElementTag::Text)
+        .unwrap()
+        .element_type;
+    let request = |key: u64, value: &str| MeasurementRequest {
+        key: MeasurementKey::new(key).unwrap(),
+        node: NodeId::new(key).unwrap(),
+        element_type: text_type,
+        environment_epoch: 1,
+        constraints: MeasureConstraints {
+            known_dimensions: [None, None],
+            available_space: [AvailableSpace::Definite(200.0), AvailableSpace::MaxContent],
+        },
+        payload: MeasurementPayload::Text(TextMeasurePayload {
+            text: value.into(),
+            style: TextMeasureStyle {
+                font_size: 16.0,
+                line_height: MeasureLineHeight::LogicalPixels(20.0),
+                ..TextMeasureStyle::default()
+            },
+            locale: None,
+            direction: MeasureTextDirection::Auto,
+            alignment: whisker_protocol::MeasureTextAlignment::Start,
+            indent: Default::default(),
+            wrap: MeasureTextWrap::Wrap,
+            word_break: MeasureTextWordBreak::Normal,
+            max_lines: None,
+            overflow: MeasureTextOverflow::Clip,
+        }),
+    };
+    let requests = [request(7, "short"), request(8, "a longer string")];
+    let mut provider = DomMeasurementProvider::new(document);
+    let mut responses = Vec::new();
+
+    provider
+        .measure_batch(SurfaceId::new(1).unwrap(), &requests, &mut responses)
+        .unwrap();
+
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0].key(), MeasurementKey::new(7).unwrap());
+    assert_eq!(responses[1].key(), MeasurementKey::new(8).unwrap());
+    assert_eq!(body.child_element_count(), children_before);
+}
+
+#[wasm_bindgen_test]
 fn accessibility_protocol_maps_to_dom_semantics() {
     let mut driver = Driver::new();
     let view_type = ElementRegistry::standard()


### PR DESCRIPTION
## Summary
- prepare all text probes before attaching any of them
- attach the complete batch before the first layout read
- defer all removals until every bounding rect has been read
- preserve mixed response order and clean probes on attachment errors

This reduces a text batch from up to N forced browser reflows to one layout phase without changing the protocol contract.

## Tests
- cargo xtask host-conformance web
- cargo clippy -p whisker-web --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check