### PR TITLE
perf(desktop): borrow element bindings on lookup

### DIFF
--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -1005,10 +1005,9 @@ impl DesktopElementRegistry {
     fn binding(
         &self,
         element_type: ElementTypeId,
-    ) -> Result<DesktopElementBinding, DesktopElementError> {
+    ) -> Result<&DesktopElementBinding, DesktopElementError> {
         self.bindings
             .get(&element_type)
-            .cloned()
             .ok_or(DesktopElementError::UnknownElementType { element_type })
     }
 }


### PR DESCRIPTION
## Summary
- return borrowed Desktop element bindings from registry lookups
- eliminate deep clones of registration schemas and bound factories during validation, measurement, event, command, and creation lookups

## Performance
- turns each registry lookup from a deep clone into a hash lookup plus shared borrow
- adds no allocation and changes no public API or behavior

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`