### PR TITLE
fix(mobile): reset pooled element visibility

### DIFF
--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -176,6 +176,7 @@ public class WhiskerMountedElement internal constructor(
     /** Resets protocol-owned state before a built-in presentation is reused. */
     public fun prepareForReuse(eventSink: WhiskerElementEventSink) {
         properties.values.forEach { it.clearer(view) }
+        view.visibility = View.VISIBLE
         eventMask = 0
         this.eventSink = eventSink
         installEventSink()

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -61,6 +61,30 @@ class HostConformanceTest {
     }
 
     @Test
+    fun pooledElementRestoresDefaultVisibilityBeforeReuse() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val registration = WhiskerElementRegistration(
+                    elementType = 1,
+                    name = WhiskerBuiltInElements.VIEW,
+                    childPolicy = WhiskerChildPolicy.Elements,
+                    measurement = WhiskerMeasurement.None,
+                )
+                assertTrue(WhiskerElementRegistry.bind(listOf(registration)))
+                val mounted = requireNotNull(
+                    WhiskerElementRegistry.mount(1, context) { _, _ -> },
+                )
+                mounted.view.visibility = View.INVISIBLE
+
+                mounted.prepareForReuse { _, _ -> }
+
+                assertEquals(View.VISIBLE, mounted.view.visibility)
+            }
+    }
+
+    @Test
     fun commonAccessibilityMapsToAndroidNodeSemantics() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()

--- a/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerModuleRegistrar.swift
@@ -305,6 +305,7 @@ public final class WhiskerMountedElement {
     /** Resets protocol-owned state before a built-in presentation is reused. */
     public func prepareForReuse(eventSink: @escaping WhiskerElementEventSink) {
         properties.values.forEach { $0.clearer(view) }
+        view.isHidden = false
         eventMask = 0
         self.eventSink = eventSink
         installEventSink()

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -27,6 +27,22 @@ final class HostConformanceTests: XCTestCase {
         WhiskerModuleKernel.install(BuiltInElementModule())
     }
 
+    func testPooledElementRestoresDefaultVisibilityBeforeReuse() throws {
+        let registration = WhiskerElementRegistration(
+            elementType: 1,
+            name: WhiskerBuiltInElements.viewName,
+            childPolicy: .elements,
+            measurement: .none
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+        let mounted = try XCTUnwrap(WhiskerElementRegistry.mount(1) { _, _ in })
+        mounted.view.isHidden = true
+
+        mounted.prepareForReuse { _, _ in }
+
+        XCTAssertFalse(mounted.view.isHidden)
+    }
+
     func testPointerCaptureOperationsReachTheUIKitSurface() {
         let view = WhiskerView(frame: .zero)
         let registration = WhiskerElementRegistration(


### PR DESCRIPTION
## Summary
- reset native visibility when a module element presentation is taken from the pool
- keep Android and iOS reuse semantics symmetric
- add Host conformance regressions for hidden pooled views

## Performance
- adds one constant-time native property assignment only when a presentation is reused
- no frame, scroll, layout, or event hot-path work is added

## Verification
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugAndroidTestKotlin :runtime:testDebugUnitTest --no-daemon`
- `cargo xtask host-conformance ios`