### PR TITLE
fix(android): report used text width

### DIFF
--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -167,12 +167,17 @@ internal class HostMeasurementProvider(private val context: Context) {
             builder.setLineSpacing((lineHeight * density - fontHeight).coerceAtLeast(0f), 1f)
         }
         val layout = builder.build()
-        val width = when {
-            knownMask and WIDTH != 0 -> knownWidth
-            availableWidthKind == DEFINITE && wrap != 0 ->
-                (layout.width / density).coerceAtMost(availableWidth)
-            else -> layout.width / density
-        }
+        val usedLineWidthPixels = (0 until layout.lineCount)
+            .maxOfOrNull(layout::getLineWidth) ?: 0f
+        val width = measuredTextWidth(
+            knownWidth = knownWidth,
+            hasKnownWidth = knownMask and WIDTH != 0,
+            availableWidth = availableWidth,
+            hasDefiniteAvailableWidth = availableWidthKind == DEFINITE,
+            wraps = wrap != 0,
+            usedLineWidthPixels = usedLineWidthPixels,
+            density = density,
+        )
         val height = if (knownMask and HEIGHT != 0) knownHeight else layout.height / density
         val first = if (layout.lineCount > 0) layout.getLineBaseline(0) / density else 0f
         val last = if (layout.lineCount > 0) {
@@ -185,6 +190,21 @@ internal class HostMeasurementProvider(private val context: Context) {
 
     private fun ready(width: Float, height: Float): FloatArray =
         floatArrayOf(READY, 0f, width, height, 0f, 0f, 0f)
+}
+
+internal fun measuredTextWidth(
+    knownWidth: Float,
+    hasKnownWidth: Boolean,
+    availableWidth: Float,
+    hasDefiniteAvailableWidth: Boolean,
+    wraps: Boolean,
+    usedLineWidthPixels: Float,
+    density: Float,
+): Float = when {
+    hasKnownWidth -> knownWidth
+    hasDefiniteAvailableWidth && wraps ->
+        (ceil(usedLineWidthPixels.toDouble()).toFloat() / density).coerceAtMost(availableWidth)
+    else -> ceil(usedLineWidthPixels.toDouble()).toFloat() / density
 }
 
 internal data class TextLayoutSemantics(

--- a/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/measure/TextMeasurementWidthTest.kt
+++ b/platforms/android/runtime/src/test/kotlin/rs/whisker/runtime/measure/TextMeasurementWidthTest.kt
@@ -1,0 +1,22 @@
+package rs.whisker.runtime.measure
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TextMeasurementWidthTest {
+    @Test
+    fun wrappedTextReportsUsedLineWidthInsteadOfConstraintWidth() {
+        assertEquals(
+            42f,
+            measuredTextWidth(
+                knownWidth = 0f,
+                hasKnownWidth = false,
+                availableWidth = 300f,
+                hasDefiniteAvailableWidth = true,
+                wraps = true,
+                usedLineWidthPixels = 83.2f,
+                density = 2f,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- derive measured text width from the widest laid-out line instead of `StaticLayout`'s constraint width
- preserve explicit known-width precedence and the wrapping constraint cap
- round only to physical pixels before converting back to logical pixels
- add a JVM regression test for a short line under a wide constraint

## Performance
The measurement path performs one allocation-free linear scan over the already-created `StaticLayout` lines. This is negligible relative to shaping/layout and does not add work to frame presentation or input paths.

## Validation
- `:runtime:testDebugUnitTest`
- `git diff --check`

Android lint was also run; it reaches pre-existing unrelated errors in `HostNode.kt` and existing constants in `TextMeasurement.kt`.