### PR TITLE
fix(android): clip outer shadows outside border box

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -34,6 +34,9 @@ import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.bridge.MobileAbi
 import rs.whisker.runtime.measure.HostMeasureBatchAbi
 import rs.whisker.runtime.measure.resolveTextLayoutSemantics
+import rs.whisker.runtime.paint.HostBoxShadow
+import rs.whisker.runtime.paint.ResolvedBoxGeometry
+import rs.whisker.runtime.paint.drawOuterBoxShadows
 import rs.whisker.runtime.scene.HostAccessibility
 import rs.whisker.runtime.scene.HostNode
 
@@ -146,6 +149,35 @@ class HostConformanceTest {
                 val context = ApplicationProvider.getApplicationContext<android.content.Context>()
                 assertTrue(Driver(context, "pointer-capture").acceptsPointerCapture())
             }
+    }
+
+    @Test
+    fun outerBoxShadowDoesNotPaintInsideTransparentBorderBox() {
+        val bitmap = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.translate(20f, 20f)
+        drawOuterBoxShadows(
+            canvas,
+            ResolvedBoxGeometry(
+                width = 20f,
+                height = 20f,
+                borderWidths = FloatArray(4),
+                cornerRadii = FloatArray(8),
+            ),
+            listOf(
+                HostBoxShadow(
+                    offsetX = 0f,
+                    offsetY = 0f,
+                    blurRadius = 0f,
+                    spreadRadius = 5f,
+                    color = android.graphics.Color.RED,
+                    inset = false,
+                ),
+            ),
+        )
+
+        assertEquals(0, android.graphics.Color.alpha(bitmap.getPixel(30, 30)))
+        assertEquals(android.graphics.Color.RED, bitmap.getPixel(17, 30))
     }
 
     @Test

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/paint/BoxShadow.kt
@@ -5,6 +5,7 @@ import android.graphics.BlurMaskFilter
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
+import android.graphics.Region
 import kotlin.math.abs
 import kotlin.math.max
 
@@ -23,7 +24,14 @@ internal fun drawOuterBoxShadows(
     shadows: List<HostBoxShadow>,
 ) {
     val box = geometry ?: return
+    if (box.width <= 0f || box.height <= 0f) return
     val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    val save = canvas.save()
+    @Suppress("DEPRECATION")
+    canvas.clipPath(
+        roundedPath(RectF(0f, 0f, box.width, box.height), box.cornerRadii),
+        Region.Op.DIFFERENCE,
+    )
     shadows.asReversed().forEach { shadow ->
         if (shadow.inset) return@forEach
         val spread = shadow.spreadRadius
@@ -48,6 +56,7 @@ internal fun drawOuterBoxShadows(
         canvas.drawPath(roundedPath(rect, radii), paint)
     }
     paint.maskFilter = null
+    canvas.restoreToCount(save)
 }
 
 internal fun drawInsetBoxShadows(


### PR DESCRIPTION
## Summary
- exclude the rounded border-box interior while drawing CSS outer box shadows
- preserve inset-shadow handling and shadow stack order
- add a bitmap regression proving a transparent card does not reveal its outer shadow through the interior

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.