### PR TITLE
fix(desktop): stop busy-spinning after scroll settle

### DIFF
--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -740,11 +740,15 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let now = Instant::now();
+        event_loop.set_control_flow(scroll_settle_control_flow(
+            self.pending_scroll_settle.map(|(deadline, _)| deadline),
+            now,
+        ));
         let Some((deadline, point)) = self.pending_scroll_settle else {
             return;
         };
-        if Instant::now() < deadline {
-            event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+        if now < deadline {
             return;
         }
         self.pending_scroll_settle = None;
@@ -756,6 +760,12 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
             self.request_frame();
         }
     }
+}
+
+fn scroll_settle_control_flow(deadline: Option<Instant>, now: Instant) -> ControlFlow {
+    deadline
+        .filter(|deadline| *deadline > now)
+        .map_or(ControlFlow::Wait, ControlFlow::WaitUntil)
 }
 
 fn printable_key_text(text: Option<&str>) -> Option<&str> {
@@ -771,8 +781,13 @@ fn ime_cursor_area(rect: LayoutRect) -> (winit::dpi::LogicalPosition<f64>, Logic
 
 #[cfg(test)]
 mod tests {
-    use super::{DesktopAppConfig, ime_cursor_area, printable_key_text};
+    use std::time::{Duration, Instant};
+
+    use super::{
+        DesktopAppConfig, ime_cursor_area, printable_key_text, scroll_settle_control_flow,
+    };
     use whisker_protocol::LayoutRect;
+    use winit::event_loop::ControlFlow;
 
     #[test]
     fn default_config_preserves_the_standalone_window_contract() {
@@ -813,5 +828,19 @@ mod tests {
         assert_eq!(position.y, 20.0);
         assert_eq!(size.width, 120.0);
         assert_eq!(size.height, 44.0);
+    }
+
+    #[test]
+    fn scroll_settle_deadlines_return_to_blocking_wait() {
+        let now = Instant::now();
+        assert_eq!(scroll_settle_control_flow(None, now), ControlFlow::Wait);
+        assert_eq!(
+            scroll_settle_control_flow(Some(now - Duration::from_millis(1)), now),
+            ControlFlow::Wait
+        );
+        assert_eq!(
+            scroll_settle_control_flow(Some(now + Duration::from_millis(1)), now),
+            ControlFlow::WaitUntil(now + Duration::from_millis(1))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- reset winit control flow to blocking `Wait` once a scroll-settle deadline expires
- retain `WaitUntil` only while a future settle deadline exists
- add focused control-flow regression coverage

## Performance
- prevents a single wheel interaction from leaving one CPU core in a persistent wake loop
- adds no polling, allocation, or work to ordinary event handling

## Tests
- `cargo test -p whisker-desktop` (60 passed)
- `CARGO_INCREMENTAL=0 cargo clippy -p whisker-desktop --lib --tests -- -D warnings`