### PR TITLE
fix(web): honor advertised text and cursor effects

### DIFF
--- a/platforms/web/src/paint/background_layers.rs
+++ b/platforms/web/src/paint/background_layers.rs
@@ -146,7 +146,7 @@ fn background_image(
     }
 }
 
-fn escape_css_url(url: &str) -> String {
+pub(super) fn escape_css_url(url: &str) -> String {
     url.replace('\\', "\\\\")
         .replace('"', "\\\"")
         .replace('\n', "\\a ")

--- a/platforms/web/src/paint/cursor.rs
+++ b/platforms/web/src/paint/cursor.rs
@@ -1,0 +1,116 @@
+use std::fmt::Write as _;
+
+use whisker_protocol::{Cursor, CursorKeyword, ResourceId};
+
+use super::background_layers::escape_css_url;
+use crate::{WebError, set_style};
+
+pub(crate) fn apply(
+    element: &web_sys::Element,
+    cursor: &Cursor,
+    resolve_resource: impl Fn(ResourceId) -> Option<String>,
+) -> Result<(), WebError> {
+    set_style(element, "cursor", &css(cursor, resolve_resource)?)
+}
+
+fn css(
+    cursor: &Cursor,
+    resolve_resource: impl Fn(ResourceId) -> Option<String>,
+) -> Result<String, WebError> {
+    let mut value = String::new();
+    for candidate in &cursor.resources {
+        let url = resolve_resource(candidate.resource).ok_or_else(|| {
+            WebError(format!(
+                "DOM Host cursor resource {} is not registered",
+                candidate.resource.get()
+            ))
+        })?;
+        if !value.is_empty() {
+            value.push_str(", ");
+        }
+        write!(value, "url(\"{}\")", escape_css_url(&url)).expect("writing to String cannot fail");
+        if let Some((x, y)) = candidate.hotspot {
+            write!(value, " {x} {y}").expect("writing to String cannot fail");
+        }
+    }
+    if !value.is_empty() {
+        value.push_str(", ");
+    }
+    value.push_str(keyword(cursor.fallback));
+    Ok(value)
+}
+
+pub(crate) const fn keyword(value: CursorKeyword) -> &'static str {
+    match value {
+        CursorKeyword::Auto => "auto",
+        CursorKeyword::Default => "default",
+        CursorKeyword::None => "none",
+        CursorKeyword::ContextMenu => "context-menu",
+        CursorKeyword::Help => "help",
+        CursorKeyword::Pointer => "pointer",
+        CursorKeyword::Progress => "progress",
+        CursorKeyword::Wait => "wait",
+        CursorKeyword::Cell => "cell",
+        CursorKeyword::Crosshair => "crosshair",
+        CursorKeyword::Text => "text",
+        CursorKeyword::VerticalText => "vertical-text",
+        CursorKeyword::Alias => "alias",
+        CursorKeyword::Copy => "copy",
+        CursorKeyword::Move => "move",
+        CursorKeyword::NoDrop => "no-drop",
+        CursorKeyword::NotAllowed => "not-allowed",
+        CursorKeyword::Grab => "grab",
+        CursorKeyword::Grabbing => "grabbing",
+        CursorKeyword::ColResize => "col-resize",
+        CursorKeyword::RowResize => "row-resize",
+        CursorKeyword::NResize => "n-resize",
+        CursorKeyword::EResize => "e-resize",
+        CursorKeyword::SResize => "s-resize",
+        CursorKeyword::WResize => "w-resize",
+        CursorKeyword::NeResize => "ne-resize",
+        CursorKeyword::NwResize => "nw-resize",
+        CursorKeyword::SeResize => "se-resize",
+        CursorKeyword::SwResize => "sw-resize",
+        CursorKeyword::EwResize => "ew-resize",
+        CursorKeyword::NsResize => "ns-resize",
+        CursorKeyword::NeswResize => "nesw-resize",
+        CursorKeyword::NwseResize => "nwse-resize",
+        CursorKeyword::ZoomIn => "zoom-in",
+        CursorKeyword::ZoomOut => "zoom-out",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+    use whisker_protocol::{CursorResource, ResourceId};
+
+    use super::*;
+
+    #[wasm_bindgen_test]
+    fn resource_candidates_include_hotspots_and_keyword_fallback() {
+        let first = ResourceId::new(1).unwrap();
+        let second = ResourceId::new(2).unwrap();
+        let cursor = Cursor {
+            resources: vec![
+                CursorResource {
+                    resource: first,
+                    hotspot: Some((4, 8)),
+                },
+                CursorResource {
+                    resource: second,
+                    hotspot: None,
+                },
+            ],
+            fallback: CursorKeyword::Pointer,
+        };
+        assert_eq!(
+            css(&cursor, |resource| Some(format!(
+                "cursor/{}.png",
+                resource.get()
+            )))
+            .unwrap(),
+            "url(\"cursor/1.png\") 4 8, url(\"cursor/2.png\"), pointer"
+        );
+    }
+}

--- a/platforms/web/src/paint/mod.rs
+++ b/platforms/web/src/paint/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod box_paint;
 pub(crate) mod clip;
 pub(crate) mod color;
 pub(crate) mod compositing;
+pub(crate) mod cursor;
 pub(crate) mod text;
 pub(crate) mod transform;
 pub(crate) mod visual_effects;

--- a/platforms/web/src/paint/text.rs
+++ b/platforms/web/src/paint/text.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use whisker_protocol::{
     FontOpticalSizing, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
     MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak, MeasureTextWrap, TextContent,
@@ -11,14 +13,11 @@ pub(crate) fn apply(element: &web_sys::Element, content: &TextContent) -> Result
     apply_metrics_style(element, &content.payload)?;
     set_style(element, "color", &css_color(&content.paint.foreground))?;
     let decoration = &content.paint.decoration;
-    let line = if decoration.lines.underline {
-        "underline"
-    } else if decoration.lines.line_through {
-        "line-through"
-    } else {
-        "none"
-    };
-    set_style(element, "text-decoration-line", line)?;
+    set_style(
+        element,
+        "text-decoration-line",
+        &decoration_lines(decoration.lines),
+    )?;
     set_style(
         element,
         "text-decoration-style",
@@ -37,22 +36,62 @@ pub(crate) fn apply(element: &web_sys::Element, content: &TextContent) -> Result
     )?;
     set_style(
         element,
+        "text-decoration-thickness",
+        &match decoration.thickness {
+            whisker_protocol::TextDecorationThickness::Auto => "auto".to_owned(),
+            whisker_protocol::TextDecorationThickness::FromFont => "from-font".to_owned(),
+            whisker_protocol::TextDecorationThickness::Length(value) => px(value),
+        },
+    )?;
+    set_style(
+        element,
         "text-shadow",
-        &content.paint.shadows.first().map_or_else(
-            || "none".to_string(),
-            |shadow| {
-                format!(
-                    "{} {} {} {}",
-                    px(shadow.offset_x),
-                    px(shadow.offset_y),
-                    px(shadow.blur_radius),
-                    css_color(&shadow.color),
-                )
-            },
-        ),
+        &text_shadows(&content.paint.shadows),
     )?;
     element.set_text_content(Some(&content.payload.text));
     Ok(())
+}
+
+fn decoration_lines(lines: whisker_protocol::TextDecorationLines) -> String {
+    let mut value = String::new();
+    for (enabled, keyword) in [
+        (lines.underline, "underline"),
+        (lines.overline, "overline"),
+        (lines.line_through, "line-through"),
+    ] {
+        if enabled {
+            if !value.is_empty() {
+                value.push(' ');
+            }
+            value.push_str(keyword);
+        }
+    }
+    if value.is_empty() {
+        value.push_str("none");
+    }
+    value
+}
+
+fn text_shadows(shadows: &[whisker_protocol::TextShadow]) -> String {
+    if shadows.is_empty() {
+        return "none".to_owned();
+    }
+    let mut value = String::new();
+    for shadow in shadows {
+        if !value.is_empty() {
+            value.push_str(", ");
+        }
+        write!(
+            value,
+            "{} {} {} {}",
+            px(shadow.offset_x),
+            px(shadow.offset_y),
+            px(shadow.blur_radius),
+            css_color(&shadow.color),
+        )
+        .expect("writing to String cannot fail");
+    }
+    value
 }
 
 pub(crate) fn apply_metrics_style(
@@ -195,4 +234,57 @@ fn settings_css<T>(values: &[T], map: impl Fn(&T) -> ([u8; 4], String)) -> Strin
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use wasm_bindgen_test::wasm_bindgen_test;
+    use whisker_protocol::{PaintColor, TextDecorationLines, TextShadow};
+
+    use super::*;
+
+    #[wasm_bindgen_test]
+    fn combines_decoration_lines_in_css_order() {
+        assert_eq!(
+            decoration_lines(TextDecorationLines {
+                underline: true,
+                overline: true,
+                line_through: true,
+            }),
+            "underline overline line-through"
+        );
+        assert_eq!(decoration_lines(TextDecorationLines::default()), "none");
+    }
+
+    #[wasm_bindgen_test]
+    fn serializes_every_text_shadow_in_paint_order() {
+        let shadows = [
+            TextShadow {
+                offset_x: 1.0,
+                offset_y: 2.0,
+                blur_radius: 3.0,
+                color: PaintColor::Srgba {
+                    red: 255,
+                    green: 0,
+                    blue: 0,
+                    alpha: 1.0,
+                },
+            },
+            TextShadow {
+                offset_x: -1.0,
+                offset_y: 0.0,
+                blur_radius: 4.0,
+                color: PaintColor::Srgba {
+                    red: 0,
+                    green: 0,
+                    blue: 255,
+                    alpha: 0.5,
+                },
+            },
+        ];
+        assert_eq!(
+            text_shadows(&shadows),
+            "1px 2px 3px rgba(255, 0, 0, 1), -1px 0px 4px rgba(0, 0, 255, 0.5)"
+        );
+    }
 }

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -53,47 +53,6 @@ pub(crate) struct WebProviderEvent {
     pub(crate) detail: WhiskerValue,
 }
 
-const fn cursor_keyword_css(value: whisker_protocol::CursorKeyword) -> &'static str {
-    use whisker_protocol::CursorKeyword;
-    match value {
-        CursorKeyword::Auto => "auto",
-        CursorKeyword::Default => "default",
-        CursorKeyword::None => "none",
-        CursorKeyword::ContextMenu => "context-menu",
-        CursorKeyword::Help => "help",
-        CursorKeyword::Pointer => "pointer",
-        CursorKeyword::Progress => "progress",
-        CursorKeyword::Wait => "wait",
-        CursorKeyword::Cell => "cell",
-        CursorKeyword::Crosshair => "crosshair",
-        CursorKeyword::Text => "text",
-        CursorKeyword::VerticalText => "vertical-text",
-        CursorKeyword::Alias => "alias",
-        CursorKeyword::Copy => "copy",
-        CursorKeyword::Move => "move",
-        CursorKeyword::NoDrop => "no-drop",
-        CursorKeyword::NotAllowed => "not-allowed",
-        CursorKeyword::Grab => "grab",
-        CursorKeyword::Grabbing => "grabbing",
-        CursorKeyword::ColResize => "col-resize",
-        CursorKeyword::RowResize => "row-resize",
-        CursorKeyword::NResize => "n-resize",
-        CursorKeyword::EResize => "e-resize",
-        CursorKeyword::SResize => "s-resize",
-        CursorKeyword::WResize => "w-resize",
-        CursorKeyword::NeResize => "ne-resize",
-        CursorKeyword::NwResize => "nw-resize",
-        CursorKeyword::SeResize => "se-resize",
-        CursorKeyword::SwResize => "sw-resize",
-        CursorKeyword::EwResize => "ew-resize",
-        CursorKeyword::NsResize => "ns-resize",
-        CursorKeyword::NeswResize => "nesw-resize",
-        CursorKeyword::NwseResize => "nwse-resize",
-        CursorKeyword::ZoomIn => "zoom-in",
-        CursorKeyword::ZoomOut => "zoom-out",
-    }
-}
-
 impl DomFrameSink {
     pub(crate) fn new_with_resources(
         document: web_sys::Document,
@@ -153,21 +112,6 @@ impl DomFrameSink {
                 {
                     Some("visual-effects payload")
                 }
-                Operation::SetCursor { cursor, .. } if !cursor.resources.is_empty() => {
-                    Some("resource-backed cursor")
-                }
-                Operation::SetText { content, .. }
-                    if content.paint.decoration.lines.overline
-                        || (content.paint.decoration.lines.underline
-                            && content.paint.decoration.lines.line_through)
-                        || !matches!(
-                            content.paint.decoration.thickness,
-                            whisker_protocol::TextDecorationThickness::Auto
-                        )
-                        || content.paint.shadows.len() > 1 =>
-                {
-                    Some("text-effects")
-                }
                 _ => None,
             })
         {
@@ -190,6 +134,21 @@ impl DomFrameSink {
         }) {
             return Err(WebError(format!(
                 "DOM Host background resource {} is not registered",
+                resource.get()
+            )));
+        }
+        if let Some(resource) = packet.operations.iter().find_map(|operation| {
+            let Operation::SetCursor { cursor, .. } = operation else {
+                return None;
+            };
+            cursor
+                .resources
+                .iter()
+                .find(|candidate| !self.resources.contains(candidate.resource))
+                .map(|candidate| candidate.resource)
+        }) {
+            return Err(WebError(format!(
+                "DOM Host cursor resource {} is not registered",
                 resource.get()
             )));
         }
@@ -497,11 +456,9 @@ impl DomFrameSink {
                 )?;
             }
             Operation::SetCursor { node, cursor } => {
-                set_style(
-                    &self.node(*node)?,
-                    "cursor",
-                    cursor_keyword_css(cursor.fallback),
-                )?;
+                paint::cursor::apply(&self.node(*node)?, cursor, |resource| {
+                    self.resources.url(resource)
+                })?;
             }
             Operation::SetProperty {
                 node,


### PR DESCRIPTION
## Summary
- project all protocol text-decoration line combinations and thickness values into CSS
- preserve every text shadow in protocol paint order
- resolve resource-backed cursor candidates, hotspots, and keyword fallback through the Web resource store
- reject missing cursor resources before touching the DOM

## Performance
- CSS strings are built once only when the corresponding `SetText` or `SetCursor` operation is present
- no extra state or per-frame scan is added

## Validation
- `cargo xtask host-conformance web` (11 tests)
- `cargo clippy -p whisker-web --all-targets --target wasm32-unknown-unknown -- -D warnings`