### PR TITLE
fix(android): share transforms with native input

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -241,6 +241,41 @@ class HostConformanceTest {
     }
 
     @Test
+    fun transformedNativeChildReceivesInputAtItsPresentedCoordinates() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val parent = WhiskerContainerView(context)
+                val node = HostNode(context, WhiskerBuiltInElements.VIEW, null)
+                val content = View(context).apply { isClickable = true }
+                node.addView(content, ViewGroup.LayoutParams(100, 100))
+                parent.addView(node, ViewGroup.LayoutParams(100, 100))
+                parent.measure(
+                    View.MeasureSpec.makeMeasureSpec(400, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(200, View.MeasureSpec.EXACTLY),
+                )
+                parent.layout(0, 0, 400, 200)
+                node.setLocalTransform(
+                    floatArrayOf(
+                        1f, 0f, 0f, 0f,
+                        0f, 1f, 0f, 0f,
+                        0f, 0f, 1f, 0f,
+                        200f, 0f, 0f, 1f,
+                    ),
+                    density = 1f,
+                )
+
+                val down = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 250f, 50f, 0)
+                try {
+                    assertTrue(parent.dispatchTouchEvent(down))
+                } finally {
+                    down.recycle()
+                }
+            }
+    }
+
+    @Test
     fun rejectsInvalidOpacityValues() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -1,5 +1,6 @@
 package rs.whisker.runtime.scene
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Matrix
@@ -80,7 +81,7 @@ internal class HostNode(
         private set
 
     private val localTransform = Matrix()
-    private var hasLocalTransform = false
+    private var needsCanvasTransformFallback = false
     private var overflowClipRect = RectF()
     private var overflowClipPath: Path? = null
     private var paintClipPath: Path? = null
@@ -255,6 +256,7 @@ internal class HostNode(
     fun resolvedBorderWidths(): FloatArray = resolvedBoxGeometry?.borderWidths ?: FloatArray(4)
 
     /** Applies a protocol transform around the local border-box origin. */
+    @SuppressLint("NewApi")
     fun setLocalTransform(values: FloatArray, density: Float) {
         require(isProjectableFlatPlaneTransform(values))
         require(density.isFinite() && density > 0f)
@@ -266,14 +268,30 @@ internal class HostNode(
                 values[3] / density, values[7] / density, values[15],
             ),
         )
-        hasLocalTransform = !localTransform.isIdentity
+        needsCanvasTransformFallback = !applyNativeTransform(localTransform)
         invalidate()
         (parent as? android.view.View)?.invalidate()
     }
 
+    @SuppressLint("NewApi")
+    private fun applyNativeTransform(matrix: Matrix): Boolean {
+        if (!animationMatrixAvailable) return false
+        return try {
+            // setAnimationMatrix existed on RenderNode from API 21 and became public in API 29.
+            // Unlike Canvas.concat, ViewGroup uses this matrix for native child hit testing too.
+            setAnimationMatrix(matrix.takeUnless(Matrix::isIdentity))
+            true
+        } catch (_: NoSuchMethodError) {
+            // An unusual OEM implementation may omit the formerly hidden method. Remember that
+            // once so animated frames do not repeatedly pay for a linkage exception.
+            animationMatrixAvailable = false
+            false
+        }
+    }
+
     override fun draw(canvas: Canvas) {
         if (root?.shouldSkipBackdropCapture(this) == true) return
-        if (!hasLocalTransform) {
+        if (!needsCanvasTransformFallback) {
             drawClipped(canvas)
             return
         }
@@ -346,6 +364,10 @@ internal class HostNode(
             if (horizontal) overflowClipRect.right else visible.right.toFloat(),
             if (vertical) overflowClipRect.bottom else visible.bottom.toFloat(),
         )
+    }
+
+    private companion object {
+        private var animationMatrixAvailable = true
     }
 }
 


### PR DESCRIPTION
## Summary
- install each protocol transform on the Android View matrix used by both rendering and native hit testing
- retain the Canvas transform only as an OEM linkage fallback
- cache a missing hidden method result so animated frames never repeatedly throw linkage errors
- add a regression that dispatches touch input at a translated native child

Android `setAnimationMatrix` was backed by RenderNode from API 21 and became public in API 29; AndroidX Transition uses the same direct-link compatibility path on API 21–28.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.