### PR TITLE
refactor(desktop): remove duplicate pointer capture state

### DIFF
--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -9,7 +9,7 @@ use whisker_protocol::{
     Accessibility, ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
     BoxClip, BoxPaint, ClipShape, Cursor, ElementTypeId, FillRule, FrameMode, FramePacket,
     HitTestBehavior, ImageRepeat, LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip,
-    PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand, PointerId,
+    PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand,
     RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
     ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
@@ -338,7 +338,6 @@ pub(crate) struct DesktopScene {
     elements: DesktopElementRegistry,
     nodes: HashMap<NodeId, RenderNode>,
     smooth_scrolls: HashMap<NodeId, SmoothScroll>,
-    pointer_captures: HashMap<PointerId, NodeId>,
     presentation_pool: HashMap<ElementTypeId, Vec<DesktopElementContent>>,
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -128,7 +128,7 @@ fn packet(mode: FrameMode, base: u64, target: u64, operations: Vec<Operation>) -
 }
 
 #[test]
-fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
+fn runtime_owned_pointer_capture_operations_are_accepted_by_the_desktop_surface() {
     let node = id(1);
     let pointer = whisker_protocol::PointerId::new(7).unwrap();
     let mut scene = scene(SurfaceId::new(1).unwrap());
@@ -147,7 +147,6 @@ fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
             ],
         ))
         .unwrap();
-    assert_eq!(scene.pointer_captures.get(&pointer), Some(&node));
 
     scene
         .present(&packet(
@@ -157,7 +156,6 @@ fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
             vec![Operation::ReleasePointerCapture { node, pointer }],
         ))
         .unwrap();
-    assert!(!scene.pointer_captures.contains_key(&pointer));
 }
 
 const CHECKED: PropertyId = PropertyId::new(1).unwrap();

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -16,7 +16,6 @@ impl DesktopScene {
             elements,
             nodes: HashMap::new(),
             smooth_scrolls: HashMap::new(),
-            pointer_captures: HashMap::new(),
             presentation_pool: HashMap::new(),
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
@@ -916,7 +915,6 @@ impl DesktopScene {
                 self.recycle_presentation(node);
             }
             self.pending_events.lock().unwrap().clear();
-            self.pointer_captures.clear();
         }
         for operation in &packet.operations {
             match operation {
@@ -1157,14 +1155,9 @@ impl DesktopScene {
                         .presentation
                         .cursor = cursor.clone();
                 }
-                Operation::SetPointerCapture { node, pointer } => {
-                    self.pointer_captures.insert(*pointer, *node);
-                }
-                Operation::ReleasePointerCapture { node, pointer } => {
-                    if self.pointer_captures.get(pointer) == Some(node) {
-                        self.pointer_captures.remove(pointer);
-                    }
-                }
+                // Pointer capture routing is owned by SurfaceRuntime. Hosts accept
+                // these protocol operations but do not maintain a second target map.
+                Operation::SetPointerCapture { .. } | Operation::ReleasePointerCapture { .. } => {}
             }
         }
         self.clamp_scroll_offsets();
@@ -1175,7 +1168,6 @@ impl DesktopScene {
         let Some(removed) = self.nodes.remove(&node) else {
             return;
         };
-        self.pointer_captures.retain(|_, target| *target != node);
         if let Some(parent) = removed.presentation.parent
             && let Some(parent) = self.nodes.get_mut(&parent)
         {


### PR DESCRIPTION
## Summary
- remove Desktop Host pointer-capture storage that was never read for event targeting
- retain protocol validation and acceptance while leaving capture routing authoritative in `SurfaceRuntime`
- update the regression to express the Runtime-owned contract

## Performance
- removes a hash-map allocation and mutation from snapshot/capture/delete paths
- does not add work to input dispatch

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`