### PR TITLE
fix(mobile): reject invalid scene frames before mutation

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -36,6 +36,14 @@ import rs.whisker.runtime.measure.HostMeasureBatchAbi
 import rs.whisker.runtime.measure.resolveTextLayoutSemantics
 import rs.whisker.runtime.scene.HostAccessibility
 import rs.whisker.runtime.scene.HostNode
+import rs.whisker.runtime.scene.HostScene
+import rs.whisker.runtime.scene.HostSceneOperation
+import rs.whisker.runtime.scene.OP_BACKGROUND_LAYERS
+import rs.whisker.runtime.scene.OP_CREATE
+import rs.whisker.runtime.scene.OP_DELETE
+import rs.whisker.runtime.scene.OP_INSERT
+import rs.whisker.runtime.scene.OP_LAYOUT
+import rs.whisker.runtime.paint.HostRasterResourceStore
 
 private const val BACKGROUND_PACKED_LAYERS = 256
 
@@ -58,6 +66,65 @@ class HostConformanceTest {
         fun registerBuiltIns() {
             WhiskerModuleKernel.install(BuiltInElementModule())
         }
+    }
+
+    @Test
+    fun invalidStructureAndLayoutAreRejectedBeforeViewMutation() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val root = WhiskerContainerView(context)
+                val scene = HostScene(root, context, { _, _, _ -> }, HostRasterResourceStore())
+                assertTrue(
+                    WhiskerElementRegistry.bind(
+                        listOf(
+                            WhiskerElementRegistration(
+                                1,
+                                WhiskerBuiltInElements.VIEW,
+                                WhiskerChildPolicy.Elements,
+                                WhiskerMeasurement.None,
+                            ),
+                        ),
+                    ),
+                )
+
+                assertEquals(0, scene.beginFrame(0, 1, 0, 1))
+                listOf(
+                    hostOperation(OP_CREATE, node = 1, member = 1),
+                    hostOperation(OP_CREATE, node = 2, member = 1),
+                    hostOperation(OP_CREATE, node = 3, member = 1),
+                    hostOperation(OP_INSERT, parent = 1, child = 2),
+                    hostOperation(OP_INSERT, parent = 2, child = 3),
+                ).forEach { assertTrue(scene.stage(it)) }
+                assertTrue(scene.commit())
+                val rootNode = root.getChildAt(0) as HostNode
+                val childNode = (0 until rootNode.childCount)
+                    .map(rootNode::getChildAt)
+                    .first { it is HostNode }
+                val childParent = childNode.parent
+
+                assertEquals(0, scene.beginFrame(1, 1, 1, 2))
+                scene.stage(hostOperation(OP_INSERT, parent = 3, child = 1))
+                assertTrue(!scene.commit())
+                assertTrue(childNode.parent === childParent)
+
+                assertEquals(0, scene.beginFrame(1, 1, 1, 2))
+                scene.stage(hostOperation(OP_DELETE, node = 2))
+                scene.stage(hostOperation(OP_BACKGROUND_LAYERS, node = 3))
+                assertTrue(!scene.commit())
+                assertTrue(childNode.parent === childParent)
+
+                assertEquals(0, scene.beginFrame(1, 1, 1, 2))
+                scene.stage(
+                    hostOperation(
+                        OP_LAYOUT,
+                        node = 1,
+                        numbers = floatArrayOf(0f, 0f, Float.NaN, 10f, 0f, 0f, 10f, 10f),
+                    ),
+                )
+                assertTrue(!scene.commit())
+            }
     }
 
     @Test
@@ -1861,3 +1928,27 @@ private fun assertPixelsClose(id: String, actual: Bitmap, expected: Bitmap) {
     }
     assertTrue("$id pixel difference $largestDifference", largestDifference <= 1)
 }
