### PR TITLE
fix(ios): accept image data URL formats

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceService.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/resource/HostResourceService.swift
@@ -110,7 +110,7 @@ final class HostResourceService {
                 return true
             }
             if scheme == "data" {
-                guard let data = Self.pngData(from: value) else {
+                guard let data = Self.imageData(fromDataURL: value) else {
                     failIfCurrent(id: id, generation: generation, code: .decode)
                     return true
                 }
@@ -252,10 +252,20 @@ final class HostResourceService {
         ))
     }
 
-    private nonisolated static func pngData(from value: String) -> Data? {
-        let prefix = "data:image/png;base64,"
-        guard value.hasPrefix(prefix) else { return nil }
-        return Data(base64Encoded: String(value.dropFirst(prefix.count)), options: [])
+    private nonisolated static func imageData(fromDataURL value: String) -> Data? {
+        guard value.count > 5, value.prefix(5).lowercased() == "data:",
+              let comma = value.firstIndex(of: ",") else { return nil }
+        let metadata = value[value.index(value.startIndex, offsetBy: 5)..<comma]
+        let fields = metadata.split(separator: ";", omittingEmptySubsequences: false)
+        guard let mediaType = fields.first,
+              mediaType.lowercased().hasPrefix("image/"),
+              fields.dropFirst().contains(where: { $0.lowercased() == "base64" }) else {
+            return nil
+        }
+        let encoded = String(value[value.index(after: comma)...])
+        guard let data = Data(base64Encoded: encoded, options: [.ignoreUnknownCharacters]),
+              !data.isEmpty else { return nil }
+        return data
     }
 
     private nonisolated static func decodeImage(_ data: Data) -> CGImage? {

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -683,6 +683,21 @@ final class HostConformanceTests: XCTestCase {
         )
     }
 
+    func testResourceServiceDecodesJPEGDataURLs() throws {
+        let png = try fixturePNGData()
+        let image = try XCTUnwrap(UIImage(data: png))
+        let jpeg = try XCTUnwrap(image.jpegData(compressionQuality: 0.8))
+        let url = "data:image/jpeg;charset=binary;BASE64,\(jpeg.base64EncodedString())"
+        let service = HostResourceService(store: HostResourceStore())
+
+        XCTAssertTrue(service.load(id: 9, generation: 1, source: .url(url)))
+
+        XCTAssertEqual(
+            try awaitResourceState(in: service, id: 9, generation: 1),
+            .ready(width: 2, height: 2)
+        )
+    }
+
     func testResourceChannelCopiesBorrowedBytesAndEncodesTypedEvents() throws {
         let view = WhiskerView(frame: .zero)
         var bytes = try fixturePNGData()


### PR DESCRIPTION
## Summary
- parse base64 data URLs by image media type instead of hard-coding PNG
- accept case-insensitive `base64` metadata and additional parameters, matching Android semantics
- verify JPEG data URLs decode into the iOS raster store

## Performance
- parsing remains off the frame path and runs once per resource generation
- no additional retained state

## Verification
- `cargo xtask host-conformance ios` (24 tests)