### PR TITLE
refactor(ios): enforce main-thread Host callbacks

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/bridge/RuntimeABI.swift
@@ -153,24 +153,18 @@ let whiskerIOSBootstrap: WhiskerBootstrapHost = { data, bootstrap in
 
 let whiskerIOSPresentFrame: WhiskerPresentFrame = { data, frame, response in
     guard let data, let frame, let response else { return false }
+    precondition(Thread.isMainThread, "Whisker frame presentation must run on the UI thread")
     let view = Unmanaged<WhiskerView>.fromOpaque(data).takeUnretainedValue()
-    if Thread.isMainThread {
-        return view.applyFrame(frame.pointee, response: &response.pointee)
-    }
-    return DispatchQueue.main.sync {
-        view.applyFrame(frame.pointee, response: &response.pointee)
-    }
+    return view.applyFrame(frame.pointee, response: &response.pointee)
 }
 
 let whiskerIOSResourceCommand: WhiskerResourceCommandHost = { data, command in
     guard let data, let command, let decoded = hostResourceCommand(command.pointee) else {
         return false
     }
+    precondition(Thread.isMainThread, "Whisker resource commands must run on the UI thread")
     let view = Unmanaged<WhiskerView>.fromOpaque(data).takeUnretainedValue()
-    if Thread.isMainThread {
-        return view.applyResourceCommand(decoded)
-    }
-    return DispatchQueue.main.sync { view.applyResourceCommand(decoded) }
+    return view.applyResourceCommand(decoded)
 }
 
 let whiskerIOSInvokeModule: WhiskerInvokeModule = {


### PR DESCRIPTION
## Summary
- make the iOS frame-presentation and resource-command UI-thread contract explicit
- remove dead synchronous main-queue hops that could deadlock if the contract were violated
- apply Host mutations directly on the established CADisplayLink/UI-thread path

## Performance
- removes a thread check and unreachable closure/sync-dispatch branch from each callback
- no new allocations or retained state

## Verification
- `cargo xtask host-conformance ios` (23 tests)