### PR TITLE
fix(ios): track one-axis clips through scrolling

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -15,6 +15,8 @@ final class WhiskerNodeView: UIView {
     private lazy var paintView = HostNodePaintView(painter: boxPainter)
     private let overflowMask = CAShapeLayer()
     private var overflowMaskScrollOrigin = CGPoint.zero
+    private var overflowMaskCompositionBounds = CGRect.zero
+    private var ancestorScrollObservations: [NSKeyValueObservation] = []
     private let clipPathMask = CAShapeLayer()
     private var clipPath: HostClipPath?
     private var boxShadows: [HostBoxShadow] = []
@@ -104,6 +106,13 @@ final class WhiskerNodeView: UIView {
 
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
+        updateAncestorScrollObservations()
+        updateOverflowMask()
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateAncestorScrollObservations()
         updateOverflowMask()
     }
 
@@ -162,6 +171,7 @@ final class WhiskerNodeView: UIView {
         clipsOverflowHorizontally = horizontal
         clipsOverflowVertically = vertical
         clipsToBounds = false
+        updateAncestorScrollObservations()
         updateOverflowMask()
     }
 
@@ -423,6 +433,7 @@ final class WhiskerNodeView: UIView {
         overflowMask.fillColor = UIColor.white.cgColor
         host.layer.mask = overflowMask
         overflowMaskScrollOrigin = (host as? UIScrollView)?.bounds.origin ?? .zero
+        overflowMaskCompositionBounds = compositionBounds
     }
 
     /// `UIScrollView` scrolls by changing `bounds.origin`. A layer mask uses
@@ -434,6 +445,36 @@ final class WhiskerNodeView: UIView {
         guard scrollView.layer.mask === overflowMask else { return }
         overflowMask.frame.origin.x += next.x - overflowMaskScrollOrigin.x
         overflowMask.frame.origin.y += next.y - overflowMaskScrollOrigin.y
+    }
+
+    private func updateAncestorScrollObservations() {
+        ancestorScrollObservations.removeAll()
+        guard clipsOverflowHorizontally != clipsOverflowVertically else { return }
+        var ancestor = superview
+        while let current = ancestor {
+            if let scrollView = current as? UIScrollView {
+                ancestorScrollObservations.append(scrollView.observe(
+                    \.contentOffset,
+                    options: [.new]
+                ) { [weak self] _, _ in
+                    self?.updateOverflowMaskForAncestorScroll()
+                })
+            }
+            ancestor = current.superview
+        }
+    }
+
+    private func updateOverflowMaskForAncestorScroll() {
+        let next = hostCompositionBounds()
+        var frame = overflowMask.frame
+        if !clipsOverflowHorizontally {
+            frame.origin.x += next.minX - overflowMaskCompositionBounds.minX
+        }
+        if !clipsOverflowVertically {
+            frame.origin.y += next.minY - overflowMaskCompositionBounds.minY
+        }
+        overflowMask.frame = frame
+        overflowMaskCompositionBounds = next
     }
 
     /// Returns the stationary view that owns the element's clipping viewport.

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -385,6 +385,24 @@ final class HostConformanceTests: XCTestCase {
         XCTAssertEqual(scrollView.layer.mask?.frame.minY, scrollView.bounds.minY)
     }
 
+    func testOneAxisOverflowClipTracksAncestorScrollOffset() throws {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        let scrollView = UIScrollView(frame: root.bounds)
+        scrollView.contentSize = CGSize(width: 100, height: 400)
+        root.addSubview(scrollView)
+
+        let node = WhiskerNodeView(element: WhiskerBuiltInElements.viewName)
+        scrollView.addSubview(node)
+        node.setLayoutFrame(CGRect(x: 0, y: 150, width: 80, height: 40))
+        node.setOverflowClip(horizontal: true, vertical: false)
+        let mask = try XCTUnwrap(node.sceneChildrenHost().layer.mask)
+        let initialY = mask.frame.minY
+
+        scrollView.contentOffset = CGPoint(x: 0, y: 60)
+
+        XCTAssertEqual(mask.frame.minY, initialY + 60, accuracy: 0.001)
+    }
+
     func testUIKitTouchTypesMapToProtocolPointerKinds() {
         XCTAssertEqual(hostPointerKind(for: .direct), .touch)
         XCTAssertEqual(hostPointerKind(for: .pencil), .pen)


### PR DESCRIPTION
## Summary
- observe ancestor scroll offsets only for nodes with exactly one clipped overflow axis
- translate the existing mask frame on the visible axis as ancestors scroll
- avoid rebuilding rounded clip paths and avoid any Rust/FFI scroll synchronization
- refresh observations when hierarchy/window attachment or clip policy changes

## Performance
Normal nodes, two-axis clips, and unclipped nodes install no observers. Scroll callbacks perform only coordinate conversion and a `CGRect` translation; they allocate no paths and do not scan the scene.

## Validation
- regression test first reproduced the stale mask coordinate
- `cargo xtask host-conformance ios` (24 tests)
- `git diff --check`