### PR TITLE
fix(android): center text line height

### DIFF
--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
@@ -44,10 +44,7 @@ public object WhiskerBuiltInElements {
                 } else {
                     0f
                 }
-                content.lineHeight?.let { lineHeight ->
-                    val fontHeight = view.paint.fontMetrics.run { descent - ascent }
-                    view.setLineSpacing((lineHeight * density - fontHeight).coerceAtLeast(0f), 1f)
-                } ?: view.setLineSpacing(0f, 1f)
+                view.setLineSpacing(0f, 1f)
                 view.setWhiskerText(content)
                 view.textDirection = when (content.direction) {
                     WhiskerTextDirection.AUTO -> View.TEXT_DIRECTION_FIRST_STRONG

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
@@ -13,6 +13,7 @@ import android.os.Build
 import android.text.style.LeadingMarginSpan
 import android.widget.TextView
 import kotlin.math.max
+import rs.whisker.runtime.internal.CenteredLineHeightSpan
 
 /** Native text element implementing Whisker's single-line decorations. */
 public class WhiskerTextView(context: Context) : TextView(context) {
@@ -107,6 +108,14 @@ public class WhiskerTextView(context: Context) : TextView(context) {
                 length,
                 Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
             )
+            whiskerLineHeight?.let { lineHeight ->
+                setSpan(
+                    CenteredLineHeightSpan(lineHeight * density),
+                    0,
+                    length,
+                    Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
+                )
+            }
         }
     }
 

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/internal/CenteredLineHeightSpan.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/internal/CenteredLineHeightSpan.kt
@@ -1,0 +1,27 @@
+package rs.whisker.runtime.internal
+
+import android.graphics.Paint
+import android.text.style.LineHeightSpan
+import kotlin.math.roundToInt
+
+/** Internal text metric span matching CSS half-leading line boxes. */
+public class CenteredLineHeightSpan(lineHeightPixels: Float) : LineHeightSpan {
+    private val targetHeight: Int = lineHeightPixels.roundToInt().coerceAtLeast(1)
+
+    override fun chooseHeight(
+        text: CharSequence?,
+        start: Int,
+        end: Int,
+        spanstartv: Int,
+        v: Int,
+        fm: Paint.FontMetricsInt,
+    ) {
+        val ascent = centeredLineAscent(fm.ascent, fm.descent, targetHeight)
+        val descent = centeredLineDescent(fm.ascent, fm.descent, targetHeight)
+        fm.ascent = ascent
+        fm.top = ascent
+        fm.descent = descent
+        fm.bottom = descent
+        fm.leading = 0
+    }
+}

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/internal/LineHeightMetrics.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/internal/LineHeightMetrics.kt
@@ -1,0 +1,11 @@
+package rs.whisker.runtime.internal
+
+public fun centeredLineAscent(ascent: Int, descent: Int, targetHeight: Int): Int {
+    val adjustment = targetHeight - (descent - ascent)
+    return ascent - adjustment / 2
+}
+
+public fun centeredLineDescent(ascent: Int, descent: Int, targetHeight: Int): Int {
+    val adjustment = targetHeight - (descent - ascent)
+    return descent + adjustment - adjustment / 2
+}

