### PR TITLE
fix(desktop): normalize vertex depth for 2D rendering

### DIFF
--- a/platforms/desktop/src/gpu/shaders.rs
+++ b/platforms/desktop/src/gpu/shaders.rs
@@ -109,7 +109,7 @@ fn vs_main(input: VertexInput, @builtin(instance_index) draw_index: u32) -> Vert
     output.position = vec4<f32>(
         transformed.x / viewport.logical_size.x * 2.0 - transformed.w,
         transformed.w - transformed.y / viewport.logical_size.y * 2.0,
-        transformed.z,
+        0.0,
         transformed.w,
     );
     output.color = input.color;


### PR DESCRIPTION
## Summary
- force box-pipeline vertex depth to zero in clip space
- make the Desktop Host robust to non-zero Z values in externally supplied transform matrices
- preserve Whisker paint order as the sole 2D stacking authority

## Performance
- replaces one vertex component read with a constant
- no CPU, allocation, or memory overhead

## Verification
- `cargo test -p whisker-desktop`
- `cargo clippy -p whisker-desktop --all-targets -- -D warnings`