### PR TITLE
fix(android): round physical layout sizes

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -149,6 +149,16 @@ class HostConformanceTest {
     }
 
     @Test
+    fun layoutSizesRoundToTheNearestPhysicalPixel() {
+        androidx.test.platform.app.InstrumentationRegistry
+            .getInstrumentation()
+            .runOnMainSync {
+                val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+                assertTrue(Driver(context, "layout-rounding").verifyLayoutRounding())
+            }
+    }
+
+    @Test
     fun everySharedPaintScenarioUsesTheProductionAndroidView() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()
@@ -1002,6 +1012,32 @@ private class Driver(
         check(stage(tag = MobileAbi.OP_CAPTURE, wide = 7))
         check(stage(tag = MobileAbi.OP_RELEASE_CAPTURE, wide = 7))
         return view.commitFrameFromNative()
+    }
+
+    fun verifyLayoutRounding(): Boolean {
+        val density = context.resources.displayMetrics.density
+        check(view.beginFrameFromNative(0, 1, 0, 1) == 0)
+        check(stage(tag = MobileAbi.OP_CREATE, member = 1))
+        check(
+            stage(
+                tag = MobileAbi.OP_LAYOUT,
+                numbers = floatArrayOf(
+                    0f,
+                    0f,
+                    10.75f / density,
+                    12.75f / density,
+                    0f,
+                    0f,
+                    6.75f / density,
+                    8.75f / density,
+                ),
+            ),
+        )
+        check(view.commitFrameFromNative())
+        val node = view.getChildAt(0) as HostNode
+        val content = checkNotNull(node.mountedElement).view
+        return node.layoutParams.width == 11 && node.layoutParams.height == 13 &&
+            content.layoutParams.width == 7 && content.layoutParams.height == 9
     }
 
     fun rejectOpacity(opacity: Float): Boolean {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -54,6 +54,7 @@ import rs.whisker.runtime.paint.parseNamedColor
 import rs.whisker.runtime.paint.rgba
 import rs.whisker.runtime.paint.resolveClipPath
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 internal data class HostSceneOperation(
     val tag: Int,
@@ -452,15 +453,15 @@ internal class HostScene(
         node.x = (node.geometry.x - if (customHost) parentNode!!.geometry.contentX else 0f) * density
         node.y = (node.geometry.y - if (customHost) parentNode!!.geometry.contentY else 0f) * density
         node.layoutParams = (node.layoutParams ?: ViewGroup.LayoutParams(0, 0)).apply {
-            width = (node.geometry.width * density).toInt().coerceAtLeast(0)
-            height = (node.geometry.height * density).toInt().coerceAtLeast(0)
+            width = (node.geometry.width * density).roundToInt().coerceAtLeast(0)
+            height = (node.geometry.height * density).roundToInt().coerceAtLeast(0)
         }
         node.mountedElement?.view?.let { content ->
             content.x = node.geometry.contentX * density
             content.y = node.geometry.contentY * density
             content.layoutParams = (content.layoutParams ?: ViewGroup.LayoutParams(0, 0)).apply {
-                width = (node.geometry.contentWidth * density).toInt().coerceAtLeast(0)
-                height = (node.geometry.contentHeight * density).toInt().coerceAtLeast(0)
+                width = (node.geometry.contentWidth * density).roundToInt().coerceAtLeast(0)
+                height = (node.geometry.contentHeight * density).roundToInt().coerceAtLeast(0)
             }
         }
         node.paint?.let { applyPaint(node, it) }


### PR DESCRIPTION
## Summary
- round logical wrapper dimensions to the nearest Android physical pixel
- apply the same rounding to mounted element content dimensions
- add a density-independent production scene regression for both boxes

This prevents adjacent fractional-dp boxes from accumulating one-pixel gaps due to unconditional truncation.

## Performance
The four existing float-to-int conversions use `roundToInt`; no allocation or extra traversal is introduced.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.