### PR TITLE
fix(android): project z order without elevation

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -149,6 +149,16 @@ class HostConformanceTest {
     }
 
     @Test
+    fun zOrderUsesPhysicalSiblingOrderWithoutAndroidElevation() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                assertTrue(Driver(context, "z-order").verifyPhysicalZOrder())
+            }
+    }
+
+    @Test
     fun everySharedPaintScenarioUsesTheProductionAndroidView() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -1002,6 +1012,29 @@ private class Driver(
         check(stage(tag = MobileAbi.OP_CAPTURE, wide = 7))
         check(stage(tag = MobileAbi.OP_RELEASE_CAPTURE, wide = 7))
         return view.commitFrameFromNative()
+    }
+
+    fun verifyPhysicalZOrder(): Boolean {
+        check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
+        repeat(3) { index ->
+            val node = (index + 1).toLong()
+            check(stage(tag = MobileAbi.OP_CREATE, node = node, member = 1))
+            check(
+                stage(
+                    tag = MobileAbi.OP_LAYOUT,
+                    node = node,
+                    numbers = floatArrayOf(node.toFloat(), 0f, 10f, 10f, 0f, 0f, 10f, 10f),
+                ),
+            )
+        }
+        check(stage(tag = MobileAbi.OP_Z_ORDER, node = 1, integer = 10))
+        check(stage(tag = MobileAbi.OP_Z_ORDER, node = 2, integer = -5))
+        check(stage(tag = MobileAbi.OP_Z_ORDER, node = 3, integer = 10))
+        check(view.commitFrameFromNative())
+
+        val orderedNodes = (0 until view.childCount).map { view.getChildAt(it) as HostNode }
+        return orderedNodes.map { it.geometry.x } == listOf(2f, 1f, 3f) &&
+            orderedNodes.all { it.translationZ == 0f }
     }
 
     fun rejectOpacity(opacity: Float): Boolean {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -120,11 +120,18 @@ internal class HostScene(
         }
         return try {
             applyingFrame = true
+            val zOrderParents = if (stagedSnapshot) {
+                null
+            } else {
+                affectedZOrderParents()
+            }
             if (stagedSnapshot) clear()
             stagedOperations.forEach(::applyOperation)
             attachRoots()
-            if (stagedOperations.any { it.tag in OP_CREATE..OP_MOVE || it.tag == OP_Z_ORDER }) {
-                refreshZOrderProjection()
+            if (zOrderParents == null) {
+                refreshAllZOrderProjections()
+            } else if (zOrderParents.isNotEmpty()) {
+                zOrderParents.forEach(::refreshZOrderProjection)
             }
             sceneEpoch = stagedSceneEpoch
             revision = stagedTargetRevision
@@ -363,13 +370,63 @@ internal class HostScene(
         }
     }
 
-    /** Preserves exact signed i32 ordering while projecting onto Android's Float Z axis. */
-    private fun refreshZOrderProjection() {
-        nodes.entries.groupBy { parents[it.key] }.values.forEach { siblings ->
-            val ranks = siblings.map { it.value.zOrder }.distinct().sorted()
-                .withIndex().associate { (rank, value) -> value to rank.toFloat() }
-            siblings.forEach { (_, node) -> node.translationZ = requireNotNull(ranks[node.zOrder]) }
+    private fun affectedZOrderParents(): Set<Long?> {
+        val affected = HashSet<Long?>()
+        stagedOperations.forEach { operation ->
+            when (operation.tag) {
+                OP_CREATE -> affected += null
+                OP_DELETE -> affected += parents[operation.node]
+                OP_INSERT -> {
+                    affected += null
+                    affected += operation.parent
+                }
+                OP_REMOVE -> {
+                    affected += operation.parent
+                    affected += null
+                }
+                OP_MOVE -> affected += operation.parent
+                OP_Z_ORDER -> affected += parents[operation.node]
+            }
         }
+        return affected
+    }
+
+    private fun refreshAllZOrderProjections() {
+        val parentIds = HashSet<Long?>()
+        parentIds += null
+        parents.values.forEach(parentIds::add)
+        parentIds.forEach(::refreshZOrderProjection)
+    }
+
+    /**
+     * Projects CSS z-order into sibling order without using Android elevation.
+     *
+     * Kotlin's stable sort preserves the structural order established by insert/move for equal
+     * z-order values. Reordering the actual children avoids the shadows Android draws for Views
+     * with positive translationZ.
+     */
+    private fun refreshZOrderProjection(parentId: Long?) {
+        val host = if (parentId == null) {
+            root
+        } else {
+            val parent = nodes[parentId] ?: return
+            parent.mountedElement?.childrenHost() ?: parent
+        }
+        val structuralOrder = buildList {
+            repeat(host.childCount) { index ->
+                (host.getChildAt(index) as? HostNode)?.let(::add)
+            }
+        }
+        if (structuralOrder.isEmpty()) return
+
+        // Clear state written by older Hosts and keep z-order independent from Android elevation.
+        structuralOrder.forEach { it.translationZ = 0f }
+
+        val desiredOrder = structuralOrder.sortedBy { it.zOrder }
+        if (structuralOrder == desiredOrder) return
+
+        desiredOrder.forEach(host::bringChildToFront)
+        host.invalidate()
     }
 
     private fun insertChild(parentId: Long, childId: Long, requestedIndex: Int) {


### PR DESCRIPTION
## Summary
- project CSS z-order through physical sibling drawing order instead of Android `translationZ`
- preserve insert/move order for equal z-index values with a stable sort
- restrict delta-frame work to affected parent groups while rebuilding all groups for snapshots
- add a production-path regression for signed z-order and zero elevation

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.