### PR TITLE
fix(desktop): pool only reusable presentation content

### DIFF
--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -585,6 +585,10 @@ pub(crate) enum DesktopElementContent {
 }
 
 impl DesktopElementContent {
+    pub(crate) fn is_reusable_presentation(&self) -> bool {
+        matches!(self, Self::Empty | Self::Text(_))
+    }
+
     pub(crate) fn reset_for_presentation_reuse(&mut self) {
         match self {
             Self::Text(text) => *text = None,
@@ -862,15 +866,6 @@ impl DesktopElementRegistry {
         events: DesktopEventEmitter,
     ) -> Result<DesktopElementContent, DesktopElementError> {
         Ok(self.binding(element_type)?.factory.create(events))
-    }
-
-    pub(crate) fn is_builtin_presentation(&self, element_type: ElementTypeId) -> bool {
-        self.binding(element_type).is_ok_and(|binding| {
-            matches!(
-                binding.registration.name.as_str(),
-                "whisker.ui/View" | "whisker.ui/Text"
-            )
-        })
     }
 
     pub(crate) fn child_policy(

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -487,6 +487,51 @@ fn native_toggle_applies_properties_invokes_command_and_routes_change() {
 }
 
 #[test]
+fn module_content_named_like_a_builtin_is_not_added_to_the_presentation_pool() {
+    let element_type = ElementTypeId::new(20).unwrap();
+    let node = id(1);
+    let registration = ElementRegistration {
+        element_type,
+        name: whisker::VIEW_ELEMENT_NAME.into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![],
+        events: vec![],
+        commands: vec![],
+    };
+    let factory = DesktopElementFactory::native(whisker::VIEW_ELEMENT_NAME, |events| {
+        Box::new(ToggleNative {
+            checked: false,
+            disabled: false,
+            events,
+        })
+    });
+    let mut scene = DesktopScene::new(
+        SurfaceId::new(1).unwrap(),
+        DesktopElementRegistry::bind(&[registration], &[factory]).unwrap(),
+    );
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![Operation::CreateNode { node, element_type }],
+        ))
+        .unwrap();
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::DeleteNode { node }],
+        ))
+        .unwrap();
+
+    assert!(scene.presentation_pool.is_empty());
+}
+
+#[test]
 fn native_toggle_rejects_wrong_property_shape_before_commit() {
     let node = id(1);
     let (mut scene, element_type) = toggle_scene();

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -1192,7 +1192,7 @@ impl DesktopScene {
     }
 
     fn recycle_presentation(&mut self, mut node: RenderNode) {
-        if !self.elements.is_builtin_presentation(node.element_type) {
+        if !node.content.is_reusable_presentation() {
             return;
         }
         node.content.reset_for_presentation_reuse();


### PR DESCRIPTION
## Summary
- decide pooling from the concrete Desktop content variant instead of a registered element name
- keep module-owned native elements out of the built-in presentation pool even if they use a built-in name
- prevent a reused module object from retaining the previous node event emitter
- add a regression for a native module registered as `whisker.ui/View`

## Performance
- keeps zero-allocation pooling for Empty/View and Text presentations
- adds one enum discriminant check only when deleting/replacing a node

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`