### PR TITLE
fix(android): propagate pointer capture through scrollers

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -34,8 +34,11 @@ import rs.whisker.runtime.input.normalizePointerInput
 import rs.whisker.runtime.bridge.MobileAbi
 import rs.whisker.runtime.measure.HostMeasureBatchAbi
 import rs.whisker.runtime.measure.resolveTextLayoutSemantics
+import rs.whisker.runtime.paint.HostRasterResourceStore
 import rs.whisker.runtime.scene.HostAccessibility
 import rs.whisker.runtime.scene.HostNode
+import rs.whisker.runtime.scene.HostScene
+import rs.whisker.runtime.scene.HostSceneOperation
 
 private const val BACKGROUND_PACKED_LAYERS = 256
 
@@ -145,6 +148,53 @@ class HostConformanceTest {
             .runOnMainSync {
                 val context = ApplicationProvider.getApplicationContext<android.content.Context>()
                 assertTrue(Driver(context, "pointer-capture").acceptsPointerCapture())
+            }
+    }
+
+    @Test
+    fun pointerCaptureDisallowsInterceptionFromTheCapturedNodesParent() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                // Bind the built-in declarations used by the direct production HostScene below.
+                Driver(context, "pointer-capture-parent")
+                val root = object : WhiskerContainerView(context) {
+                    var interceptionDisallowed = false
+
+                    override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+                        interceptionDisallowed = disallowIntercept
+                        super.requestDisallowInterceptTouchEvent(disallowIntercept)
+                    }
+                }
+                val scene = HostScene(root, context, { _, _, _ -> }, HostRasterResourceStore())
+                fun operation(tag: Int, wide: Long = 0L) = HostSceneOperation(
+                    tag = tag,
+                    flags = 0,
+                    node = 1L,
+                    parent = 0L,
+                    child = 0L,
+                    index = 0,
+                    member = if (tag == MobileAbi.OP_CREATE) 1 else 0,
+                    integer = 0,
+                    scalar = 0f,
+                    wide = wide,
+                    numbers = null,
+                    text = null,
+                    names = null,
+                    value = null,
+                )
+
+                check(scene.beginFrame(0, 1, 0, 1) == 0)
+                scene.stage(operation(MobileAbi.OP_CREATE))
+                scene.stage(operation(MobileAbi.OP_CAPTURE, 7L))
+                assertTrue(scene.commit())
+                assertTrue(root.interceptionDisallowed)
+
+                check(scene.beginFrame(1, 1, 1, 2) == 0)
+                scene.stage(operation(MobileAbi.OP_RELEASE_CAPTURE, 7L))
+                assertTrue(scene.commit())
+                assertEquals(false, root.interceptionDisallowed)
             }
     }
 

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -145,6 +145,9 @@ internal class HostScene(
     }
 
     fun clear() {
+        pointerCaptures.values.forEach { nodeId ->
+            nodes[nodeId]?.parent?.requestDisallowInterceptTouchEvent(false)
+        }
         nodes.values.toList().forEach(::releasePresentation)
         nodes.clear()
         parents.clear()
@@ -321,15 +324,16 @@ internal class HostScene(
             }
             OP_CURSOR -> (nodes[id] ?: return).setCursorKeyword(operation.integer)
             OP_CAPTURE -> {
-                pointerCaptures[operation.wide] = id
-                root.parent?.requestDisallowInterceptTouchEvent(true)
+                pointerCaptures.put(operation.wide, id)?.let { previousNode ->
+                    nodes[previousNode]?.parent?.requestDisallowInterceptTouchEvent(false)
+                }
+                reapplyNativePointerInterception()
             }
             OP_RELEASE_CAPTURE -> {
                 if (pointerCaptures[operation.wide] == id) {
                     pointerCaptures.remove(operation.wide)
-                    if (pointerCaptures.isEmpty()) {
-                        root.parent?.requestDisallowInterceptTouchEvent(false)
-                    }
+                    nodes[id]?.parent?.requestDisallowInterceptTouchEvent(false)
+                    reapplyNativePointerInterception()
                 }
             }
         }
@@ -397,11 +401,16 @@ internal class HostScene(
     }
 
     private fun deleteNode(id: Long) {
-        val node = nodes.remove(id) ?: return
+        val node = nodes[id] ?: return
         val descendants = nodes.keys.filter { candidate -> isDescendant(candidate, id) }
         val removedNodes = descendants.toSet() + id
-        pointerCaptures.entries.removeAll { it.value in removedNodes }
-        if (pointerCaptures.isEmpty()) root.parent?.requestDisallowInterceptTouchEvent(false)
+        pointerCaptures.entries.removeAll { (_, capturedNode) ->
+            if (capturedNode !in removedNodes) return@removeAll false
+            nodes[capturedNode]?.parent?.requestDisallowInterceptTouchEvent(false)
+            true
+        }
+        reapplyNativePointerInterception()
+        nodes.remove(id)
         descendants.forEach { child ->
             nodes.remove(child)?.let(::releasePresentation)
             parents.remove(child)
@@ -409,6 +418,17 @@ internal class HostScene(
         parents.remove(id)
         (node.parent as? ViewGroup)?.removeView(node)
         releasePresentation(node)
+    }
+
+    /** Propagates capture from its actual node through nested native scrollers to the window. */
+    private fun reapplyNativePointerInterception() {
+        if (pointerCaptures.isEmpty()) {
+            root.parent?.requestDisallowInterceptTouchEvent(false)
+            return
+        }
+        pointerCaptures.values.forEach { nodeId ->
+            (nodes[nodeId]?.parent ?: root.parent)?.requestDisallowInterceptTouchEvent(true)
+        }
     }
 
     private fun releasePresentation(node: HostNode) {


### PR DESCRIPTION
## Summary
- issue `requestDisallowInterceptTouchEvent` from the captured node parent so nested ScrollView ancestors participate
- clear released/deleted capture paths and reapply remaining captures to preserve multi-pointer shared ancestors
- clear internal interception state before a scene reset
- add a direct production HostScene regression proving capture reaches the node parent and release restores it

## Performance
Capture/release traverses only active captures; ordinary pointer events and frames are unchanged. Active capture cardinality is bounded by the small number of physical pointers.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.