### PR TITLE
perf(desktop): keep frame validation side-effect free

### DIFF
--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -155,6 +155,10 @@ impl DesktopElementFactory {
             }
         }
     }
+
+    fn accepts_text_style(&self) -> bool {
+        matches!(&self.kind, DesktopElementFactoryKind::Native(_))
+    }
 }
 
 impl fmt::Debug for DesktopElementFactory {
@@ -864,6 +868,13 @@ impl DesktopElementRegistry {
         Ok(self.binding(element_type)?.factory.create(events))
     }
 
+    pub(crate) fn validate_element_type(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<(), DesktopElementError> {
+        self.binding(element_type).map(|_| ())
+    }
+
     pub(crate) fn is_builtin_presentation(&self, element_type: ElementTypeId) -> bool {
         self.binding(element_type).is_ok_and(|binding| {
             matches!(
@@ -916,7 +927,8 @@ impl DesktopElementRegistry {
         &self,
         element_type: ElementTypeId,
     ) -> Result<bool, DesktopElementError> {
-        Ok(self.binding(element_type)?.registration.text_style)
+        let binding = self.binding(element_type)?;
+        Ok(binding.registration.text_style && binding.factory.accepts_text_style())
     }
 
     pub(crate) fn validate_property(

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -2,7 +2,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
 use crate::element::{
-    DesktopElementFactory, DesktopNativeElement, DesktopNativeEvent, built_in_element_factories,
+    DesktopElementFactory, DesktopNativeElement, DesktopNativeEvent, DesktopViewDefinition,
+    DesktopViewImplementation, built_in_element_factories,
 };
 use whisker::standard_element_registrations;
 use whisker_protocol::{
@@ -1246,6 +1247,54 @@ fn text_content_operation_is_dispatched_by_registered_element_type() {
         scene.paint_commands().as_slice(),
         [PaintCommand::Box { .. }, PaintCommand::Text { node, .. }] if *node == root
     ));
+}
+
+#[test]
+fn validation_does_not_instantiate_module_elements() {
+    let element_type = ElementTypeId::new(22).unwrap();
+    let node = id(1);
+    let constructions = Arc::new(AtomicUsize::new(0));
+    let observed_constructions = Arc::clone(&constructions);
+    let mut registrations = standard_element_registrations();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/PlainText".into(),
+        child_policy: whisker_protocol::ChildPolicy::PlainText,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![],
+        events: vec![],
+        commands: vec![],
+    });
+    let mut factories = built_in_element_factories();
+    factories.push(
+        DesktopViewDefinition::new("whisker.test/PlainText", move |_| {
+            observed_constructions.fetch_add(1, Ordering::Relaxed);
+        })
+        .plain_text()
+        .into_desktop_factory(),
+    );
+    let mut scene = DesktopScene::new(
+        SurfaceId::new(1).unwrap(),
+        DesktopElementRegistry::bind(&registrations, &factories).unwrap(),
+    );
+
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetText {
+                    node,
+                    content: text(),
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert_eq!(constructions.load(Ordering::Relaxed), 1);
 }
 
 #[test]

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -796,8 +796,7 @@ impl DesktopScene {
         for operation in &packet.operations {
             match operation {
                 Operation::CreateNode { node, element_type } => {
-                    self.elements
-                        .create(*element_type, DesktopEventEmitter::default())?;
+                    self.elements.validate_element_type(*element_type)?;
                     types.insert(*node, *element_type);
                 }
                 Operation::InsertChild { parent, .. } => {
@@ -821,19 +820,20 @@ impl DesktopScene {
                         return Err(DesktopPresentError::Unsupported("text-decoration"));
                     }
                     if let Some(element_type) = types.get(node).copied() {
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text(*node, content.clone())?;
+                        if !self
+                            .elements
+                            .child_policy(element_type)?
+                            .accepts_plain_text()
+                        {
+                            return Err(DesktopElementError::UnexpectedText { node: *node }.into());
+                        }
                     }
                 }
-                Operation::SetTextStyle { node, style } => {
+                Operation::SetTextStyle { node, .. } => {
                     if let Some(element_type) = types.get(node).copied() {
                         if !self.elements.receives_text_style(element_type)? {
                             return Err(DesktopPresentError::Unsupported("text-style"));
                         }
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text_style(*node, style)?;
                     }
                 }
                 Operation::SetProperty {


### PR DESCRIPTION
## Summary
- validate element types and text capabilities from immutable bound metadata
- stop constructing throwaway native/module elements during frame preflight
- preserve transactional rejection for unsupported text operations
- add a constructor-count regression proving one native object is created per committed node

## Performance
- removes up to one allocation/factory call for every CreateNode, SetText, and SetTextStyle during preflight
- avoids running module constructor side effects before a frame is committed

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`