### PR TITLE
fix(desktop): reset scroll animations on snapshot

### DIFF
--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -724,6 +724,75 @@ fn smooth_scroll_command_advances_on_host_frames() {
 }
 
 #[test]
+fn snapshot_discards_scroll_animation_from_the_previous_scene_epoch() {
+    let scroll = id(1);
+    let content = id(2);
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node: scroll,
+                    element_type: element_type(whisker::SCROLL_VIEW_ELEMENT_NAME),
+                },
+                Operation::CreateNode {
+                    node: content,
+                    element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+                },
+                Operation::InsertChild {
+                    parent: scroll,
+                    child: content,
+                    index: 0,
+                },
+                Operation::SetLayout {
+                    node: scroll,
+                    geometry: geometry(0.0, 0.0, 100.0, 100.0),
+                },
+                Operation::SetLayout {
+                    node: content,
+                    geometry: geometry(0.0, 0.0, 100.0, 500.0),
+                },
+            ],
+        ))
+        .unwrap();
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::InvokeCommand {
+                node: scroll,
+                command: whisker::SCROLL_TO_COMMAND,
+                arguments: WhiskerValue::map([
+                    ("offset", WhiskerValue::Float(240.0)),
+                    ("smooth", WhiskerValue::Bool(true)),
+                ]),
+            }],
+        ))
+        .unwrap();
+    assert!(scene.has_active_scroll_animations());
+
+    let mut replacement = packet(
+        FrameMode::Snapshot,
+        0,
+        1,
+        vec![Operation::CreateNode {
+            node: scroll,
+            element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+        }],
+    );
+    replacement.header.scene_epoch = 2;
+    scene.present(&replacement).unwrap();
+
+    assert!(!scene.has_active_scroll_animations());
+    assert!(!scene.advance_scroll_animations(16.0));
+    assert_eq!(scene.nodes[&scroll].scroll_offset, [0.0, 0.0]);
+}
+
+#[test]
 fn snap_stop_always_limits_one_wheel_sequence_to_the_adjacent_child() {
     let scroll = id(1);
     let first = id(2);

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -917,6 +917,7 @@ impl DesktopScene {
             }
             self.pending_events.lock().unwrap().clear();
             self.pointer_captures.clear();
+            self.smooth_scrolls.clear();
         }
         for operation in &packet.operations {
             match operation {


### PR DESCRIPTION
## Summary
- discard in-flight smooth-scroll animation state when a replacement scene snapshot arrives
- prevent a previous scene epoch from mutating a newly reused node ID
- add a regression covering snapshot replacement during smooth scrolling

## Performance
- one `HashMap::clear` on snapshot recovery only
- no steady-state scroll or frame overhead

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`