### PR TITLE
fix(driver): preserve interior NUL in Host strings

### DIFF
--- a/crates/whisker-driver/src/ffi_runtime.rs
+++ b/crates/whisker-driver/src/ffi_runtime.rs
@@ -1,6 +1,8 @@
 //! Safe retained runtime behind the Android and iOS C entry points.
 
-use std::ffi::{CString, c_void};
+#[cfg(target_os = "android")]
+use std::ffi::CString;
+use std::ffi::c_void;
 
 use crate::abi::*;
 use crate::ffi_module::module_host;

--- a/crates/whisker-driver/src/ffi_runtime/frame.rs
+++ b/crates/whisker-driver/src/ffi_runtime/frame.rs
@@ -151,7 +151,7 @@ pub(super) struct MobileFrameOwned {
     _font_variations: Vec<Box<[MobileFontVariation]>>,
     _transforms: Vec<Box<[f32; 16]>>,
     _values: Vec<Box<WhiskerValueRaw>>,
-    _strings: Vec<CString>,
+    _strings: Vec<Box<[u8]>>,
     pub(super) _operations: Vec<MobileOperation>,
 }
 
@@ -885,7 +885,7 @@ fn mobile_background_repeat(value: ImageRepeat) -> u32 {
 }
 fn mobile_gradient_stops(
     stops: &[whisker_engine::whisker_protocol::GradientStop],
-    strings: &mut Vec<CString>,
+    strings: &mut Vec<Box<[u8]>>,
 ) -> Result<Box<[MobileGradientStop]>, MobileFrameError> {
     if !(2..=4_096).contains(&stops.len()) {
         return Err(MobileFrameError);
@@ -904,7 +904,7 @@ fn mobile_gradient_stops(
 }
 pub(super) fn mobile_paint(
     value: &whisker_engine::whisker_protocol::BoxPaint,
-    strings: &mut Vec<CString>,
+    strings: &mut Vec<Box<[u8]>>,
 ) -> MobileBoxPaint {
     MobileBoxPaint {
         background: mobile_color(&value.background_color, strings),
@@ -945,7 +945,7 @@ pub(super) fn mobile_paint(
 #[allow(clippy::vec_box)]
 fn push_mobile_text(
     content: &TextContent,
-    strings: &mut Vec<CString>,
+    strings: &mut Vec<Box<[u8]>>,
     text_font_families: &mut Vec<Box<[WhiskerStringRef]>>,
     font_features: &mut Vec<Box<[MobileFontFeature]>>,
     font_variations: &mut Vec<Box<[MobileFontVariation]>>,
@@ -1057,7 +1057,7 @@ fn push_mobile_text(
     Ok(texts.last().expect("pushed mobile text").as_ref() as *const _ as *const c_void)
 }
 
-fn mobile_color(value: &PaintColor, strings: &mut Vec<CString>) -> MobileColor {
+fn mobile_color(value: &PaintColor, strings: &mut Vec<Box<[u8]>>) -> MobileColor {
     match value {
         PaintColor::Named(name) => MobileColor {
             kind: 0,

--- a/crates/whisker-driver/src/ffi_runtime/measurement.rs
+++ b/crates/whisker-driver/src/ffi_runtime/measurement.rs
@@ -90,7 +90,7 @@ impl MeasurementProvider for MobileMeasurementHost {
 }
 
 pub(super) struct MobileMeasureBatch {
-    _strings: Vec<CString>,
+    _strings: Vec<Box<[u8]>>,
     _bytes: Vec<Vec<u8>>,
     _font_families: Vec<Box<[WhiskerStringRef]>>,
     _font_features: Vec<Box<[MobileFontFeature]>>,

--- a/crates/whisker-driver/src/ffi_runtime/resource.rs
+++ b/crates/whisker-driver/src/ffi_runtime/resource.rs
@@ -142,7 +142,7 @@ pub(super) fn decode_resource_failure(value: u32) -> Option<ResourceFailureCode>
 
 pub(super) struct MobileBootstrapOwned {
     pub(super) value: MobileBootstrap,
-    _strings: Vec<CString>,
+    _strings: Vec<Box<[u8]>>,
     _members: Vec<Vec<MobileMemberRegistration>>,
     _registrations: Vec<MobileElementRegistration>,
 }
@@ -246,11 +246,14 @@ impl MobileBootstrapOwned {
     }
 }
 
-pub(super) fn push_string(strings: &mut Vec<CString>, value: &str) -> WhiskerStringRef {
-    let value = CString::new(value).unwrap_or_default();
+pub(super) fn push_string(strings: &mut Vec<Box<[u8]>>, value: &str) -> WhiskerStringRef {
+    if value.is_empty() {
+        return empty_string();
+    }
+    let value = value.as_bytes().to_vec().into_boxed_slice();
     let result = WhiskerStringRef {
-        ptr: value.as_ptr(),
-        len: value.as_bytes().len(),
+        ptr: value.as_ptr().cast(),
+        len: value.len(),
     };
     strings.push(value);
     result
@@ -268,7 +271,7 @@ pub(super) fn member_registration(
     name: &str,
     kind: ElementValueKind,
     optional: bool,
-    strings: &mut Vec<CString>,
+    strings: &mut Vec<Box<[u8]>>,
 ) -> MobileMemberRegistration {
     MobileMemberRegistration {
         id,

--- a/crates/whisker-driver/src/value_codec.rs
+++ b/crates/whisker-driver/src/value_codec.rs
@@ -1,7 +1,6 @@
 //! Owned conversions for the borrowed [`whisker_driver_sys`] value ABI.
 
 use std::collections::BTreeMap;
-use std::ffi::CString;
 
 use whisker_driver_sys::{
     VALUE_ARRAY, VALUE_BOOL, VALUE_BYTES, VALUE_ERROR, VALUE_FLOAT, VALUE_INT, VALUE_MAP,
@@ -13,7 +12,7 @@ use whisker_runtime::value::WhiskerValue;
 /// Pinned allocations referenced by borrowed `WhiskerValueRaw` trees.
 #[derive(Default)]
 pub struct RawValueArena {
-    strings: Vec<CString>,
+    strings: Vec<Box<[u8]>>,
     bytes: Vec<Vec<u8>>,
     arrays: Vec<Vec<WhiskerValueRaw>>,
     maps: Vec<Vec<WhiskerKeyValueRaw>>,
@@ -21,10 +20,16 @@ pub struct RawValueArena {
 
 impl RawValueArena {
     fn string(&mut self, value: &str) -> WhiskerStringRef {
-        let string = CString::new(value).unwrap_or_default();
+        if value.is_empty() {
+            return WhiskerStringRef {
+                ptr: std::ptr::null(),
+                len: 0,
+            };
+        }
+        let string = value.as_bytes().to_vec().into_boxed_slice();
         let result = WhiskerStringRef {
-            ptr: string.as_ptr(),
-            len: string.as_bytes().len(),
+            ptr: string.as_ptr().cast(),
+            len: string.len(),
         };
         self.strings.push(string);
         result
@@ -166,6 +171,15 @@ mod tests {
         ]));
         let mut arena = RawValueArena::default();
         let raw = arena.encode(&value);
+        assert_eq!(unsafe { decode_value(&raw) }, value);
+    }
+
+    #[test]
+    fn value_abi_preserves_interior_nul_bytes() {
+        let value = WhiskerValue::String("left\0right".into());
+        let mut arena = RawValueArena::default();
+        let raw = arena.encode(&value);
+
         assert_eq!(unsafe { decode_value(&raw) }, value);
     }
 }


### PR DESCRIPTION
## Summary
- store mobile ABI strings as owned byte slices rather than C strings
- preserve interior NUL bytes in WhiskerValue, text, measurement, paint, and bootstrap strings
- keep empty strings represented by the existing null-pointer/zero-length convention
- add a typed WhiskerValue round-trip regression test

## Performance
- keeps the same one owned allocation per non-empty borrowed string
- removes CString validation and the extra terminator byte
- does not introduce parsing or copying at the Host boundary beyond the existing UTF-8 decode

## Tests
- `cargo test -p whisker-driver` (22 passed)
- `cargo clippy -p whisker-driver --all-targets -- -D warnings`
- `cargo xtask mobile-abi check`