### PR TITLE
fix(web): recover partial DOM frames with snapshots

### DIFF
--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -138,7 +138,7 @@ impl DomFrameSink {
         self.resources.register_url(resource, url)
     }
 
-    fn apply(&mut self, packet: &FramePacket) -> Result<(), WebError> {
+    fn validate_frame(&self, packet: &FramePacket) -> Result<(), WebError> {
         if let Some(feature) = packet
             .operations
             .iter()
@@ -193,25 +193,33 @@ impl DomFrameSink {
                 resource.get()
             )));
         }
+        Ok(())
+    }
+
+    fn apply(&mut self, packet: &FramePacket) -> Result<(), WebError> {
         if packet.header.mode == FrameMode::Snapshot {
-            self.release_all_pointer_captures();
-            self.root.set_inner_html("");
-            self.nodes.clear();
-            self.node_types.clear();
-            self.parents.clear();
-            self.layouts.clear();
-            self.box_paints.clear();
-            self.text_nodes.clear();
-            self.native_nodes.clear();
-            self.event_masks.clear();
-            self.scroll_listeners.clear();
-            self.pointer_captures.clear();
-            self.pending_events.borrow_mut().clear();
+            self.reset_presentation();
         }
         for operation in &packet.operations {
             self.apply_operation(operation)?;
         }
         Ok(())
+    }
+
+    fn reset_presentation(&mut self) {
+        self.release_all_pointer_captures();
+        self.root.set_inner_html("");
+        self.nodes.clear();
+        self.node_types.clear();
+        self.parents.clear();
+        self.layouts.clear();
+        self.box_paints.clear();
+        self.text_nodes.clear();
+        self.native_nodes.clear();
+        self.event_masks.clear();
+        self.scroll_listeners.clear();
+        self.pointer_captures.clear();
+        self.pending_events.borrow_mut().clear();
     }
 
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), WebError> {
@@ -837,12 +845,30 @@ impl FrameSink for DomFrameSink {
                 capability.as_str()
             )));
         }
+        self.validate_frame(packet)?;
         let mut next = self.projection.clone();
         let result = next
             .apply(packet)
             .map_err(|error| WebError(error.to_string()))?;
         if matches!(result, ApplyResult::Accepted { .. }) {
-            self.apply(packet)?;
+            if let Err(error) = self.apply(packet) {
+                // A DOM exception can happen after earlier operations in this
+                // transaction have already mutated the live tree. There is no
+                // portable rollback for DOM or custom-element callbacks, so
+                // drop the partial presentation and ask the sender for a full
+                // snapshot. This path is cold: successful frames pay only the
+                // existing result branch.
+                web_sys::console::error_1(
+                    &format!(
+                        "DOM Host discarded a partially applied frame and requested a snapshot: {error}"
+                    )
+                    .into(),
+                );
+                self.reset_presentation();
+                return Ok(ApplyResult::NeedSnapshot {
+                    receiver_revision: self.projection.revision(),
+                });
+            }
             self.projection = next;
         }
         Ok(result)

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -24,18 +24,19 @@ use whisker_host_conformance::{
     SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
-    Accessibility, AccessibilityChecked, AccessibilityRole, AccessibilityState, AvailableSpace,
-    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
-    BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
-    LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily, MeasureFontStyle,
-    MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak,
-    MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    PathCommand, PointerKind, ProtocolVersion, RadialGradientExtent, RadialGradientShape,
-    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest,
-    ResourceSource, SurfaceId, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint,
-    TextShadow, Transform, Visibility, WhiskerValue,
+    Accessibility, AccessibilityChecked, AccessibilityRole, AccessibilityState, ApplyResult,
+    AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
+    BorderLineStyle, BoxClip, BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket,
+    GradientStop, ImageRepeat, LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily,
+    MeasureFontStyle, MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow,
+    MeasureTextWordBreak, MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
+    PaintLengthPercentage, PaintPosition, PathCommand, PointerKind, ProtocolVersion,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent,
+    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent,
+    TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
+    WhiskerValue,
 };
 use whisker_style::StyleEnvironment;
 
@@ -64,6 +65,52 @@ fn browser_pointer_metadata_maps_to_protocol_values() {
     assert_ne!(stable_pointer_id(-1), 0);
     assert_ne!(stable_pointer_id(0), stable_pointer_id(-1));
     assert_eq!(stable_pointer_id(-1), stable_pointer_id(-1));
+}
+
+#[wasm_bindgen_test]
+fn dom_failure_discards_partial_transaction_and_recovers_from_snapshot() {
+    let mut driver = Driver::new();
+    let mut failed = packet(
+        1,
+        [0.0, 0.0, 40.0, 40.0],
+        &ColorFixture::Srgba {
+            red: 255,
+            green: 0,
+            blue: 0,
+            alpha: 1.0,
+        },
+        None,
+    );
+    failed.operations.push(Operation::SetPointerCapture {
+        node: NodeId::new(1).unwrap(),
+        pointer: whisker_protocol::PointerId::new(u64::MAX - 2_000_000_000).unwrap(),
+    });
+
+    assert_eq!(
+        driver.sink.present(&failed).unwrap(),
+        ApplyResult::NeedSnapshot {
+            receiver_revision: 0,
+        }
+    );
+    assert_eq!(driver.root.children().length(), 0);
+
+    let recovery = packet(
+        1,
+        [0.0, 0.0, 40.0, 40.0],
+        &ColorFixture::Srgba {
+            red: 255,
+            green: 0,
+            blue: 0,
+            alpha: 1.0,
+        },
+        None,
+    );
+    assert_eq!(
+        driver.sink.present(&recovery).unwrap(),
+        ApplyResult::Accepted { revision: 1 }
+    );
+    assert_eq!(driver.root.children().length(), 1);
+    driver.root.remove();
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- separate mutation-free Web frame preflight from live DOM application
- discard a partially applied DOM transaction and return `NeedSnapshot` after a DOM exception
- verify a failed pointer-capture operation leaves no duplicate node and recovers from the next snapshot

## Performance
- successful frames add one predictable result branch only
- full DOM clearing runs only on the existing snapshot path or the exceptional recovery path

## Validation
- `cargo xtask host-conformance web`
- `cargo clippy -p whisker-web --all-targets --target wasm32-unknown-unknown -- -D warnings`
- `cargo check -p whisker-web --tests --target wasm32-unknown-unknown`