### PR TITLE
fix(ios): measure multiline ellipsis height correctly

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
@@ -133,9 +133,7 @@ func whiskerTextParagraphStyle(
     case 3: .right
     default: .center
     }
-    paragraph.lineBreakMode = request.overflow != 0
-        ? .byTruncatingTail
-        : (request.word_break == 1 ? .byCharWrapping : .byWordWrapping)
+    paragraph.lineBreakMode = request.word_break == 1 ? .byCharWrapping : .byWordWrapping
     if request.line_height > 0 {
         paragraph.minimumLineHeight = CGFloat(request.line_height)
         paragraph.maximumLineHeight = CGFloat(request.line_height)

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -60,6 +60,16 @@ final class HostConformanceTests: XCTestCase {
         }
     }
 
+    func testEllipsisMeasurementKeepsMultilineWrapping() {
+        var request = WhiskerMobileMeasureRequest()
+        request.overflow = 1
+        request.word_break = 0
+
+        let paragraph = whiskerTextParagraphStyle(request, widthBasis: 80)
+
+        XCTAssertEqual(paragraph.lineBreakMode, .byWordWrapping)
+    }
+
     func testModuleEventsReachOnlyObservingSurfacesAndLifecycleIsAggregated() {
         let module = EventLifecycleTestModule()
         module.qualifiedName = "event-test:Clock"


### PR DESCRIPTION
## Summary
- keep intrinsic text measurement in word/character wrapping mode even when paint uses ellipsis
- preserve multiline height before applying the existing max-lines clamp
- add an iOS host conformance regression test

## Performance
- no additional allocation or traversal; this only selects the correct paragraph line-break mode

## Test
- `cargo xtask host-conformance ios`