### PR TITLE
fix(host): honor min-content text measurement

### DIFF
--- a/crates/whisker-host-conformance/src/lib.rs
+++ b/crates/whisker-host-conformance/src/lib.rs
@@ -264,6 +264,9 @@ pub enum Command {
         indent: TextIndentFixture,
         /// Definite available width.
         available_width: f32,
+        /// Available-space mode forwarded to the Host measurer.
+        #[serde(default)]
+        available_width_kind: AvailableWidthFixture,
     },
     /// Checks one previously produced text measurement.
     CheckpointMeasurement {
@@ -814,6 +817,19 @@ pub enum WhiteSpaceFixture {
     Normal,
     /// Collapse whitespace and suppress wrapping.
     NoWrap,
+}
+
+/// Width availability supplied to intrinsic text measurement.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AvailableWidthFixture {
+    /// A finite constraint using `available_width`.
+    #[default]
+    Definite,
+    /// The smallest width allowed by text wrapping opportunities.
+    MinContent,
+    /// The unwrapped intrinsic width.
+    MaxContent,
 }
 
 /// Lynx-supported `word-break` values.

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -878,7 +878,14 @@ private class Driver(
         val requestInts = IntArray(HostMeasureBatchAbi.REQUEST_INT_STRIDE).apply {
             this[HostMeasureBatchAbi.ELEMENT_TYPE] = 2
             this[HostMeasureBatchAbi.KIND] = 1
-            this[HostMeasureBatchAbi.AVAILABLE_WIDTH_KIND] = 0
+            this[HostMeasureBatchAbi.AVAILABLE_WIDTH_KIND] = when (
+                command.optString("available_width_kind", "definite")
+            ) {
+                "definite" -> 0
+                "min_content" -> 1
+                "max_content" -> 2
+                else -> error("unsupported available_width_kind: $command")
+            }
             this[HostMeasureBatchAbi.AVAILABLE_HEIGHT_KIND] = 2
             this[HostMeasureBatchAbi.FONT_WEIGHT] = command.optInt("font_weight", 400)
             this[HostMeasureBatchAbi.FONT_STYLE] = when (command.optString("font_style", "normal")) {

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -143,10 +143,11 @@ internal class HostMeasurementProvider(private val context: Context) {
                 )
             }
         }
-        val maxWidthPx = if (availableWidthKind == DEFINITE && wrap != 0) {
-            ceil(availableWidth * density).toInt().coerceAtLeast(1)
-        } else {
-            ceil(paint.measureText(text) + semantics.indentPixels).toInt().coerceAtLeast(1)
+        val maxWidthPx = when {
+            availableWidthKind == DEFINITE && wrap != 0 ->
+                ceil(availableWidth * density).toInt().coerceAtLeast(1)
+            availableWidthKind == MIN_CONTENT && wrap != 0 -> 1
+            else -> ceil(paint.measureText(text) + semantics.indentPixels).toInt().coerceAtLeast(1)
         }
         val builder = StaticLayout.Builder.obtain(
             layoutText, 0, layoutText.length, paint, maxWidthPx,
@@ -282,6 +283,7 @@ private fun Char.isCjk(): Boolean = code in 0x2E80..0x9FFF || code in 0xF900..0x
     code in 0xAC00..0xD7AF
 
 private const val DEFINITE = 0
+private const val MIN_CONTENT = 1
 private const val WIDTH = 1
 private const val HEIGHT = 2
 private const val BOTH_DIMENSIONS = WIDTH or HEIGHT

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -168,6 +168,7 @@ impl NativeTextHost {
         };
         let available_width = match request.constraints.available_space[0] {
             AvailableSpace::Definite(value) => Some(value.max(0.0)),
+            AvailableSpace::MinContent if payload.wrap == MeasureTextWrap::Wrap => Some(0.0),
             AvailableSpace::MinContent | AvailableSpace::MaxContent => None,
         };
         let width = request.constraints.known_dimensions[0].or(available_width);

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1469,6 +1469,7 @@ impl Driver {
             alignment,
             indent,
             available_width,
+            available_width_kind,
         } = command
         else {
             unreachable!("measure_text is only called for MeasureText commands")
@@ -1482,7 +1483,17 @@ impl Driver {
             constraints: MeasureConstraints {
                 known_dimensions: [None, None],
                 available_space: [
-                    AvailableSpace::Definite(*available_width),
+                    match available_width_kind {
+                        whisker_host_conformance::AvailableWidthFixture::Definite => {
+                            AvailableSpace::Definite(*available_width)
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MinContent => {
+                            AvailableSpace::MinContent
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MaxContent => {
+                            AvailableSpace::MaxContent
+                        }
+                    },
                     AvailableSpace::MaxContent,
                 ],
             },

--- a/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
@@ -86,8 +86,16 @@ private func measureText(
         .kern: CGFloat(request.letter_spacing),
         .paragraphStyle: paragraph,
     ]
-    let width = request.available_width_kind == 0 && request.wrap != 0
-        ? CGFloat(request.available_width) : CGFloat.greatestFiniteMagnitude
+    let width: CGFloat
+    if request.wrap == 0 {
+        width = .greatestFiniteMagnitude
+    } else {
+        width = switch request.available_width_kind {
+        case 0: CGFloat(request.available_width)
+        case 1: 1
+        default: .greatestFiniteMagnitude
+        }
+    }
     let source = hostString(request.text)
     let measuredText = request.word_break == 2 ? protectCJKBreaks(source) : source
     var measured = (measuredText as NSString).boundingRect(

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -1144,7 +1144,12 @@ private final class Driver {
         request.kind = UInt32(WHISKER_MEASURE_TEXT)
         request.environment_epoch = 1
         request.available_width = Float(try number(command, "available_width"))
-        request.available_width_kind = 0
+        request.available_width_kind = switch command["available_width_kind"] as? String ?? "definite" {
+        case "definite": 0
+        case "min_content": 1
+        case "max_content": 2
+        default: throw Failure("unsupported available_width_kind")
+        }
         request.available_height_kind = 2
         request.font_style = fontStyle
         request.wrap = wrap

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -1058,6 +1058,7 @@ impl Driver {
                     alignment,
                     indent,
                     available_width,
+                    available_width_kind,
                 } => self.measure_text(
                     *key,
                     text,
@@ -1078,6 +1079,7 @@ impl Driver {
                     *alignment,
                     *indent,
                     *available_width,
+                    *available_width_kind,
                 ),
                 Command::CheckpointMeasurement {
                     key,
@@ -1193,6 +1195,7 @@ impl Driver {
         alignment: whisker_host_conformance::TextAlignmentFixture,
         indent: whisker_host_conformance::TextIndentFixture,
         available_width: f32,
+        available_width_kind: whisker_host_conformance::AvailableWidthFixture,
     ) {
         let key_id = MeasurementKey::new(key).expect("fixture measurement key is non-zero");
         let element_type = ElementRegistry::standard()
@@ -1207,7 +1210,17 @@ impl Driver {
             constraints: MeasureConstraints {
                 known_dimensions: [None, None],
                 available_space: [
-                    AvailableSpace::Definite(available_width),
+                    match available_width_kind {
+                        whisker_host_conformance::AvailableWidthFixture::Definite => {
+                            AvailableSpace::Definite(available_width)
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MinContent => {
+                            AvailableSpace::MinContent
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MaxContent => {
+                            AvailableSpace::MaxContent
+                        }
+                    },
                     AvailableSpace::MaxContent,
                 ],
             },

--- a/tests/host-conformance/core/text-measure-min-content.json
+++ b/tests/host-conformance/core/text-measure-min-content.json
@@ -1,0 +1,26 @@
+{
+  "schema": 1,
+  "id": "host.measure.text.min-content",
+  "test": {
+    "commands": [
+      { "type": "attach_surface", "width": 320.0, "height": 600.0, "scale": 1.0 },
+      {
+        "type": "measure_text",
+        "key": 30,
+        "text": "a a a a a a a a a a a a a a a a a a a a",
+        "font_size": 20.0,
+        "line_height": 28.0,
+        "available_width": 0.0,
+        "available_width_kind": "min_content"
+      },
+      {
+        "type": "checkpoint_measurement",
+        "key": 30,
+        "min_width": 0.1,
+        "max_width": 40.0,
+        "min_height": 28.0,
+        "max_height": 1200.0
+      }
+    ]
+  }
+}

--- a/tests/host-conformance/manifest.json
+++ b/tests/host-conformance/manifest.json
@@ -675,6 +675,13 @@
       "checkpoints": ["measurement", "semantic-projection"]
     },
     {
+      "id": "host.measure.text.min-content",
+      "feature": "text-measurement-min-content",
+      "fixture": "core/text-measure-min-content.json",
+      "required_hosts": ["desktop", "web", "android", "ios"],
+      "checkpoints": ["measurement"]
+    },
+    {
       "id": "core.pointer-style-lynx",
       "feature": "cursor-pointer-events",
       "fixture": "core/pointer-style-lynx.json",


### PR DESCRIPTION
## Summary
- extend the shared Host conformance command with explicit definite/min-content/max-content width availability
- add one four-Host min-content text fixture
- measure wrapped min-content text at its narrowest native layout width on Desktop, Android, and iOS
- preserve no-wrap as max-content and leave Web on native CSS `min-content`

## Performance
- no new allocation or cache on normal definite/max-content paths
- min-content reuses each Host's existing native text shaper and remains covered by Rust measurement caching

## Validation
- `cargo test -p whisker-host-conformance`
- Desktop shared Host conformance fixture
- `cargo check -p whisker-web --target wasm32-unknown-unknown --tests`
- Android runtime + Android test Kotlin compilation
- `cargo xtask host-conformance ios` (23 tests)
- `git diff --check`