### PR TITLE
fix(android): suppress input for hidden nodes

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -149,6 +149,33 @@ class HostConformanceTest {
     }
 
     @Test
+    fun hiddenContainerDoesNotDispatchToNativeContent() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                val node = HostNode(context, WhiskerBuiltInElements.VIEW, null)
+                node.addView(
+                    View(context).apply { isClickable = true },
+                    ViewGroup.LayoutParams(100, 100),
+                )
+                node.measure(
+                    View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+                    View.MeasureSpec.makeMeasureSpec(100, View.MeasureSpec.EXACTLY),
+                )
+                node.layout(0, 0, 100, 100)
+                node.setWhiskerVisibility(false)
+
+                val down = MotionEvent.obtain(0L, 0L, MotionEvent.ACTION_DOWN, 50f, 50f, 0)
+                try {
+                    assertEquals(false, node.dispatchTouchEvent(down))
+                } finally {
+                    down.recycle()
+                }
+            }
+    }
+
+    @Test
     fun everySharedPaintScenarioUsesTheProductionAndroidView() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostNode.kt
@@ -202,7 +202,7 @@ internal class HostNode(
     }
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
-        if (!whiskerVisible && hitTestBehavior == 2) return false
+        if (!whiskerVisible) return false
         return when (hitTestBehavior) {
             1 -> false
             2 -> onTouchEvent(event)


### PR DESCRIPTION
## Summary
- make a computed `visibility: hidden` node ineligible for native touch dispatch regardless of pointer-events mode
- keep Rust root-level pointer normalization unchanged, so visible Rust targets continue to use authoritative hit testing
- add an instrumentation regression with clickable native content

## Performance
This adds one existing boolean check to Android HostNode touch dispatch and no allocation or traversal.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.