### PR TITLE
fix(android): normalize generic pointer actions

### DIFF
--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -225,6 +225,25 @@ class HostConformanceTest {
     }
 
     @Test
+    fun genericMouseActionsKeepRustHoverStateSynchronized() {
+        listOf(
+            MotionEvent.ACTION_HOVER_ENTER,
+            MotionEvent.ACTION_HOVER_EXIT,
+            MotionEvent.ACTION_SCROLL,
+        ).forEach { action ->
+            val event = MotionEvent.obtain(0L, 0L, action, 10f, 20f, 0)
+            try {
+                val normalized = normalizePointerInput(event, density = 2f).single()
+                assertEquals(1, normalized.event)
+                assertEquals(5f, normalized.x, 0.001f)
+                assertEquals(10f, normalized.y, 0.001f)
+            } finally {
+                event.recycle()
+            }
+        }
+    }
+
+    @Test
     fun projectsAThreeDimensionalTransformOntoTheNodePlane() {
         androidx.test.platform.app.InstrumentationRegistry
             .getInstrumentation()

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/input/PointerInput.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/input/PointerInput.kt
@@ -19,13 +19,24 @@ internal fun normalizePointerInput(event: MotionEvent, density: Float): List<Hos
     if (!density.isFinite() || density <= 0f) return emptyList()
     val eventKind = when (event.actionMasked) {
         MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN -> POINTER_DOWN
-        MotionEvent.ACTION_MOVE, MotionEvent.ACTION_HOVER_MOVE -> POINTER_MOVE
+        MotionEvent.ACTION_MOVE,
+        MotionEvent.ACTION_HOVER_ENTER,
+        MotionEvent.ACTION_HOVER_MOVE,
+        MotionEvent.ACTION_HOVER_EXIT,
+        MotionEvent.ACTION_SCROLL,
+        -> POINTER_MOVE
         MotionEvent.ACTION_UP, MotionEvent.ACTION_POINTER_UP -> POINTER_UP
         MotionEvent.ACTION_CANCEL -> POINTER_CANCEL
         else -> return emptyList()
     }
     val indices = when (event.actionMasked) {
-        MotionEvent.ACTION_MOVE, MotionEvent.ACTION_HOVER_MOVE, MotionEvent.ACTION_CANCEL ->
+        MotionEvent.ACTION_MOVE,
+        MotionEvent.ACTION_HOVER_ENTER,
+        MotionEvent.ACTION_HOVER_MOVE,
+        MotionEvent.ACTION_HOVER_EXIT,
+        MotionEvent.ACTION_SCROLL,
+        MotionEvent.ACTION_CANCEL,
+        ->
             0 until event.pointerCount
         else -> event.actionIndex..event.actionIndex
     }


### PR DESCRIPTION
## Summary
- normalize hover enter, hover exit, and generic scroll samples as pointer moves
- keep Rust authoritative hover/hit-test state synchronized for mouse and ChromeOS input
- leave wheel delta handling on the native ScrollView path, which emits the existing semantic scroll event
- add coverage for all three formerly dropped MotionEvent classes

## Performance
The existing `when` branches gain constants only. There is no new listener, allocation, or event beyond OS samples that were previously discarded.

## Validation
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:compileDebugKotlin :runtime:compileDebugAndroidTestKotlin --no-daemon`
- `git diff --check`

No emulator was connected, so the instrumentation test was compiled but not executed locally.