### PR TITLE
fix(ios): hide scroll chrome with CSS visibility

### DIFF
--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -17,6 +17,7 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
     public let contentView = WhiskerContainerView(frame: .zero)
     private var eventSink: ((String, WhiskerValue) -> Void)?
     private var horizontal = false
+    private var chromeVisible = true
     private var snapFactor: CGFloat?
     private var snapOffset: CGFloat = 0
     private var snapStopAlways = false
@@ -43,8 +44,17 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
 
     public func setScrollOrientation(_ value: String) {
         horizontal = value == "horizontal"
-        showsHorizontalScrollIndicator = horizontal
-        showsVerticalScrollIndicator = !horizontal
+        updateIndicatorVisibility()
+    }
+
+    public func setWhiskerChromeVisible(_ visible: Bool) {
+        chromeVisible = visible
+        updateIndicatorVisibility()
+    }
+
+    private func updateIndicatorVisibility() {
+        showsHorizontalScrollIndicator = chromeVisible && horizontal
+        showsVerticalScrollIndicator = chromeVisible && !horizontal
     }
 
     public func setItemSnap(factor: Double, offset: Double) {

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -269,6 +269,8 @@ final class WhiskerNodeView: UIView {
         paintView.isHidden = !visible
         boxShadowLayers.forEach { $0.isHidden = !visible }
         backdropBlurView?.isHidden = !visible
+        (mountedElement?.view as? WhiskerScrollContainerView)?
+            .setWhiskerChromeVisible(visible)
         if let mountedElement, mountedElement.childrenHost() == nil {
             mountedElement.view.isHidden = !visible
         }

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -313,6 +313,42 @@ final class HostConformanceTests: XCTestCase {
         XCTAssertEqual(values["scrollHeight"], .float(300))
     }
 
+    func testHiddenScrollViewSuppressesOnlyItsNativeIndicators() throws {
+        let registration = WhiskerElementRegistration(
+            elementType: 3,
+            name: WhiskerBuiltInElements.scrollViewName,
+            childPolicy: .elements,
+            measurement: .none,
+            properties: [
+                WhiskerPropertyBinding(id: 1, name: "scroll-orientation", value: .string),
+                WhiskerPropertyBinding(id: 2, name: "item-snap", value: .map),
+                WhiskerPropertyBinding(id: 3, name: "scroll-snap-stop", value: .string),
+                WhiskerPropertyBinding(id: 4, name: "enable-scroll", value: .bool),
+            ],
+            events: [WhiskerEventBinding(id: 1, name: "scroll", detail: .map)],
+            commands: [
+                WhiskerCommandBinding(id: 1, name: "scrollTo", arguments: .map),
+                WhiskerCommandBinding(id: 2, name: "scrollBy", arguments: .map),
+            ]
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+        let mounted = try XCTUnwrap(WhiskerElementRegistry.mount(3) { _, _ in })
+        let scrollView = try XCTUnwrap(mounted.view as? WhiskerScrollContainerView)
+        let node = WhiskerNodeView(element: registration.name)
+        node.mountedElement = mounted
+
+        node.setWhiskerVisibility(false)
+
+        XCTAssertFalse(scrollView.isHidden)
+        XCTAssertFalse(scrollView.showsHorizontalScrollIndicator)
+        XCTAssertFalse(scrollView.showsVerticalScrollIndicator)
+
+        scrollView.setScrollOrientation("horizontal")
+        node.setWhiskerVisibility(true)
+        XCTAssertTrue(scrollView.showsHorizontalScrollIndicator)
+        XCTAssertFalse(scrollView.showsVerticalScrollIndicator)
+    }
+
     func testHorizontalScrollViewSettlesOnNearestCarouselItem() {
         let scrollView = WhiskerScrollContainerView(
             frame: CGRect(x: 0, y: 0, width: 320, height: 180)


### PR DESCRIPTION
## Summary
- suppress UIScrollView indicators while the ScrollView element has `visibility: hidden`
- keep the scroll content view mounted so descendants can still override inherited visibility
- restore the orientation-appropriate indicator when visibility returns
- add a UIKit Host conformance regression

## Performance
- updates two UIKit booleans only when computed visibility changes
- no frame, layout, or scroll callback overhead

## Verification
- `cargo xtask host-conformance ios` (24 tests)