### PR TITLE
perf(ios): make z-order projection incremental

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -66,14 +66,19 @@ final class HostScene {
             deferredEvents.removeAll()
             events.forEach { $0() }
         }
-        if frame.mode == UInt8(WHISKER_FRAME_SNAPSHOT) { clear() }
-        for operation in values where !apply(operation) {
-            response.status = UInt8(WHISKER_APPLY_REJECTED)
-            response.revision = revision
-            return true
+        let snapshot = frame.mode == UInt8(WHISKER_FRAME_SNAPSHOT)
+        if snapshot { clear() }
+        var zOrderParents = Set<UInt64>()
+        for operation in values {
+            recordZOrderImpact(operation, into: &zOrderParents)
+            if !apply(operation) {
+                response.status = UInt8(WHISKER_APPLY_REJECTED)
+                response.revision = revision
+                return true
+            }
         }
         attachRoots()
-        refreshZOrderProjection()
+        refreshZOrderProjection(parentKeys: snapshot ? nil : zOrderParents)
         sceneEpoch = frame.scene_epoch
         revision = frame.target_revision
         response.status = UInt8(WHISKER_APPLY_ACCEPTED)
@@ -531,31 +536,55 @@ final class HostScene {
         }
     }
 
-    private func normalizeZOrder(parent parentID: UInt64?) {
-        let creationOrder = Dictionary(uniqueKeysWithValues: nodeOrder.enumerated().map { ($1, $0) })
+    private func recordZOrderImpact(
+        _ operation: WhiskerMobileOperation,
+        into parentKeys: inout Set<UInt64>
+    ) {
+        let rootKey: UInt64 = 0
+        switch operation.tag {
+        case UInt32(WHISKER_OP_CREATE):
+            parentKeys.insert(rootKey)
+        case UInt32(WHISKER_OP_DELETE), UInt32(WHISKER_OP_Z_ORDER):
+            parentKeys.insert(parents[operation.node] ?? rootKey)
+        case UInt32(WHISKER_OP_INSERT):
+            parentKeys.insert(rootKey)
+            parentKeys.insert(operation.parent)
+        case UInt32(WHISKER_OP_REMOVE):
+            parentKeys.insert(operation.parent)
+            parentKeys.insert(rootKey)
+        case UInt32(WHISKER_OP_MOVE):
+            parentKeys.insert(operation.parent)
+        default:
+            break
+        }
+    }
+
+    private func normalizeZOrder(
+        parent parentID: UInt64?,
+        siblings: [UInt64],
+        idsByView: [ObjectIdentifier: UInt64]
+    ) {
         let host: UIView?
         if let parentID, let parent = nodes[parentID] {
             host = parent.sceneChildrenHost()
         } else {
             host = root
         }
-        let idsByView = Dictionary(uniqueKeysWithValues: nodes.map { (ObjectIdentifier($1), $0) })
         let siblingPairs: [(UInt64, Int)] = (host?.subviews ?? []).enumerated()
             .compactMap { index, view in
                 guard let id = idsByView[ObjectIdentifier(view)] else { return nil }
                 return (id, index)
             }
         let siblingOrder = Dictionary(uniqueKeysWithValues: siblingPairs)
-        let siblings = nodeOrder.filter { id in
-            nodes[id] != nil && parents[id] == parentID
-        }.sorted { left, right in
+        let creationOrder = Dictionary(uniqueKeysWithValues: siblings.enumerated().map { ($1, $0) })
+        let ordered = siblings.sorted { left, right in
             let leftZ = zOrders[left] ?? 0
             let rightZ = zOrders[right] ?? 0
             if leftZ != rightZ { return leftZ < rightZ }
             return siblingOrder[left, default: creationOrder[left, default: 0]] <
                 siblingOrder[right, default: creationOrder[right, default: 0]]
         }
-        for id in siblings {
+        for id in ordered {
             guard let node = nodes[id] else { continue }
             // `CALayer.render(in:)`, used by deterministic Host capture as
             // well as some UIKit snapshot paths, preserves sublayer order but
@@ -566,10 +595,31 @@ final class HostScene {
         }
     }
 
-    private func refreshZOrderProjection() {
-        normalizeZOrder(parent: nil)
-        for parentID in Set(parents.values).sorted() where nodes[parentID] != nil {
-            normalizeZOrder(parent: parentID)
+    private func refreshZOrderProjection(parentKeys requested: Set<UInt64>?) {
+        let rootKey: UInt64 = 0
+        var parentKeys: Set<UInt64>
+        if let requested {
+            parentKeys = requested
+        } else {
+            parentKeys = Set(parents.values)
+            parentKeys.insert(rootKey)
+        }
+        guard !parentKeys.isEmpty else { return }
+
+        var siblingsByParent: [UInt64: [UInt64]] = [:]
+        var idsByView: [ObjectIdentifier: UInt64] = [:]
+        for id in nodeOrder where nodes[id] != nil {
+            let parentKey = parents[id] ?? rootKey
+            guard parentKeys.contains(parentKey), let node = nodes[id] else { continue }
+            siblingsByParent[parentKey, default: []].append(id)
+            idsByView[ObjectIdentifier(node)] = id
+        }
+        for parentKey in parentKeys.sorted() {
+            normalizeZOrder(
+                parent: parentKey == rootKey ? nil : parentKey,
+                siblings: siblingsByParent[parentKey] ?? [],
+                idsByView: idsByView
+            )
         }
     }
 

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -20,11 +20,81 @@ private final class EventLifecycleTestModule: Module {
     }
 }
 
+private final class ZOrderCountingView: UIView {
+    var reorderCount = 0
+
+    override func bringSubviewToFront(_ view: UIView) {
+        reorderCount += 1
+        super.bringSubviewToFront(view)
+    }
+}
+
 @MainActor
 final class HostConformanceTests: XCTestCase {
     override class func setUp() {
         super.setUp()
         WhiskerModuleKernel.install(BuiltInElementModule())
+    }
+
+    func testPaintOnlyFrameDoesNotReprojectRootZOrder() {
+        let root = ZOrderCountingView()
+        let scene = HostScene(
+            root: root,
+            resources: HostResourceStore(),
+            logicalBounds: { CGRect(x: 0, y: 0, width: 100, height: 100) },
+            emitElementEvent: { _, _, _ in }
+        )
+        let registration = WhiskerElementRegistration(
+            elementType: 1,
+            name: WhiskerBuiltInElements.viewName,
+            childPolicy: .elements,
+            measurement: .none
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+
+        func present(
+            _ operations: inout [WhiskerMobileOperation],
+            mode: UInt8,
+            baseRevision: UInt64,
+            targetRevision: UInt64
+        ) {
+            operations.withUnsafeMutableBufferPointer { buffer in
+                var frame = WhiskerMobileFrame()
+                frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
+                frame.protocol_major = 1
+                frame.mode = mode
+                frame.scene_epoch = 1
+                frame.base_revision = baseRevision
+                frame.target_revision = targetRevision
+                frame.operations = UnsafePointer(buffer.baseAddress!)
+                frame.operation_count = buffer.count
+                var response = WhiskerMobileApplyResponse()
+                XCTAssertTrue(scene.applyFrame(frame, response: &response))
+                XCTAssertEqual(response.status, UInt8(WHISKER_APPLY_ACCEPTED))
+            }
+        }
+
+        var snapshot = [
+            operation(tag: UInt32(WHISKER_OP_CREATE), node: 1, member: 1),
+            operation(tag: UInt32(WHISKER_OP_CREATE), node: 2, member: 1),
+        ]
+        present(
+            &snapshot,
+            mode: UInt8(WHISKER_FRAME_SNAPSHOT),
+            baseRevision: 0,
+            targetRevision: 1
+        )
+        root.reorderCount = 0
+
+        var delta = [operation(tag: UInt32(WHISKER_OP_OPACITY), node: 1, scalar: 0.5)]
+        present(
+            &delta,
+            mode: UInt8(WHISKER_FRAME_DELTA),
+            baseRevision: 1,
+            targetRevision: 2
+        )
+
+        XCTAssertEqual(root.reorderCount, 0)
     }
 
     func testPointerCaptureOperationsReachTheUIKitSurface() {


### PR DESCRIPTION
## Summary
- skip UIKit z-order projection for layout, paint, opacity, and other unrelated frames
- track only parents affected by structural or z-order operations
- build sibling lookup tables once per relevant frame instead of once per parent
- add a regression test proving paint-only frames perform no UIView reordering

## Performance
- common animation/scroll paint frames now make zero `bringSubviewToFront` calls
- relevant frames use one O(N) grouping pass followed by sorting only affected sibling groups
- no retained per-node index or duplicate scene map is added

## Test
- `cargo xtask host-conformance ios`