### PR TITLE
perf(web): sync only direct child layouts

### DIFF
--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -633,12 +633,16 @@ impl DomFrameSink {
     }
 
     fn sync_child_layouts(&self, parent: NodeId) -> Result<(), WebError> {
-        let children = self
-            .parents
-            .iter()
-            .filter_map(|(child, candidate)| (*candidate == parent).then_some(*child))
-            .collect::<Vec<_>>();
-        for child in children {
+        let children = self.node(parent)?.children();
+        for index in 0..children.length() {
+            let Some(child) = children
+                .item(index)
+                .and_then(|element| element.get_attribute("data-whisker-node"))
+                .and_then(|value| value.parse().ok())
+                .and_then(NodeId::new)
+            else {
+                continue;
+            };
             self.sync_layout(child)?;
         }
         Ok(())


### PR DESCRIPTION
## Summary
- enumerate a parent DOM element direct Whisker children when its border changes
- remove the full parents-map scan and temporary Vec allocation from sync_child_layouts
- skip module-owned internal DOM children without a Whisker node id

A parent update is now O(direct children) instead of O(all scene nodes), with no additional retained index.

## Tests
- cargo xtask host-conformance web
- cargo check -p whisker-web --target wasm32-unknown-unknown
- cargo clippy -p whisker-web --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check