### PR TITLE
fix(web): apply resolved border widths

### DIFF
--- a/platforms/web/src/paint/box.rs
+++ b/platforms/web/src/paint/box.rs
@@ -3,17 +3,17 @@ use whisker_protocol::{BorderLineStyle, BoxPaint, PaintCornerRadius, PaintLength
 use super::color::css_color;
 use crate::{WebError, set_style};
 
-pub(crate) fn apply(element: &web_sys::Element, paint: &BoxPaint) -> Result<(), WebError> {
+pub(crate) fn apply(
+    element: &web_sys::Element,
+    paint: &BoxPaint,
+    border_widths: [f32; 4],
+) -> Result<(), WebError> {
     set_style(
         element,
         "background-color",
         &css_color(&paint.background_color),
     )?;
-    let widths = &paint.border_widths;
-    set_style(element, "border-top-width", &length(widths.top))?;
-    set_style(element, "border-right-width", &length(widths.right))?;
-    set_style(element, "border-bottom-width", &length(widths.bottom))?;
-    set_style(element, "border-left-width", &length(widths.left))?;
+    apply_border_widths(element, border_widths)?;
     let colors = &paint.border_colors;
     set_style(element, "border-top-color", &css_color(&colors.top))?;
     set_style(element, "border-right-color", &css_color(&colors.right))?;
@@ -46,6 +46,16 @@ pub(crate) fn apply(element: &web_sys::Element, paint: &BoxPaint) -> Result<(), 
         &corner_radius(radii.bottom_left),
     )?;
     Ok(())
+}
+
+pub(crate) fn apply_border_widths(
+    element: &web_sys::Element,
+    widths: [f32; 4],
+) -> Result<(), WebError> {
+    set_style(element, "border-top-width", &format!("{}px", widths[0]))?;
+    set_style(element, "border-right-width", &format!("{}px", widths[1]))?;
+    set_style(element, "border-bottom-width", &format!("{}px", widths[2]))?;
+    set_style(element, "border-left-width", &format!("{}px", widths[3]))
 }
 
 fn length(value: PaintLengthPercentage) -> String {

--- a/platforms/web/src/scene/frame_sink.rs
+++ b/platforms/web/src/scene/frame_sink.rs
@@ -392,6 +392,7 @@ impl DomFrameSink {
             }
             Operation::SetLayout { node, geometry } => {
                 self.layouts.insert(*node, *geometry);
+                self.sync_border_widths(*node)?;
                 self.sync_layout(*node)?;
                 self.sync_content_box(*node)?;
                 self.sync_child_layouts(*node)?;
@@ -399,7 +400,8 @@ impl DomFrameSink {
             }
             Operation::SetBoxPaint { node, paint } => {
                 let element = self.node(*node)?;
-                paint::box_paint::apply(&element, paint)?;
+                let border_widths = self.resolve_border_widths(*node, paint);
+                paint::box_paint::apply(&element, paint, border_widths)?;
                 self.box_paints.insert(*node, paint.clone());
                 self.sync_content_box(*node)?;
                 self.sync_child_layouts(*node)?;
@@ -648,6 +650,10 @@ impl DomFrameSink {
         let Some(paint) = self.box_paints.get(&node) else {
             return [0.0; 4];
         };
+        self.resolve_border_widths(node, paint)
+    }
+
+    fn resolve_border_widths(&self, node: NodeId, paint: &whisker_protocol::BoxPaint) -> [f32; 4] {
         let border_box = self
             .layouts
             .get(&node)
@@ -657,28 +663,44 @@ impl DomFrameSink {
         let resolve = |value: whisker_protocol::PaintLengthPercentage, axis: f32| {
             value.length + value.fraction * axis
         };
+        let uses_width = |style| {
+            !matches!(
+                style,
+                whisker_protocol::BorderLineStyle::None | whisker_protocol::BorderLineStyle::Hidden
+            )
+        };
         [
-            if paint.border_styles.top == whisker_protocol::BorderLineStyle::None {
-                0.0
-            } else {
+            if uses_width(paint.border_styles.top) {
                 resolve(paint.border_widths.top, border_box.height)
-            },
-            if paint.border_styles.right == whisker_protocol::BorderLineStyle::None {
-                0.0
             } else {
+                0.0
+            },
+            if uses_width(paint.border_styles.right) {
                 resolve(paint.border_widths.right, border_box.width)
-            },
-            if paint.border_styles.bottom == whisker_protocol::BorderLineStyle::None {
-                0.0
             } else {
+                0.0
+            },
+            if uses_width(paint.border_styles.bottom) {
                 resolve(paint.border_widths.bottom, border_box.height)
-            },
-            if paint.border_styles.left == whisker_protocol::BorderLineStyle::None {
-                0.0
             } else {
+                0.0
+            },
+            if uses_width(paint.border_styles.left) {
                 resolve(paint.border_widths.left, border_box.width)
+            } else {
+                0.0
             },
         ]
+    }
+
+    fn sync_border_widths(&self, node: NodeId) -> Result<(), WebError> {
+        let Some(paint) = self.box_paints.get(&node) else {
+            return Ok(());
+        };
+        paint::box_paint::apply_border_widths(
+            &self.node(node)?,
+            self.resolve_border_widths(node, paint),
+        )
     }
 
     fn sync_content_box(&self, node: NodeId) -> Result<(), WebError> {

--- a/platforms/web/src/tests/host_conformance.rs
+++ b/platforms/web/src/tests/host_conformance.rs
@@ -24,18 +24,19 @@ use whisker_host_conformance::{
     SceneNodeFixture, VisibilityFixture,
 };
 use whisker_protocol::{
-    Accessibility, AccessibilityChecked, AccessibilityRole, AccessibilityState, AvailableSpace,
-    BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode, BorderLineStyle, BoxClip,
-    BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket, GradientStop, ImageRepeat,
-    LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily, MeasureFontStyle,
-    MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow, MeasureTextWordBreak,
-    MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload, MeasurementRequest,
-    MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor, PaintCoordinate,
-    PaintCornerRadius, PaintCorners, PaintEdges, PaintImage, PaintLengthPercentage, PaintPosition,
-    PathCommand, PointerKind, ProtocolVersion, RadialGradientExtent, RadialGradientShape,
-    ResourceCommand, ResourceDimensions, ResourceEvent, ResourceId, ResourceKind, ResourceRequest,
-    ResourceSource, SurfaceId, TextContent, TextMeasurePayload, TextMeasureStyle, TextPaint,
-    TextShadow, Transform, Visibility, WhiskerValue,
+    Accessibility, AccessibilityChecked, AccessibilityRole, AccessibilityState, ApplyResult,
+    AvailableSpace, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
+    BorderLineStyle, BoxClip, BoxPaint, ClipShape, FillRule, FrameHeader, FrameMode, FramePacket,
+    GradientStop, ImageRepeat, LayoutGeometry, LayoutRect, MeasureConstraints, MeasureFontFamily,
+    MeasureFontStyle, MeasureLineHeight, MeasureTextDirection, MeasureTextOverflow,
+    MeasureTextWordBreak, MeasureTextWrap, MeasurementKey, MeasurementMetrics, MeasurementPayload,
+    MeasurementRequest, MeasurementResponse, NodeId, Operation, OverflowClip, PaintBox, PaintColor,
+    PaintCoordinate, PaintCornerRadius, PaintCorners, PaintEdges, PaintImage,
+    PaintLengthPercentage, PaintPosition, PathCommand, PointerKind, ProtocolVersion,
+    RadialGradientExtent, RadialGradientShape, ResourceCommand, ResourceDimensions, ResourceEvent,
+    ResourceId, ResourceKind, ResourceRequest, ResourceSource, SurfaceId, TextContent,
+    TextMeasurePayload, TextMeasureStyle, TextPaint, TextShadow, Transform, Visibility,
+    WhiskerValue,
 };
 use whisker_style::StyleEnvironment;
 
@@ -64,6 +65,47 @@ fn browser_pointer_metadata_maps_to_protocol_values() {
     assert_ne!(stable_pointer_id(-1), 0);
     assert_ne!(stable_pointer_id(0), stable_pointer_id(-1));
     assert_eq!(stable_pointer_id(-1), stable_pointer_id(-1));
+}
+
+#[wasm_bindgen_test]
+fn border_widths_use_resolved_pixels_and_hidden_takes_no_space() {
+    let mut driver = Driver::new();
+    let mut frame = packet(
+        1,
+        [0.0, 0.0, 40.0, 20.0],
+        &ColorFixture::Named {
+            value: "transparent".to_owned(),
+        },
+        None,
+    );
+    let paint = frame
+        .operations
+        .iter_mut()
+        .find_map(|operation| match operation {
+            Operation::SetBoxPaint { paint, .. } => Some(paint),
+            _ => None,
+        })
+        .unwrap();
+    paint.border_widths.top = PaintLengthPercentage {
+        length: 7.0,
+        fraction: 0.25,
+    };
+    paint.border_widths.right = PaintLengthPercentage {
+        length: 1.0,
+        fraction: 0.1,
+    };
+    paint.border_styles.top = BorderLineStyle::Hidden;
+    paint.border_styles.right = BorderLineStyle::Solid;
+
+    assert_eq!(
+        driver.sink.present(&frame).unwrap(),
+        ApplyResult::Accepted { revision: 1 }
+    );
+    let node = driver.root.first_element_child().unwrap();
+    let style = node.dyn_ref::<web_sys::HtmlElement>().unwrap().style();
+    assert_style(&style, "border-top-width", "0px");
+    assert_style(&style, "border-right-width", "5px");
+    driver.root.remove();
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary
- resolve protocol length-percentage border widths against the current border box before writing CSS
- refresh percentage-derived widths when layout size changes
- treat both `none` and `hidden` as zero used border width for content positioning
- cover hidden and percentage width behavior through the production DOM sink

## Performance
- width resolution is four arithmetic operations on `SetLayout`/`SetBoxPaint` only
- no DOM computed-style reads or tree scans are introduced

## Validation
- `cargo xtask host-conformance web` (9 tests)
- `cargo clippy -p whisker-web --all-targets --target wasm32-unknown-unknown -- -D warnings`