### PR TITLE
fix(gradle): drain module discovery output concurrently

### DIFF
--- a/platforms/android/gradle-plugin/whisker-settings-plugin/build.gradle.kts
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/build.gradle.kts
@@ -53,3 +53,7 @@ publishing {
 kotlin {
     jvmToolchain(17)
 }
+
+dependencies {
+    testImplementation(kotlin("test"))
+}

--- a/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/src/main/kotlin/rs/whisker/gradle/WhiskerPlugin.kt
@@ -6,6 +6,7 @@ import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
 import java.util.Properties
+import java.util.concurrent.FutureTask
 
 // Settings-scope entry point. Users declare this in
 // `settings.gradle.kts`:
@@ -137,19 +138,17 @@ class WhiskerPlugin : Plugin<Settings> {
             "--workspace=${workspace.absolutePath}",
             "--package=$userPackage",
         ).start()
-        val out = proc.inputStream.bufferedReader().readText()
-        val err = proc.errorStream.bufferedReader().readText()
-        val rc = proc.waitFor()
-        if (rc != 0) {
+        val result = captureProcess(proc)
+        if (result.exitCode != 0) {
             error(
-                "whisker modules failed (exit $rc).\n" +
-                    "stderr:\n$err\n" +
+                "whisker modules failed (exit ${result.exitCode}).\n" +
+                    "stderr:\n${result.stderr}\n" +
                     "Whisker CLI: $whiskerCli\n" +
                     "Hint: install with `cargo install whisker-cli` " +
                     "and make sure it's on the JVM's PATH.",
             )
         }
-        return out
+        return result.stdout
     }
 
     private fun writeConfigForProjectPlugin(
@@ -166,3 +165,34 @@ class WhiskerPlugin : Plugin<Settings> {
         cfg.outputStream().use { props.store(it, "rs.whisker Settings plugin output") }
     }
 }
+
+internal data class ProcessCapture(
+    val exitCode: Int,
+    val stdout: String,
+    val stderr: String,
+)
+
+/** Drains both child pipes concurrently so neither pipe can block process completion. */
+internal fun captureProcess(process: Process): ProcessCapture {
+    val stdout = FutureTask { process.inputStream.bufferedReader().use { it.readText() } }
+    val stderr = FutureTask {
+        process.errorStream.bufferedReader().use { reader ->
+            val tail = StringBuilder()
+            val buffer = CharArray(8 * 1024)
+            while (true) {
+                val count = reader.read(buffer)
+                if (count < 0) break
+                tail.append(buffer, 0, count)
+                val excess = tail.length - MAX_CAPTURED_STDERR_CHARS
+                if (excess > 0) tail.delete(0, excess)
+            }
+            tail.toString()
+        }
+    }
+    Thread(stdout, "whisker-modules-stdout").apply { isDaemon = true }.start()
+    Thread(stderr, "whisker-modules-stderr").apply { isDaemon = true }.start()
+    val exitCode = process.waitFor()
+    return ProcessCapture(exitCode, stdout.get(), stderr.get())
+}
+
+private const val MAX_CAPTURED_STDERR_CHARS = 64 * 1024

--- a/platforms/android/gradle-plugin/whisker-settings-plugin/src/test/kotlin/rs/whisker/gradle/ProcessCaptureTest.kt
+++ b/platforms/android/gradle-plugin/whisker-settings-plugin/src/test/kotlin/rs/whisker/gradle/ProcessCaptureTest.kt
@@ -1,0 +1,26 @@
+package rs.whisker.gradle
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ProcessCaptureTest {
+    @Test
+    fun drainsLargeStderrWithoutBlockingStdout() {
+        val shell = File("/bin/sh")
+        if (!shell.isFile) return
+        val process = ProcessBuilder(
+            shell.absolutePath,
+            "-c",
+            "yes x | head -c 262144 >&2; printf stderr-tail >&2; printf module-report",
+        ).start()
+
+        val result = captureProcess(process)
+
+        assertEquals(0, result.exitCode)
+        assertEquals("module-report", result.stdout)
+        assertTrue(result.stderr.endsWith("stderr-tail"))
+        assertTrue(result.stderr.length <= 64 * 1024)
+    }
+}


### PR DESCRIPTION
## Summary
- drain `whisker modules` stdout and stderr concurrently on dedicated daemon readers
- retain full JSON stdout while bounding diagnostic stderr to its latest 64 KiB
- preserve exit status and actionable failure diagnostics
- add a regression with stderr larger than the OS pipe buffer

This removes the stdout/stderr producer-consumer deadlock without adding any application runtime work. The two short-lived readers exist only during uncached Gradle module discovery.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android/gradle-plugin :whisker-settings-plugin:test --no-daemon`
- `git diff --check`