### PR TITLE
fix(android): forward generated activity deep links

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -802,7 +802,7 @@ mod tests {
             extra_gradle_plugins: Vec::new(),
             extra_gradle_dependencies: Vec::new(),
             extra_files: BTreeMap::new(),
-            template_version: 35,
+            template_version: 36,
         }
     }
 
@@ -817,6 +817,11 @@ mod tests {
                 .contains("window.setBackgroundDrawableResource(R.color.whisker_background)")
         );
         assert!(MAIN_ACTIVITY_KT.contains("setContentView(WhiskerView(this))"));
+        assert!(MAIN_ACTIVITY_KT.contains("override fun onNewIntent(intent: Intent)"));
+        assert!(
+            MAIN_ACTIVITY_KT
+                .contains("intent.dataString?.let(WhiskerAppContext::dispatchDeepLink)")
+        );
         assert!(APP_BUILD_GRADLE_KTS.contains("androidx.activity:activity:1.8.2"));
     }
 

--- a/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
+++ b/crates/whisker-cng/src/templates/android/app/src/main/kotlin/MainActivity.kt
@@ -1,7 +1,9 @@
 package {{android_application_id}}
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import rs.whisker.runtime.WhiskerAppContext
 import rs.whisker.runtime.WhiskerView{{main_activity_imports}}
 import rs.whisker.runtime.WhiskerWindow
 import rs.whisker.runtime.generated.WhiskerModuleBehaviors
@@ -18,5 +20,16 @@ class MainActivity : ComponentActivity() {
         System.loadLibrary("{{rust_lib_name}}")
         WhiskerModuleBehaviors.registerAll()
         setContentView(WhiskerView(this))
+        dispatchDeepLink(intent)
 {{main_activity_post_super}}    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        dispatchDeepLink(intent)
+    }
+
+    private fun dispatchDeepLink(intent: Intent) {
+        intent.dataString?.let(WhiskerAppContext::dispatchDeepLink)
+    }
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerAppContext.kt
@@ -142,7 +142,7 @@ public class WhiskerAppContext internal constructor() {
         private val deepLinkListeners: CopyOnWriteArrayList<DeepLinkListener> =
             CopyOnWriteArrayList()
 
-        /** Called by [rs.whisker.runtime.WhiskerActivity.onNewIntent]. */
+        /** Called by the generated Activity for cold-start and `onNewIntent` deep links. */
         @JvmStatic
         public fun dispatchDeepLink(url: String) {
             for (l in deepLinkListeners) l.onDeepLink(url)


### PR DESCRIPTION
## Summary
- forward both initial Activity intents and warm `onNewIntent` URLs to WhiskerAppContext
- preserve the deep-link listener contract used by `whisker-web-browser` OAuth sessions
- update the stale WhiskerActivity reference and bump the Android CNG template version
- assert the generated Activity contains the forwarding hook

The review classified this as dead API, but a repository-wide check found a real `whisker-web-browser` consumer. Wiring the missing Host entry point fixes that package instead of deleting its contract.

## Validation
- `cargo test -p whisker-cng --lib generated_activity_only_composes_the_sdk_view`
- `platforms/android/gradle-plugin/gradlew -p platforms/android :module:compileDebugKotlin --no-daemon`
- `git diff --check`