+
+private fun hostOperation(
+    tag: Int,
+    node: Long = 0,
+    parent: Long = 0,
+    child: Long = 0,
+    member: Int = 0,
+    numbers: FloatArray? = null,
+): HostSceneOperation = HostSceneOperation(
+    tag = tag,
+    flags = 0,
+    node = node,
+    parent = parent,
+    child = child,
+    index = 0,
+    member = member,
+    integer = 0,
+    scalar = 0f,
+    wide = 0,
+    numbers = numbers,
+    text = null,
+    names = null,
+    value = null,
+)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -170,10 +170,14 @@ internal class HostScene(
                 elementTypes[operation.node] = operation.member
             }
             OP_DELETE -> {
-                if (!existing.remove(operation.node)) return false
-                elementTypes.remove(operation.node)
+                if (operation.node !in existing) return false
+                val removed = existing.filterTo(mutableSetOf()) {
+                    it == operation.node || isStagedDescendant(it, operation.node, stagedParents)
+                }
+                existing.removeAll(removed)
+                elementTypes.keys.removeAll(removed)
                 stagedParents.entries.removeAll {
-                    it.key == operation.node || it.value == operation.node
+                    it.key in removed || it.value in removed
                 }
             }
             OP_INSERT -> {
@@ -182,13 +186,21 @@ internal class HostScene(
                 if (
                     operation.parent !in existing || operation.child !in existing ||
                     stagedParents.containsKey(operation.child) ||
+                    isStagedDescendant(operation.parent, operation.child, stagedParents) ||
                     policy != WhiskerChildPolicy.Elements
                 ) return false
                 stagedParents[operation.child] = operation.parent
             }
             OP_REMOVE -> if (stagedParents.remove(operation.child) != operation.parent) return false
             OP_MOVE -> if (stagedParents[operation.child] != operation.parent) return false
-            OP_LAYOUT -> if (operation.node !in existing || operation.numbers?.size ?: 0 < 8) return false
+            OP_LAYOUT -> {
+                val values = operation.numbers
+                if (
+                    operation.node !in existing || values == null || values.size < 8 ||
+                    !validLayoutValues(values) ||
+                    values[2] < 0f || values[3] < 0f || values[6] < 0f || values[7] < 0f
+                ) return false
+            }
             OP_PAINT -> if (
                 operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
@@ -241,6 +253,28 @@ internal class HostScene(
             else -> return false
         }
         return true
+    }
+
+    private fun validLayoutValues(values: FloatArray): Boolean {
+        var index = 0
+        while (index < 8) {
+            if (!values[index].isFinite()) return false
+            index += 1
+        }
+        return true
+    }
+
+    private fun isStagedDescendant(
+        candidate: Long,
+        ancestor: Long,
+        stagedParents: Map<Long, Long>,
+    ): Boolean {
+        var current: Long? = candidate
+        while (current != null) {
+            if (current == ancestor) return true
+            current = stagedParents[current]
+        }
+        return false
     }
 
     private fun applyOperation(operation: HostSceneOperation) {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -112,14 +112,28 @@ final class HostScene {
                 existing.insert(operation.node)
                 elementTypes[operation.node] = Int(operation.member)
             case UInt32(WHISKER_OP_DELETE):
-                guard existing.remove(operation.node) != nil else { return false }
-                elementTypes.removeValue(forKey: operation.node)
+                guard existing.contains(operation.node) else { return false }
+                let removed = existing.filter {
+                    $0 == operation.node || isStagedDescendant(
+                        $0,
+                        of: operation.node,
+                        parents: stagedParents
+                    )
+                }
+                existing.subtract(removed)
+                removed.forEach { elementTypes.removeValue(forKey: $0) }
+                let removedSet = Set(removed)
                 stagedParents = stagedParents.filter {
-                    $0.key != operation.node && $0.value != operation.node
+                    !removedSet.contains($0.key) && !removedSet.contains($0.value)
                 }
             case UInt32(WHISKER_OP_INSERT):
                 guard existing.contains(operation.parent), existing.contains(operation.child),
                       stagedParents[operation.child] == nil,
+                      !isStagedDescendant(
+                          operation.parent,
+                          of: operation.child,
+                          parents: stagedParents
+                      ),
                       elementTypes[operation.parent]
                         .flatMap({ WhiskerElementRegistry.registration($0) })?
                         .childPolicy.acceptsElements == true
@@ -130,8 +144,12 @@ final class HostScene {
                 stagedParents.removeValue(forKey: operation.child)
             case UInt32(WHISKER_OP_MOVE):
                 guard stagedParents[operation.child] == operation.parent else { return false }
-            case UInt32(WHISKER_OP_LAYOUT), UInt32(WHISKER_OP_PAINT),
-                 UInt32(WHISKER_OP_PROPERTY), UInt32(WHISKER_OP_COMMAND),
+            case UInt32(WHISKER_OP_LAYOUT):
+                guard existing.contains(operation.node),
+                      let geometry = operation.payload?
+                        .assumingMemoryBound(to: WhiskerMobileLayoutGeometry.self).pointee,
+                      validLayoutGeometry(geometry) else { return false }
+            case UInt32(WHISKER_OP_PAINT), UInt32(WHISKER_OP_PROPERTY), UInt32(WHISKER_OP_COMMAND),
                  UInt32(WHISKER_OP_ACCESSIBILITY):
                 guard existing.contains(operation.node), operation.payload != nil else { return false }
             case UInt32(WHISKER_OP_TEXT), UInt32(WHISKER_OP_TEXT_STYLE):
@@ -252,6 +270,28 @@ final class HostScene {
             }
         }
         return true
+    }
+
+    private func isStagedDescendant(
+        _ candidate: UInt64,
+        of ancestor: UInt64,
+        parents: [UInt64: UInt64]
+    ) -> Bool {
+        var current: UInt64? = candidate
+        while let node = current {
+            if node == ancestor { return true }
+            current = parents[node]
+        }
+        return false
+    }
+
+    private func validLayoutGeometry(_ geometry: WhiskerMobileLayoutGeometry) -> Bool {
+        validLayoutRect(geometry.border) && validLayoutRect(geometry.content)
+    }
+
+    private func validLayoutRect(_ rect: WhiskerMobileRect) -> Bool {
+        rect.x.isFinite && rect.y.isFinite && rect.width.isFinite && rect.height.isFinite
+            && rect.width >= 0 && rect.height >= 0
     }
 
     private func apply(_ operation: WhiskerMobileOperation) -> Bool {

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -27,6 +27,111 @@ final class HostConformanceTests: XCTestCase {
         WhiskerModuleKernel.install(BuiltInElementModule())
     }
 
+    func testInvalidStructureAndLayoutAreRejectedBeforeUIKitMutation() throws {
+        let root = UIView()
+        let scene = HostScene(
+            root: root,
+            resources: HostResourceStore(),
+            logicalBounds: { CGRect(x: 0, y: 0, width: 100, height: 100) },
+            emitElementEvent: { _, _, _ in }
+        )
+        let registration = WhiskerElementRegistration(
+            elementType: 1,
+            name: WhiskerBuiltInElements.viewName,
+            childPolicy: .elements,
+            measurement: .none
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+
+        func present(
+            _ operations: inout [WhiskerMobileOperation],
+            mode: UInt8,
+            baseRevision: UInt64,
+            targetRevision: UInt64
+        ) -> UInt8 {
+            operations.withUnsafeMutableBufferPointer { buffer in
+                var frame = WhiskerMobileFrame()
+                frame.abi_major = UInt16(WHISKER_MOBILE_ABI_MAJOR)
+                frame.protocol_major = 1
+                frame.mode = mode
+                frame.scene_epoch = 1
+                frame.base_revision = baseRevision
+                frame.target_revision = targetRevision
+                frame.operations = UnsafePointer(buffer.baseAddress!)
+                frame.operation_count = buffer.count
+                var response = WhiskerMobileApplyResponse()
+                XCTAssertTrue(scene.applyFrame(frame, response: &response))
+                return response.status
+            }
+        }
+
+        var snapshot = [
+            operation(tag: UInt32(WHISKER_OP_CREATE), node: 1, member: 1),
+            operation(tag: UInt32(WHISKER_OP_CREATE), node: 2, member: 1),
+            operation(tag: UInt32(WHISKER_OP_CREATE), node: 3, member: 1),
+            operation(tag: UInt32(WHISKER_OP_INSERT), parent: 1, child: 2),
+            operation(tag: UInt32(WHISKER_OP_INSERT), parent: 2, child: 3),
+        ]
+        XCTAssertEqual(
+            present(
+                &snapshot,
+                mode: UInt8(WHISKER_FRAME_SNAPSHOT),
+                baseRevision: 0,
+                targetRevision: 1
+            ),
+            UInt8(WHISKER_APPLY_ACCEPTED)
+        )
+        let rootNode = try XCTUnwrap(root.subviews.first as? WhiskerNodeView)
+        let childNode = try XCTUnwrap(rootNode.sceneChildrenHost().subviews.first)
+
+        var cycle = [operation(tag: UInt32(WHISKER_OP_INSERT), parent: 3, child: 1)]
+        XCTAssertEqual(
+            present(
+                &cycle,
+                mode: UInt8(WHISKER_FRAME_DELTA),
+                baseRevision: 1,
+                targetRevision: 2
+            ),
+            UInt8(WHISKER_APPLY_REJECTED)
+        )
+        XCTAssertTrue(childNode.superview === rootNode.sceneChildrenHost())
+
+        var deletedDescendantUse = [
+            operation(tag: UInt32(WHISKER_OP_DELETE), node: 2),
+            operation(tag: UInt32(WHISKER_OP_BACKGROUND_LAYERS), node: 3),
+        ]
+        XCTAssertEqual(
+            present(
+                &deletedDescendantUse,
+                mode: UInt8(WHISKER_FRAME_DELTA),
+                baseRevision: 1,
+                targetRevision: 2
+            ),
+            UInt8(WHISKER_APPLY_REJECTED)
+        )
+        XCTAssertTrue(childNode.superview === rootNode.sceneChildrenHost())
+
+        var invalidLayout = WhiskerMobileLayoutGeometry()
+        invalidLayout.border.width = .nan
+        withUnsafePointer(to: &invalidLayout) { payload in
+            var operations = [operation(
+                tag: UInt32(WHISKER_OP_LAYOUT),
+                node: 1,
+                payload: UnsafeRawPointer(payload),
+                count: 1
+            )]
+            XCTAssertEqual(
+                present(
+                    &operations,
+                    mode: UInt8(WHISKER_FRAME_DELTA),
+                    baseRevision: 1,
+                    targetRevision: 2
+                ),
+                UInt8(WHISKER_APPLY_REJECTED)
+            )
+        }
+    }
+
     func testPointerCaptureOperationsReachTheUIKitSurface() {
         let view = WhiskerView(frame: .zero)
         let registration = WhiskerElementRegistration(


### PR DESCRIPTION
## Summary
- reject cyclic child insertion before touching UIKit or Android View hierarchies
- remove complete staged subtrees during validation so later operations cannot target deleted descendants
- reject non-finite or negative layout extents before they reach native geometry APIs
- add equivalent iOS and Android Host regression coverage

## Performance
- the hot layout-validation path performs eight scalar checks without temporary collections
- subtree ancestry walks occur only for structural insert/delete operations
- no retained validation mirror or per-frame background work is added

## Tests
- `cargo xtask host-conformance ios`
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugAndroidTestKotlin --no-daemon`
- full Android instrumentation was attempted but no emulator/device is currently connected; CI runs the compiled test suite