### PR TITLE
fix(android): scope element bindings per surface

### DIFF
--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerModuleRegistrar.kt
@@ -230,19 +230,59 @@ private data class WhiskerDeclaredElement(
     val commands: Map<String, WhiskerCommandComponent>,
 )
 
-private data class WhiskerBoundElement(
+internal data class WhiskerBoundElement(
     val registration: WhiskerElementRegistration,
     val factory: WhiskerElementFactory,
     val properties: Map<Int, WhiskerPropComponent>,
     val commands: Map<Int, WhiskerCommandComponent>,
 )
 
-/** Process-wide Host declaration registry and per-surface negotiated table. */
+/** One surface's immutable-after-bootstrap mapping from Rust IDs to Host declarations. */
+public class WhiskerElementBindings private constructor() {
+    @Volatile private var boundByType: Map<Int, WhiskerBoundElement> = emptyMap()
+
+    internal fun publish(bindings: Map<Int, WhiskerBoundElement>) {
+        boundByType = bindings
+    }
+
+    public fun mount(
+        elementType: Int,
+        context: Context,
+        eventSink: WhiskerElementEventSink,
+    ): WhiskerMountedElement? {
+        val element = boundByType[elementType] ?: return null
+        val view = element.factory.makeView(context)
+        return WhiskerMountedElement(
+            element.registration,
+            view,
+            element.factory.textUpdater,
+            element.factory.textStyleUpdater,
+            element.factory.childrenHost,
+            element.properties,
+            element.commands,
+            element.registration.events.associateBy { it.name },
+            eventSink,
+        )
+    }
+
+    public fun measure(elementType: Int, request: WhiskerMeasureRequest): WhiskerMeasuredSize? =
+        boundByType[elementType]?.factory?.measurer?.invoke(request)
+
+    public fun registration(elementType: Int): WhiskerElementRegistration? =
+        boundByType[elementType]?.registration
+
+    internal companion object {
+        fun empty(): WhiskerElementBindings = WhiskerElementBindings()
+    }
+}
+
+/** Process-wide Host declarations used to negotiate independent surface-local binding tables. */
 public object WhiskerElementRegistry {
     private const val LOG_TAG = "WhiskerElementRegistry"
     private val declarations = ConcurrentHashMap<String, WhiskerDeclaredElement>()
-    @Volatile private var boundByType: Map<Int, WhiskerBoundElement> = emptyMap()
-    @Volatile private var boundByName: Map<String, WhiskerBoundElement> = emptyMap()
+
+    @JvmStatic
+    public fun newBindings(): WhiskerElementBindings = WhiskerElementBindings.empty()
 
     @JvmStatic
     public fun register(factory: WhiskerElementFactory) {
@@ -302,7 +342,10 @@ public object WhiskerElementRegistry {
 
     /** Match Host strings to Rust registrations and compile compact dispatch tables. */
     @JvmStatic
-    public fun bind(registrations: List<WhiskerElementRegistration>): Boolean {
+    public fun bind(
+        target: WhiskerElementBindings,
+        registrations: List<WhiskerElementRegistration>,
+    ): Boolean {
         fun reject(message: String): Boolean {
             Log.e(LOG_TAG, "Host element bootstrap rejected: $message")
             return false
@@ -350,39 +393,9 @@ public object WhiskerElementRegistry {
                 return reject("duplicate Rust element name `${registration.name}`")
             }
         }
-        boundByType = byType
-        boundByName = byName
+        target.publish(byType)
         return true
     }
-
-    @JvmStatic
-    public fun mount(
-        elementType: Int,
-        context: Context,
-        eventSink: WhiskerElementEventSink,
-    ): WhiskerMountedElement? {
-        val element = boundByType[elementType] ?: return null
-        val view = element.factory.makeView(context)
-        return WhiskerMountedElement(
-            element.registration,
-            view,
-            element.factory.textUpdater,
-            element.factory.textStyleUpdater,
-            element.factory.childrenHost,
-            element.properties,
-            element.commands,
-            element.registration.events.associateBy { it.name },
-            eventSink,
-        )
-    }
-
-    @JvmStatic
-    public fun measure(elementType: Int, request: WhiskerMeasureRequest): WhiskerMeasuredSize? =
-        boundByType[elementType]?.factory?.measurer?.invoke(request)
-
-    @JvmStatic
-    public fun registration(elementType: Int): WhiskerElementRegistration? =
-        boundByType[elementType]?.registration
 }
 
 /** Single bootstrap boundary for independently compiled Host modules. */

--- a/platforms/android/module/src/test/kotlin/rs/whisker/runtime/WhiskerElementBindingsTest.kt
+++ b/platforms/android/module/src/test/kotlin/rs/whisker/runtime/WhiskerElementBindingsTest.kt
@@ -1,0 +1,32 @@
+package rs.whisker.runtime
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WhiskerElementBindingsTest {
+    @Test
+    fun bindingASecondSurfaceDoesNotReplaceTheFirstSurfacesIds() {
+        val name = "binding-test/Independent"
+        WhiskerElementRegistry.register(
+            WhiskerElementFactory(name = name) { error("mount is not needed by this test") },
+        )
+        fun registration(elementType: Int) = WhiskerElementRegistration(
+            elementType = elementType,
+            name = name,
+            childPolicy = WhiskerChildPolicy.None,
+            measurement = WhiskerMeasurement.None,
+        )
+        val first = WhiskerElementRegistry.newBindings()
+        val second = WhiskerElementRegistry.newBindings()
+
+        assertTrue(WhiskerElementRegistry.bind(first, listOf(registration(11))))
+        assertTrue(WhiskerElementRegistry.bind(second, listOf(registration(29))))
+
+        assertEquals(11, first.registration(11)?.elementType)
+        assertNull(first.registration(29))
+        assertEquals(29, second.registration(29)?.elementType)
+        assertNull(second.registration(11))
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -48,10 +48,11 @@ class WhiskerView(context: Context) :
     private var frameScheduled = false
     private var windowVisible = true
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val measurements = HostMeasurementProvider(context)
-    private val bootstrap = HostElementBootstrap()
+    private val elements = WhiskerElementRegistry.newBindings()
+    private val measurements = HostMeasurementProvider(context, elements)
+    private val bootstrap = HostElementBootstrap(elements)
     private val rasterResources = HostRasterResourceStore()
-    private val scene = HostScene(this, context, ::dispatchElementEvent, rasterResources)
+    private val scene = HostScene(this, context, ::dispatchElementEvent, rasterResources, elements)
     private val resourceService = HostResourceService(
         rasterResources,
         ::handleResourceEvent,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -17,13 +17,16 @@ import java.text.Bidi
 import java.util.Locale
 import kotlin.math.ceil
 import rs.whisker.runtime.WhiskerAvailableSpace
-import rs.whisker.runtime.WhiskerElementRegistry
+import rs.whisker.runtime.WhiskerElementBindings
 import rs.whisker.runtime.WhiskerMeasureRequest
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.resolveWhiskerTypeface
 
 /** Intrinsic measurement implementation shared by all Android Host frames. */
-internal class HostMeasurementProvider(private val context: Context) {
+internal class HostMeasurementProvider(
+    private val context: Context,
+    private val elements: WhiskerElementBindings,
+) {
     @Suppress("LongParameterList")
     fun measure(
         elementType: Int, kind: Int,
@@ -55,7 +58,7 @@ internal class HostMeasurementProvider(private val context: Context) {
                 if (knownMask and HEIGHT != 0) knownHeight else intrinsicHeight,
             )
         }
-        val custom = WhiskerElementRegistry.measure(
+        val custom = elements.measure(
             elementType,
             WhiskerMeasureRequest(
                 if (availableWidthKind == DEFINITE) availableWidth else null,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostElementBootstrap.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostElementBootstrap.kt
@@ -3,6 +3,7 @@ package rs.whisker.runtime.scene
 import rs.whisker.runtime.WhiskerChildPolicy
 import rs.whisker.runtime.WhiskerCommandBinding
 import rs.whisker.runtime.WhiskerElementRegistration
+import rs.whisker.runtime.WhiskerElementBindings
 import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerEventBinding
 import rs.whisker.runtime.WhiskerMeasurement
@@ -10,7 +11,7 @@ import rs.whisker.runtime.WhiskerPropertyBinding
 import rs.whisker.runtime.WhiskerValueKind
 
 /** Builds and atomically binds the Rust-provided element schema table. */
-internal class HostElementBootstrap {
+internal class HostElementBootstrap(private val bindings: WhiskerElementBindings) {
     private val registrations = ArrayList<WhiskerElementRegistration>()
 
     fun begin() {
@@ -57,5 +58,5 @@ internal class HostElementBootstrap {
         )
     }
 
-    fun finish(): Boolean = WhiskerElementRegistry.bind(registrations)
+    fun finish(): Boolean = WhiskerElementRegistry.bind(bindings, registrations)
 }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/scene/HostScene.kt
@@ -10,7 +10,7 @@ import java.util.ArrayDeque
 import rs.whisker.runtime.WhiskerChildPolicy
 import rs.whisker.runtime.WhiskerContainerView
 import rs.whisker.runtime.WhiskerView
-import rs.whisker.runtime.WhiskerElementRegistry
+import rs.whisker.runtime.WhiskerElementBindings
 import rs.whisker.runtime.WhiskerTextContent
 import rs.whisker.runtime.WhiskerFontStyle
 import rs.whisker.runtime.WhiskerFontFeature
@@ -78,6 +78,7 @@ internal class HostScene(
     private val context: Context,
     private val emitElementEvent: (Long, String, WhiskerValue) -> Unit,
     private val rasterResources: HostRasterResourceStore,
+    private val elements: WhiskerElementBindings,
 ) {
     private val nodes = LinkedHashMap<Long, HostNode>()
     private val parents = HashMap<Long, Long>()
@@ -165,7 +166,7 @@ internal class HostScene(
             OP_CREATE -> {
                 if (
                     operation.node == 0L || !existing.add(operation.node) ||
-                    WhiskerElementRegistry.registration(operation.member) == null
+                    elements.registration(operation.member) == null
                 ) return false
                 elementTypes[operation.node] = operation.member
             }
@@ -178,7 +179,7 @@ internal class HostScene(
             }
             OP_INSERT -> {
                 val policy = elementTypes[operation.parent]
-                    ?.let(WhiskerElementRegistry::registration)?.childPolicy
+                    ?.let(elements::registration)?.childPolicy
                 if (
                     operation.parent !in existing || operation.child !in existing ||
                     stagedParents.containsKey(operation.child) ||
@@ -219,7 +220,7 @@ internal class HostScene(
             OP_TEXT, OP_TEXT_STYLE -> {
                 val values = operation.numbers ?: return false
                 val registration = elementTypes[operation.node]
-                    ?.let(WhiskerElementRegistry::registration) ?: return false
+                    ?.let(elements::registration) ?: return false
                 if (
                     operation.node !in existing || operation.text == null ||
                     values.size < 37 || operation.names?.size ?: 0 < 3 ||
@@ -248,7 +249,7 @@ internal class HostScene(
         when (operation.tag) {
             OP_CREATE -> {
                 val registration = requireNotNull(
-                    WhiskerElementRegistry.registration(operation.member),
+                    elements.registration(operation.member),
                 )
                 val eventSink: rs.whisker.runtime.WhiskerElementEventSink = { event, detail ->
                     emitElementEvent(id, event.name, detail)
@@ -256,7 +257,7 @@ internal class HostScene(
                 val mounted = presentationPool[operation.member]?.pollFirst()?.also {
                     it.prepareForReuse(eventSink)
                 } ?: requireNotNull(
-                    WhiskerElementRegistry.mount(operation.member, context, eventSink),
+                    elements.mount(operation.member, context, eventSink),
                 )
                 val node = HostNode(context, registration.name, root as? WhiskerView)
                 node.mountedElement = mounted


### PR DESCRIPTION
## Summary
- keep Host module declarations process-wide while moving negotiated compact-ID tables into `WhiskerElementBindings` owned by each WhiskerView
- inject the same surface-local table into bootstrap, frame projection, mounting, and intrinsic measurement
- publish a completed table atomically only after full validation
- add a regression proving a second surface with different IDs cannot replace the first surface table

## Performance and memory
- hot lookups remain one volatile immutable-map read plus one hash lookup, matching the previous global table
- each surface retains one compact table proportional to its registered element/member count; no per-frame allocation is added

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :module:testDebugUnitTest :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`