### PR TITLE
feat(desktop): align OS shell hot-reload APIs

### DIFF
--- a/platforms/linux/Cargo.toml
+++ b/platforms/linux/Cargo.toml
@@ -11,5 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 description = "Native Linux application shell for Whisker."
 
+[features]
+hot-reload = ["whisker-desktop/hot-reload"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 whisker-desktop = { workspace = true }

--- a/platforms/linux/src/lib.rs
+++ b/platforms/linux/src/lib.rs
@@ -12,4 +12,4 @@
 pub type LinuxAppConfig = whisker_desktop::DesktopAppConfig;
 /// Failure while creating or running the native Linux Host.
 pub type LinuxError = whisker_desktop::DesktopAppError;
-pub use whisker_desktop::run;
+pub use whisker_desktop::{run, run_with_application_hash};

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -11,5 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 description = "Native Windows application shell for Whisker."
 
+[features]
+hot-reload = ["whisker-desktop/hot-reload"]
+
 [target.'cfg(target_os = "windows")'.dependencies]
 whisker-desktop = { workspace = true }

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -12,4 +12,4 @@
 pub type WindowsAppConfig = whisker_desktop::DesktopAppConfig;
 /// Failure while creating or running the native Windows Host.
 pub type WindowsError = whisker_desktop::DesktopAppError;
-pub use whisker_desktop::run;
+pub use whisker_desktop::{run, run_with_application_hash};


### PR DESCRIPTION
## Summary
- expose `run_with_application_hash` from Linux and Windows shells, matching macOS
- forward each shell's `hot-reload` feature to the shared Desktop implementation
- let generated Hosts use one entry-point shape on every Desktop OS

## Performance
- feature/API wiring only; no runtime cost
- hot-reload code remains feature-gated

## Verification
- `cargo check -p whisker-macos --features hot-reload`
- `cargo metadata --no-deps --format-version 1`
- Linux/Windows cross checks reached target dependencies but could not complete on macOS because the corresponding native C toolchains are not installed (`x86_64-linux-gnu-gcc` / Windows headers)