--- a/platforms/android/module/src/test/kotlin/rs/whisker/runtime/internal/LineHeightMetricsTest.kt
+++ b/platforms/android/module/src/test/kotlin/rs/whisker/runtime/internal/LineHeightMetricsTest.kt
@@ -1,0 +1,18 @@
+package rs.whisker.runtime.internal
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LineHeightMetricsTest {
+    @Test
+    fun distributesPositiveLeadingAroundTheGlyphBox() {
+        assertEquals(-21, centeredLineAscent(ascent = -15, descent = 5, targetHeight = 32))
+        assertEquals(11, centeredLineDescent(ascent = -15, descent = 5, targetHeight = 32))
+    }
+
+    @Test
+    fun contractsBothSidesForAFontHeightLargerThanLineHeight() {
+        assertEquals(-11, centeredLineAscent(ascent = -15, descent = 5, targetHeight = 12))
+        assertEquals(1, centeredLineDescent(ascent = -15, descent = 5, targetHeight = 12))
+    }
+}

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/CenteredLineHeightSpanTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/CenteredLineHeightSpanTest.kt
@@ -1,0 +1,41 @@
+package rs.whisker.runtime
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.StaticLayout
+import android.text.TextPaint
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import rs.whisker.runtime.internal.CenteredLineHeightSpan
+import rs.whisker.runtime.internal.centeredLineAscent
+
+@RunWith(AndroidJUnit4::class)
+class CenteredLineHeightSpanTest {
+    @Test
+    fun staticLayoutUsesTheCenteredBaselineAndRequestedLineHeight() {
+        val paint = TextPaint().apply { textSize = 32f }
+        val targetHeight = 64
+        val value = SpannableString("Whisker").apply {
+            setSpan(
+                CenteredLineHeightSpan(targetHeight.toFloat()),
+                0,
+                length,
+                Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
+            )
+        }
+        val natural = paint.fontMetricsInt
+        val expectedBaseline = -centeredLineAscent(
+            natural.ascent,
+            natural.descent,
+            targetHeight,
+        )
+        val layout = StaticLayout.Builder.obtain(value, 0, value.length, paint, 1024)
+            .setIncludePad(false)
+            .build()
+
+        assertEquals(targetHeight, layout.height)
+        assertEquals(expectedBaseline, layout.getLineBaseline(0))
+    }
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -21,6 +21,7 @@ import rs.whisker.runtime.WhiskerElementRegistry
 import rs.whisker.runtime.WhiskerMeasureRequest
 import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.resolveWhiskerTypeface
+import rs.whisker.runtime.internal.CenteredLineHeightSpan
 
 /** Intrinsic measurement implementation shared by all Android Host frames. */
 internal class HostMeasurementProvider(private val context: Context) {
@@ -131,16 +132,28 @@ internal class HostMeasurementProvider(private val context: Context) {
             indentLogicalPixels,
             indentPercentage,
         )
-        val layoutText: CharSequence = if (displayText.isEmpty() || semantics.indentPixels == 0f) {
+        val layoutText: CharSequence = if (
+            displayText.isEmpty() || (semantics.indentPixels == 0f && lineHeight <= 0f)
+        ) {
             displayText
         } else {
             SpannableString(displayText).apply {
-                setSpan(
-                    LeadingMarginSpan.Standard(semantics.indentPixels.toInt(), 0),
-                    0,
-                    length,
-                    Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
-                )
+                if (semantics.indentPixels != 0f) {
+                    setSpan(
+                        LeadingMarginSpan.Standard(semantics.indentPixels.toInt(), 0),
+                        0,
+                        length,
+                        Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
+                    )
+                }
+                if (lineHeight > 0f) {
+                    setSpan(
+                        CenteredLineHeightSpan(lineHeight * density),
+                        0,
+                        length,
+                        Spanned.SPAN_INCLUSIVE_EXCLUSIVE,
+                    )
+                }
             }
         }
         val maxWidthPx = if (availableWidthKind == DEFINITE && wrap != 0) {
@@ -161,10 +174,6 @@ internal class HostMeasurementProvider(private val context: Context) {
             )
         if (overflow == TEXT_OVERFLOW_ELLIPSIS) {
             builder.setEllipsize(TextUtils.TruncateAt.END).setEllipsizedWidth(maxWidthPx)
-        }
-        if (lineHeight > 0f) {
-            val fontHeight = paint.fontMetrics.run { descent - ascent }
-            builder.setLineSpacing((lineHeight * density - fontHeight).coerceAtLeast(0f), 1f)
         }
         val layout = builder.build()
         val width = when {


### PR DESCRIPTION
## Summary
- replace additive bottom-only line spacing with a centered `LineHeightSpan`
- use the same metric adjustment for intrinsic measurement and native Text rendering
- support line heights smaller than the font metric box instead of silently clamping them
- reset legacy TextView line spacing so reused views cannot retain stale state

## Performance
- allocates one span only when text content with an explicit line height is updated
- `chooseHeight` performs integer arithmetic only and allocates nothing per line/frame

## Validation
- unit tests first reproduced both asymmetric expansion and ignored contraction
- Android JVM tests for module and runtime
- Android instrumentation test verifies actual `StaticLayout` height and baseline
- Android runtime + instrumentation Kotlin compilation
- `git diff --check`