### PR TITLE
fix(driver): encode empty mobile ABI slices as null

### DIFF
--- a/crates/whisker-driver/src/ffi_runtime/frame.rs
+++ b/crates/whisker-driver/src/ffi_runtime/frame.rs
@@ -129,7 +129,7 @@ impl FrameSink for MobileFrameSink {
 // C frame stores pointers into these allocations for the callback duration.
 #[allow(clippy::vec_box)]
 pub(super) struct MobileFrameOwned {
-    value: MobileFrame,
+    pub(super) value: MobileFrame,
     _arena: RawValueArena,
     _layouts: Vec<Box<MobileLayoutGeometry>>,
     _paints: Vec<Box<MobileBoxPaint>>,
@@ -780,7 +780,7 @@ impl MobileFrameOwned {
             frame_id: packet.header.frame_id,
             base_revision: packet.header.base_revision,
             target_revision: packet.header.target_revision,
-            operations: operations.as_ptr(),
+            operations: nonempty_ptr(&operations),
             operation_count: operations.len(),
         };
         Ok(Self {

--- a/crates/whisker-driver/src/ffi_runtime/measurement.rs
+++ b/crates/whisker-driver/src/ffi_runtime/measurement.rs
@@ -28,9 +28,9 @@ impl MeasurementProvider for MobileMeasurementHost {
         let mut batch = MobileMeasureBatch::new(requests);
         if !(self.callback)(
             self.data,
-            batch.requests.as_ptr(),
+            nonempty_ptr(&batch.requests),
             batch.requests.len(),
-            batch.responses.as_mut_ptr(),
+            nonempty_mut_ptr(&mut batch.responses),
         ) {
             return Err(MobileMeasureError("mobile Host rejected measurement batch"));
         }
@@ -317,6 +317,14 @@ pub(super) fn nonempty_ptr<T>(values: &[T]) -> *const T {
         values.as_ptr()
     }
 }
+
+fn nonempty_mut_ptr<T>(values: &mut [T]) -> *mut T {
+    if values.is_empty() {
+        std::ptr::null_mut()
+    } else {
+        values.as_mut_ptr()
+    }
+}
 fn available_kind(value: AvailableSpace) -> u8 {
     match value {
         AvailableSpace::Definite(_) => 0,
@@ -328,5 +336,37 @@ fn available_value(value: AvailableSpace) -> f32 {
     match value {
         AvailableSpace::Definite(value) => value,
         _ => 0.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    extern "C" fn observe_empty_batch(
+        data: *mut c_void,
+        requests: *const MobileMeasureRequest,
+        count: usize,
+        responses: *mut MobileMeasureResponse,
+    ) -> bool {
+        // SAFETY: the test passes a live `bool` as callback data.
+        unsafe { *data.cast::<bool>() = requests.is_null() && responses.is_null() && count == 0 };
+        true
+    }
+
+    #[test]
+    fn empty_measurement_batch_uses_null_pointers() {
+        let mut observed = false;
+        let mut host = MobileMeasurementHost {
+            callback: observe_empty_batch,
+            data: std::ptr::from_mut(&mut observed).cast(),
+        };
+        let mut responses = Vec::new();
+
+        host.measure_batch(SurfaceId::new(1).unwrap(), &[], &mut responses)
+            .unwrap();
+
+        assert!(observed);
+        assert!(responses.is_empty());
     }
 }

--- a/crates/whisker-driver/src/ffi_runtime/tests.rs
+++ b/crates/whisker-driver/src/ffi_runtime/tests.rs
@@ -7,6 +7,28 @@ use whisker_engine::whisker_protocol::{
 };
 
 #[test]
+fn empty_snapshot_uses_a_null_operation_pointer() {
+    let packet = FramePacket {
+        header: FrameHeader {
+            version: ProtocolVersion::CURRENT,
+            surface: SurfaceId::new(1).unwrap(),
+            scene_epoch: 1,
+            frame_id: 1,
+            base_revision: 0,
+            target_revision: 1,
+            viewport_epoch: 1,
+            mode: FrameMode::Snapshot,
+        },
+        operations: Vec::new(),
+    };
+
+    let frame = MobileFrameOwned::new(&packet).unwrap();
+
+    assert_eq!(frame.value.operation_count, 0);
+    assert!(frame.value.operations.is_null());
+}
+
+#[test]
 fn mobile_pointer_input_decodes_without_host_specific_types() {
     let event = mobile_pointer_event(42.5, 0, 7, 1, 24.0, 16.0, 1, -1).unwrap();
     assert_eq!(event.kind, InputEventKind::PointerDown);


### PR DESCRIPTION
## Summary
- encode zero-operation snapshots with a null operation pointer
- encode empty measurement batches with null request and response pointers
- use the same pointer/count invariant already enforced by the mobile C bridge
- add regression tests for both empty boundaries

## Performance
- only adds an emptiness branch at ABI construction time
- no allocation or copying is introduced

## Tests
- `cargo test -p whisker-driver` (23 passed)
- `cargo clippy -p whisker-driver --all-targets -- -D warnings`
- `cargo xtask mobile-abi check`