### PR TITLE
refactor(ios): remove duplicate pointer capture state

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostScene.swift
@@ -16,7 +16,6 @@ final class HostScene {
     private var revision: UInt64 = 0
     private var applyingFrame = false
     private var deferredEvents: [() -> Void] = []
-    private var pointerCaptures: [UInt64: UInt64] = [:]
 
     init(
         root: UIView,
@@ -92,7 +91,6 @@ final class HostScene {
         nodeOrder.removeAll()
         parents.removeAll()
         zOrders.removeAll()
-        pointerCaptures.removeAll()
     }
 
     private func validate(_ operations: [WhiskerMobileOperation], snapshot: Bool) -> Bool {
@@ -414,14 +412,9 @@ final class HostScene {
             nodes[id]?.setHitTestBehavior(operation.integer)
         case UInt32(WHISKER_OP_CURSOR):
             nodes[id]?.setCursorKeyword(operation.integer)
-        case UInt32(WHISKER_OP_CAPTURE):
-            // UIKit keeps delivering a UITouch sequence to its recognizer
-            // after it begins; retaining ownership mirrors explicit capture.
-            pointerCaptures[operation.wide] = id
-        case UInt32(WHISKER_OP_RELEASE_CAPTURE):
-            if pointerCaptures[operation.wide] == id {
-                pointerCaptures.removeValue(forKey: operation.wide)
-            }
+        // Capture targeting is owned by SurfaceRuntime. UIKit already keeps a
+        // UITouch stream attached to its recognizer, so no Host mirror is needed.
+        case UInt32(WHISKER_OP_CAPTURE), UInt32(WHISKER_OP_RELEASE_CAPTURE): break
         case UInt32(WHISKER_OP_OPACITY):
             nodes[id]?.alpha = CGFloat(operation.scalar)
         case UInt32(WHISKER_OP_VISIBILITY):
@@ -509,7 +502,6 @@ final class HostScene {
             parents.removeValue(forKey: $0)
         }
         let removed = Set(descendants).union([id])
-        pointerCaptures = pointerCaptures.filter { !removed.contains($0.value) }
         nodeOrder.removeAll { removed.contains($0) }
         removed.forEach { zOrders.removeValue(forKey: $0) }
         parents.removeValue(forKey: id)

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -27,7 +27,7 @@ final class HostConformanceTests: XCTestCase {
         WhiskerModuleKernel.install(BuiltInElementModule())
     }
 
-    func testPointerCaptureOperationsReachTheUIKitSurface() {
+    func testRuntimeOwnedPointerCaptureOperationsAreAcceptedByUIKit() {
         let view = WhiskerView(frame: .zero)
         let registration = WhiskerElementRegistration(
             elementType: 1,


### PR DESCRIPTION
## Summary
- remove UIKit pointer-capture bookkeeping that was never read for targeting or gesture arbitration
- continue validating and accepting capture protocol operations while leaving target routing in SurfaceRuntime
- document why UIKit needs no native capture mirror
- retain Android bookkeeping because it actively controls parent gesture interception

## Performance
- removes dictionary writes and delete-time filtering on iOS
- adds no input-path work

## Verification
- `cargo xtask host-conformance ios` (23 tests)