### PR TITLE
fix(mobile): prevent element-event reentry during present

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostEventGate.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostEventGate.kt
@@ -1,0 +1,29 @@
+package rs.whisker.runtime.scene
+
+/** Prevents Host element callbacks from re-entering Rust while a frame is being presented. */
+internal class HostEventGate(
+    private val schedule: (() -> Unit) -> Unit,
+) {
+    private var isApplyingFrame = false
+    private val deferred = ArrayList<() -> Unit>()
+
+    fun beginFrame() {
+        check(!isApplyingFrame)
+        isApplyingFrame = true
+    }
+
+    fun endFrame() {
+        check(isApplyingFrame)
+        isApplyingFrame = false
+        if (deferred.isEmpty()) return
+        val events = deferred.toList()
+        deferred.clear()
+        schedule {
+            events.forEach { it() }
+        }
+    }
+
+    fun dispatch(event: () -> Unit) {
+        if (isApplyingFrame) deferred += event else event()
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -88,8 +88,7 @@ internal class HostScene(
     private var stagedTargetRevision = 0L
     private var stagedSnapshot = false
     private val stagedOperations = ArrayList<HostSceneOperation>()
-    private var applyingFrame = false
-    private val deferredEvents = ArrayList<() -> Unit>()
+    private val eventGate = HostEventGate { event -> root.post(event) }
     private val pointerCaptures = HashMap<Long, Long>()
 
     /** 0 stages a transaction, 1 asks Rust for a snapshot, 2 rejects. */
@@ -119,7 +118,7 @@ internal class HostScene(
             return false
         }
         return try {
-            applyingFrame = true
+            eventGate.beginFrame()
             if (stagedSnapshot) clear()
             stagedOperations.forEach(::applyOperation)
             attachRoots()
@@ -133,15 +132,12 @@ internal class HostScene(
             Log.e("WhiskerView", "Frame commit failed", error)
             false
         } finally {
-            applyingFrame = false
-            val events = deferredEvents.toList()
-            deferredEvents.clear()
-            events.forEach { it() }
+            eventGate.endFrame()
         }
     }
 
     fun dispatchOrDefer(event: () -> Unit) {
-        if (applyingFrame) deferredEvents += event else event()
+        eventGate.dispatch(event)
     }
 
     fun clear() {

--- a/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/scene/HostEventGateTest.kt
+++ b/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/scene/HostEventGateTest.kt
@@ -1,0 +1,23 @@
+package rs.whisker.runtime.scene
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HostEventGateTest {
+    @Test
+    fun elementEventsWaitUntilAfterFramePresentationReturns() {
+        var scheduled: (() -> Unit)? = null
+        val gate = HostEventGate { scheduled = it }
+        val events = mutableListOf<String>()
+
+        gate.beginFrame()
+        gate.dispatch { events += "first" }
+        gate.dispatch { events += "second" }
+        gate.endFrame()
+
+        assertTrue(events.isEmpty())
+        scheduled?.invoke()
+        assertEquals(listOf("first", "second"), events)
+    }
+}

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostEventGate.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostEventGate.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Prevents Host element callbacks from re-entering Rust while a frame is being presented.
+final class HostEventGate {
+    private let schedule: (@escaping () -> Void) -> Void
+    private var isApplyingFrame = false
+    private var deferred: [() -> Void] = []
+
+    init(schedule: @escaping (@escaping () -> Void) -> Void) {
+        self.schedule = schedule
+    }
+
+    func beginFrame() {
+        precondition(!isApplyingFrame)
+        isApplyingFrame = true
+    }
+
+    func endFrame() {
+        precondition(isApplyingFrame)
+        isApplyingFrame = false
+        guard !deferred.isEmpty else { return }
+        let events = deferred
+        deferred.removeAll(keepingCapacity: true)
+        schedule {
+            events.forEach { $0() }
+        }
+    }
+
+    func dispatch(_ event: @escaping () -> Void) {
+        if isApplyingFrame {
+            deferred.append(event)
+        } else {
+            event()
+        }
+    }
+}

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -14,8 +14,9 @@ final class HostScene {
     private var zOrders: [UInt64: Int32] = [:]
     private var sceneEpoch: UInt32 = 0
     private var revision: UInt64 = 0
-    private var applyingFrame = false
-    private var deferredEvents: [() -> Void] = []
+    private let eventGate = HostEventGate { event in
+        DispatchQueue.main.async(execute: event)
+    }
     private var pointerCaptures: [UInt64: UInt64] = [:]
 
     init(
@@ -59,12 +60,9 @@ final class HostScene {
             response.revision = revision
             return true
         }
-        applyingFrame = true
+        eventGate.beginFrame()
         defer {
-            applyingFrame = false
-            let events = deferredEvents
-            deferredEvents.removeAll()
-            events.forEach { $0() }
+            eventGate.endFrame()
         }
         if frame.mode == UInt8(WHISKER_FRAME_SNAPSHOT) { clear() }
         for operation in values where !apply(operation) {
@@ -82,7 +80,7 @@ final class HostScene {
     }
 
     func dispatchOrDefer(_ event: @escaping () -> Void) {
-        if applyingFrame { deferredEvents.append(event) } else { event() }
+        eventGate.dispatch(event)
     }
 
     func clear() {

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -27,6 +27,21 @@ final class HostConformanceTests: XCTestCase {
         WhiskerModuleKernel.install(BuiltInElementModule())
     }
 
+    func testElementEventsWaitUntilAfterFramePresentationReturns() {
+        var scheduled: (() -> Void)?
+        let gate = HostEventGate { scheduled = $0 }
+        var events: [String] = []
+
+        gate.beginFrame()
+        gate.dispatch { events.append("first") }
+        gate.dispatch { events.append("second") }
+        gate.endFrame()
+
+        XCTAssertTrue(events.isEmpty)
+        scheduled?()
+        XCTAssertEqual(events, ["first", "second"])
+    }
+
     func testPointerCaptureOperationsReachTheUIKitSurface() {
         let view = WhiskerView(frame: .zero)
         let registration = WhiskerElementRegistration(


### PR DESCRIPTION
## Summary
- queue iOS and Android element events raised while applying a frame
- deliver the FIFO batch on the next UI-loop turn, after the Host present callback has returned to Rust
- share the same event-gate execution model across both mobile Hosts
- add focused Swift and Kotlin regression tests

## Performance
- event-free frames only pay a boolean transition and an empty check
- allocations and UI-loop scheduling happen only when native elements emit during frame application
- ordinary scroll events outside frame application keep their existing coalescing path

## Tests
- `cargo xtask host-conformance ios`
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:testDebugUnitTest --no-daemon`