### PR TITLE
fix(android): reject unknown element members

### DIFF
--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -383,6 +383,16 @@ public object WhiskerElementRegistry {
     @JvmStatic
     public fun registration(elementType: Int): WhiskerElementRegistration? =
         boundByType[elementType]?.registration
+
+    /** Constant-time validation for the retained scene's compact property operations. */
+    @JvmStatic
+    public fun hasProperty(elementType: Int, property: Int): Boolean =
+        boundByType[elementType]?.properties?.containsKey(property) == true
+
+    /** Constant-time validation for the retained scene's compact command operations. */
+    @JvmStatic
+    public fun hasCommand(elementType: Int, command: Int): Boolean =
+        boundByType[elementType]?.commands?.containsKey(command) == true
 }
 
 /** Single bootstrap boundary for independently compiled Host modules. */

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -149,6 +149,16 @@ class HostConformanceTest {
     }
 
     @Test
+    fun rejectsUnknownElementPropertyAndCommandIds() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                assertTrue(Driver(context, "unknown-members").rejectsUnknownMembers())
+            }
+    }
+
+    @Test
     fun everySharedPaintScenarioUsesTheProductionAndroidView() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -1004,6 +1014,20 @@ private class Driver(
         return view.commitFrameFromNative()
     }
 
+    fun rejectsUnknownMembers(): Boolean {
+        val cases = listOf(
+            Triple(MobileAbi.OP_PROPERTY, 999, WhiskerValue.Int(1)),
+            Triple(MobileAbi.OP_CLEAR_PROPERTY, 999, null),
+            Triple(MobileAbi.OP_COMMAND, 999, WhiskerValue.Null),
+        )
+        return cases.all { (tag, member, value) ->
+            check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
+            check(stage(tag = MobileAbi.OP_CREATE, member = 1))
+            check(stage(tag = tag, member = member, value = value))
+            !view.commitFrameFromNative()
+        }
+    }
+
     fun rejectOpacity(opacity: Float): Boolean {
         check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
         check(stage(tag = 1, member = 1))
@@ -1511,6 +1535,7 @@ private class Driver(
         numbers: FloatArray? = null,
         text: String? = null,
         names: Array<String>? = null,
+        value: WhiskerValue? = null,
     ): Boolean = view.stageOperationFromNative(
         tag,
         flags,
@@ -1525,7 +1550,7 @@ private class Driver(
         numbers,
         text,
         names,
-        null,
+        value,
     )
 
     private fun paint(command: JSONObject): Pair<FloatArray, Array<String>> {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -193,7 +193,7 @@ internal class HostScene(
                 operation.node !in existing || operation.numbers?.size ?: 0 < 53 ||
                 operation.names?.size ?: 0 < 5
             ) return false
-            OP_CLIP, OP_Z_ORDER, OP_CLEAR_PROPERTY, OP_EVENT_MASK ->
+            OP_CLIP, OP_Z_ORDER, OP_EVENT_MASK ->
                 if (operation.node !in existing) return false
             OP_HIT_TEST -> if (operation.node !in existing || operation.integer !in 0..3) return false
             OP_CURSOR -> if (operation.node !in existing || operation.integer !in 0..34) return false
@@ -235,7 +235,28 @@ internal class HostScene(
                 if (operation.tag == OP_TEXT && registration.childPolicy != WhiskerChildPolicy.PlainText) return false
                 if (operation.tag == OP_TEXT_STYLE && !registration.textStyle) return false
             }
-            OP_PROPERTY, OP_COMMAND, OP_ACCESSIBILITY ->
+            OP_PROPERTY -> if (
+                operation.node !in existing || operation.value == null ||
+                !WhiskerElementRegistry.hasProperty(
+                    elementTypes[operation.node] ?: return false,
+                    operation.member,
+                )
+            ) return false
+            OP_CLEAR_PROPERTY -> if (
+                operation.node !in existing ||
+                !WhiskerElementRegistry.hasProperty(
+                    elementTypes[operation.node] ?: return false,
+                    operation.member,
+                )
+            ) return false
+            OP_COMMAND -> if (
+                operation.node !in existing || operation.value == null ||
+                !WhiskerElementRegistry.hasCommand(
+                    elementTypes[operation.node] ?: return false,
+                    operation.member,
+                )
+            ) return false
+            OP_ACCESSIBILITY ->
                 if (operation.node !in existing || operation.value == null) return false
             OP_BACKGROUND_LAYERS -> if (!validBackgroundLayers(operation, existing, rasterResources)) return false
             else -> return false


### PR DESCRIPTION
## Summary
- reject property set/clear operations whose compact ID is absent from the negotiated element binding
- reject commands whose compact ID is absent from the negotiated element binding
- expose allocation-free, constant-time bound-member checks from the Android element registry
- add production-scene regressions for property, clear-property, and command IDs

## Performance
Validation adds two existing hash-table lookups only to module property/command operations. It does not allocate or scan member declarations per frame.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.