### PR TITLE
review rollup 1/7: core style, layout, paint, and protocol

### DIFF
--- a/crates/whisker-css/src/prop/background.rs
+++ b/crates/whisker-css/src/prop/background.rs
@@ -48,10 +48,11 @@ impl Css {
     pub fn background_position(self, v: Position) -> Self {
         let serialized_value = v.to_css_string();
         let value = background_position_value(v)
-            .expect("background-position combines one horizontal and one vertical component");
+            .map(whisker_style::StyleValue::BackgroundPosition)
+            .unwrap_or_else(|| whisker_style::StyleValue::Text(serialized_value.clone()));
         self.push_semantic(
             crate::StyleProperty::BackgroundPosition,
-            whisker_style::StyleValue::BackgroundPosition(value),
+            value,
             serialized_value,
         )
     }
@@ -453,6 +454,30 @@ mod tests {
                     ),
                 }
             )
+        );
+    }
+
+    #[test]
+    fn invalid_background_position_is_diagnostic_instead_of_panicking() {
+        let result = std::panic::catch_unwind(|| {
+            let specified = Css::new()
+                .background_position(Position::Keywords(
+                    PositionKeyword::Top,
+                    PositionKeyword::Bottom,
+                ))
+                .to_specified_style();
+            whisker_style::resolve_style(
+                &specified,
+                None,
+                whisker_style::StyleEnvironment::default(),
+            )
+        });
+
+        assert_eq!(
+            result.expect("public CSS builders must not panic"),
+            Err(whisker_style::StyleResolutionError::InvalidPropertyValue(
+                whisker_style::StyleProperty::BackgroundPosition,
+            ))
         );
     }
 

--- a/crates/whisker-css/src/prop/box_model.rs
+++ b/crates/whisker-css/src/prop/box_model.rs
@@ -94,6 +94,16 @@ impl Css {
         self.push_typed(crate::StyleProperty::PaddingLeft, v.into())
     }
 
+    /// Sets `padding-inline-start` on the logical start edge.
+    pub fn padding_inline_start(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::PaddingInlineStart, v.into())
+    }
+
+    /// Sets `padding-inline-end` on the logical end edge.
+    pub fn padding_inline_end(self, v: impl Into<LengthPercentage>) -> Self {
+        self.push_typed(crate::StyleProperty::PaddingInlineEnd, v.into())
+    }
+
     // ---------- Margin longhand ----------
 
     /// Sets `margin-top`. Lynx allows negative values and `auto`.
@@ -118,6 +128,16 @@ impl Css {
     /// <https://lynxjs.org/api/css/properties/margin-left>
     pub fn margin_left(self, v: impl Into<MarginValue>) -> Self {
         self.push_typed(crate::StyleProperty::MarginLeft, v.into())
+    }
+
+    /// Sets `margin-inline-start` on the logical start edge.
+    pub fn margin_inline_start(self, v: impl Into<MarginValue>) -> Self {
+        self.push_typed(crate::StyleProperty::MarginInlineStart, v.into())
+    }
+
+    /// Sets `margin-inline-end` on the logical end edge.
+    pub fn margin_inline_end(self, v: impl Into<MarginValue>) -> Self {
+        self.push_typed(crate::StyleProperty::MarginInlineEnd, v.into())
     }
 
     // ---------- Gap ----------
@@ -145,11 +165,11 @@ impl Css {
 
 #[cfg(test)]
 mod tests {
-    use crate::Css;
     use crate::data_type::{FitContent, MaxContent};
     use crate::ext::*;
     use crate::keyword::BoxSizing;
     use crate::value::Size;
+    use crate::{Css, MarginValue};
 
     #[test]
     fn width_height_basic() {
@@ -218,6 +238,19 @@ mod tests {
         assert_eq!(
             s.to_string(),
             "margin-top: -4px; margin-right: 0%; margin-bottom: 8px; margin-left: -50%;"
+        );
+    }
+
+    #[test]
+    fn logical_margin_and_padding_builders_remain_typed() {
+        let style = Css::new()
+            .margin_inline_start(px(-4))
+            .margin_inline_end(MarginValue::Auto)
+            .padding_inline_start(px(6))
+            .padding_inline_end(percent(8));
+        assert_eq!(
+            style.to_string(),
+            "margin-inline-start: -4px; margin-inline-end: auto; padding-inline-start: 6px; padding-inline-end: 8%;"
         );
     }
 

--- a/crates/whisker-engine/src/lib.rs
+++ b/crates/whisker-engine/src/lib.rs
@@ -21,6 +21,7 @@ mod color;
 mod layout;
 mod measurement;
 mod paint;
+mod radial_gradient;
 mod recording;
 mod scene;
 mod surface;

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -246,6 +246,7 @@ struct PassState {
 pub(crate) struct MeasurementCoordinator {
     specs: BTreeMap<NodeId, SpecState>,
     cache: HashMap<CacheKey, CacheEntry>,
+    consumer_keys: HashMap<NodeId, Vec<CacheKey>>,
     outstanding: BTreeMap<MeasurementKey, OutstandingRequest>,
     outstanding_by_cache: HashMap<CacheKey, MeasurementKey>,
     pending: BTreeMap<MeasurementRequestId, PendingRequest>,
@@ -259,6 +260,7 @@ impl Default for MeasurementCoordinator {
         Self {
             specs: BTreeMap::new(),
             cache: HashMap::new(),
+            consumer_keys: HashMap::new(),
             outstanding: BTreeMap::new(),
             outstanding_by_cache: HashMap::new(),
             pending: BTreeMap::new(),
@@ -279,6 +281,7 @@ impl MeasurementCoordinator {
             return Vec::new();
         }
         self.cache.clear();
+        self.consumer_keys.clear();
         self.outstanding.clear();
         self.outstanding_by_cache.clear();
         self.pending.clear();
@@ -547,23 +550,41 @@ impl MeasurementCoordinator {
     }
 
     fn remove_consumer(&mut self, node: NodeId) {
-        for entry in self.cache.values_mut() {
-            entry.consumers.remove(&node);
-        }
-        let mut empty = Vec::new();
-        for (key, request) in &mut self.outstanding {
-            request.consumers.remove(&node);
-            if request.consumers.is_empty() {
-                empty.push(*key);
+        let Some(cache_keys) = self.consumer_keys.remove(&node) else {
+            return;
+        };
+        for cache_key in cache_keys {
+            let remove_cached = self.cache.get_mut(&cache_key).is_some_and(|entry| {
+                entry.consumers.remove(&node);
+                entry.consumers.is_empty()
+            });
+            if remove_cached {
+                let entry = self
+                    .cache
+                    .remove(&cache_key)
+                    .expect("checked cache entry remains present");
+                if let CachedState::Pending { request_id, .. } = entry.state {
+                    self.pending.remove(&request_id);
+                }
+                continue;
+            }
+
+            let Some(key) = self.outstanding_by_cache.get(&cache_key).copied() else {
+                continue;
+            };
+            let remove_outstanding = self.outstanding.get_mut(&key).is_some_and(|request| {
+                request.consumers.remove(&node);
+                request.consumers.is_empty()
+            });
+            if remove_outstanding {
+                self.outstanding.remove(&key);
+                self.outstanding_by_cache.remove(&cache_key);
             }
         }
-        for key in empty {
-            let request = self
-                .outstanding
-                .remove(&key)
-                .expect("collected key remains outstanding");
-            self.outstanding_by_cache.remove(&request.cache_key);
-        }
+    }
+
+    fn remember_consumer(&mut self, node: NodeId, cache_key: CacheKey) {
+        self.consumer_keys.entry(node).or_default().push(cache_key);
     }
 
     fn cache_key(state: &SpecState, constraints: MeasureConstraints, epoch: u64) -> CacheKey {
@@ -627,8 +648,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
         let cache_key = Self::cache_key(&state, constraints, epoch);
 
         if let Some(entry) = self.cache.get_mut(&cache_key) {
-            entry.consumers.insert(node);
+            let added = entry.consumers.insert(node);
             let cached = entry.state.clone();
+            if added {
+                self.remember_consumer(node, cache_key);
+            }
             return match cached {
                 CachedState::Ready(metrics) => {
                     self.specs
@@ -663,8 +687,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
                 .outstanding
                 .get_mut(&key)
                 .expect("cache index points to an outstanding request");
-            request.consumers.insert(node);
+            let added = request.consumers.insert(node);
             self.pass.requests.insert(key, request.request.clone());
+            if added {
+                self.remember_consumer(node, cache_key);
+            }
             return self.use_fallback(state.spec.pending_policy, state.last_ready.as_ref(), None);
         }
 
@@ -688,10 +715,11 @@ impl IntrinsicMeasurer for MeasurementCoordinator {
             key,
             OutstandingRequest {
                 request: request.clone(),
-                cache_key,
+                cache_key: cache_key.clone(),
                 consumers: BTreeSet::from([node]),
             },
         );
+        self.remember_consumer(node, cache_key);
         self.pass.requests.insert(key, request);
         self.use_fallback(state.spec.pending_policy, state.last_ready.as_ref(), None)
     }
@@ -1219,6 +1247,9 @@ mod tests {
         let (mut no_consumers, _, _) = pending_coordinator();
         no_consumers.set_spec(node(1), element(), None).unwrap();
         assert_eq!(no_consumers.pending_count(), 0);
+        assert!(no_consumers.cache.is_empty());
+        assert!(no_consumers.pending.is_empty());
+        assert!(no_consumers.consumer_keys.is_empty());
 
         let mut outstanding = MeasurementCoordinator::default();
         outstanding.set_environment(1);
@@ -1240,6 +1271,7 @@ mod tests {
         outstanding.set_spec(node(2), element(), None).unwrap();
         assert!(outstanding.outstanding.is_empty());
         assert!(outstanding.outstanding_by_cache.is_empty());
+        assert!(outstanding.consumer_keys.is_empty());
 
         let mut invalid_pending = MeasurementCoordinator::default();
         invalid_pending.set_environment(1);
@@ -1264,6 +1296,82 @@ mod tests {
                 ))),
             }]),
             Err(MeasurementError::InvalidMetrics { key })
+        );
+    }
+
+    #[test]
+    fn unused_ready_cache_entries_are_reclaimed_without_breaking_shared_entries() {
+        let mut coordinator = MeasurementCoordinator::default();
+        coordinator.set_environment(1);
+        for value in 1..=2 {
+            coordinator
+                .set_spec(
+                    node(value),
+                    element(),
+                    Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+                )
+                .unwrap();
+        }
+
+        coordinator.begin_pass();
+        coordinator.measure(node(1), constraints(10.0));
+        coordinator.measure(node(2), constraints(10.0));
+        let request = coordinator.finish_pass().unwrap().requests.remove(0);
+        coordinator
+            .apply_batch(&[MeasurementResponse::Ready {
+                key: request.key,
+                environment_epoch: 1,
+                metrics: metrics(5.0, 4.0),
+            }])
+            .unwrap();
+        assert_eq!(coordinator.cache.len(), 1);
+
+        coordinator.remove_node(node(1));
+        assert_eq!(coordinator.cache.len(), 1);
+        assert!(!coordinator.consumer_keys.contains_key(&node(1)));
+
+        coordinator.remove_node(node(2));
+        assert!(coordinator.cache.is_empty());
+        assert!(coordinator.consumer_keys.is_empty());
+    }
+
+    #[test]
+    fn removing_last_pending_consumer_makes_deferred_completion_stale() {
+        let mut coordinator = MeasurementCoordinator::default();
+        coordinator.set_environment(1);
+        coordinator
+            .set_spec(
+                node(1),
+                element(),
+                Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+            )
+            .unwrap();
+        coordinator.begin_pass();
+        coordinator.measure(node(1), constraints(10.0));
+        let key = coordinator.finish_pass().unwrap().requests[0].key;
+        let request_id = MeasurementRequestId::new(30).expect("request");
+        coordinator
+            .apply_batch(&[MeasurementResponse::Pending {
+                key,
+                environment_epoch: 1,
+                request_id,
+                provisional: None,
+            }])
+            .unwrap();
+
+        coordinator.remove_node(node(1));
+        assert!(coordinator.pending.is_empty());
+        assert!(coordinator.cache.is_empty());
+        assert_eq!(
+            coordinator
+                .apply_ready(&MeasurementReady {
+                    key,
+                    request_id,
+                    environment_epoch: 1,
+                    metrics: metrics(5.0, 4.0),
+                })
+                .unwrap(),
+            DeferredMeasurementApply::IgnoredStale
         );
     }
 }

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -1326,11 +1326,27 @@ mod tests {
             .unwrap();
         assert_eq!(coordinator.cache.len(), 1);
 
+        coordinator
+            .set_spec(
+                node(3),
+                element(),
+                Some(spec(MeasurementKind::Text, PendingMeasurePolicy::Block)),
+            )
+            .unwrap();
+        coordinator.begin_pass();
+        assert_eq!(
+            coordinator.measure(node(3), constraints(10.0)),
+            LayoutSize::new(5.0, 4.0)
+        );
+        assert!(coordinator.finish_pass().unwrap().requests.is_empty());
+
         coordinator.remove_node(node(1));
         assert_eq!(coordinator.cache.len(), 1);
         assert!(!coordinator.consumer_keys.contains_key(&node(1)));
 
         coordinator.remove_node(node(2));
+        assert_eq!(coordinator.cache.len(), 1);
+        coordinator.remove_node(node(3));
         assert!(coordinator.cache.is_empty());
         assert!(coordinator.consumer_keys.is_empty());
     }

--- a/crates/whisker-engine/src/paint/motion_path.rs
+++ b/crates/whisker-engine/src/paint/motion_path.rs
@@ -8,6 +8,7 @@ pub(super) fn motion_path_state(
 ) -> Option<(f32, f32, f32)> {
     let mut segments = Vec::new();
     let mut total_length = 0.0_f32;
+    let mut zero_length_position = None;
     match path {
         OffsetPathValue::None => return None,
         OffsetPathValue::Path(commands) => {
@@ -19,6 +20,7 @@ pub(super) fn motion_path_state(
                         let point = finite_motion_point(point)?;
                         current = Some(point);
                         subpath_start = Some(point);
+                        zero_length_position.get_or_insert(point);
                         continue;
                     }
                     MotionPathCommandValue::LineTo(point) => {
@@ -90,6 +92,10 @@ pub(super) fn motion_path_state(
                 resolve_motion_length(*center_x, border_width),
                 resolve_motion_length(*center_y, border_height),
             );
+            if ![radius, center.0, center.1].into_iter().all(f32::is_finite) || radius < 0.0 {
+                return None;
+            }
+            zero_length_position = Some((center.0 + radius, center.1));
             append_ellipse(
                 &mut segments,
                 center,
@@ -112,17 +118,34 @@ pub(super) fn motion_path_state(
                 resolve_motion_length(*center_x, border_width),
                 resolve_motion_length(*center_y, border_height),
             );
+            if ![radii.0, radii.1, center.0, center.1]
+                .into_iter()
+                .all(f32::is_finite)
+                || radii.0 < 0.0
+                || radii.1 < 0.0
+            {
+                return None;
+            }
+            zero_length_position = Some((center.0 + radii.0, center.1));
             append_ellipse(&mut segments, center, radii, 0.0, std::f32::consts::TAU);
         }
         OffsetPathValue::Inset(value) => {
-            append_inset_path(&mut segments, value, border_width, border_height)?;
+            zero_length_position = Some(append_inset_path(
+                &mut segments,
+                value,
+                border_width,
+                border_height,
+            )?);
         }
     }
     for segment in &segments {
         total_length += segment.length;
     }
-    if segments.is_empty() || !total_length.is_finite() {
+    if !total_length.is_finite() {
         return None;
+    }
+    if segments.is_empty() {
+        return zero_length_position.map(|point| (point.0, point.1, 0.0));
     }
     let target = progress.clamp(0.0, 1.0) * total_length;
     let mut traversed = 0.0;
@@ -281,7 +304,7 @@ fn append_inset_path(
     value: &whisker_style::ComputedInsetPathValue,
     border_width: f32,
     border_height: f32,
-) -> Option<()> {
+) -> Option<MotionPoint> {
     let mut top = resolve_motion_length(value.offsets.top, border_height);
     let mut right = resolve_motion_length(value.offsets.right, border_width);
     let mut bottom = resolve_motion_length(value.offsets.bottom, border_height);
@@ -309,7 +332,7 @@ fn append_inset_path(
     let width = (border_width - left - right).max(0.0);
     let height = (border_height - top - bottom).max(0.0);
     if width <= 0.0 || height <= 0.0 {
-        return None;
+        return Some((left, top));
     }
     let right_edge = left + width;
     let bottom_edge = top + height;
@@ -427,7 +450,7 @@ fn append_inset_path(
         current = start;
     }
     push_motion_line(segments, current, start);
-    Some(())
+    Some(start)
 }
 
 fn push_motion_segment(

--- a/crates/whisker-engine/src/paint/tests.rs
+++ b/crates/whisker-engine/src/paint/tests.rs
@@ -581,10 +581,6 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
             },
         ]),
         OffsetPathValue::Path(vec![MotionPathCommandValue::Close]),
-        OffsetPathValue::Path(vec![
-            MotionPathCommandValue::MoveTo(point(1.0, 1.0)),
-            MotionPathCommandValue::LineTo(point(1.0, 1.0)),
-        ]),
     ] {
         assert_eq!(
             lower_transform(
@@ -598,6 +594,18 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
             None
         );
     }
+
+    let zero_length = ComputedTransformStyle {
+        offset_path: OffsetPathValue::Path(vec![
+            MotionPathCommandValue::MoveTo(point(4.0, 6.0)),
+            MotionPathCommandValue::LineTo(point(4.0, 6.0)),
+        ]),
+        ..ComputedTransformStyle::default()
+    };
+    let transform = lower_transform(&zero_length, 1.0, 1.0)
+        .expect("a valid zero-length path still has a deterministic position");
+    assert_eq!(transform.0[12], 4.0);
+    assert_eq!(transform.0[13], 6.0);
 
     let quadratic = OffsetPathValue::Path(vec![
         MotionPathCommandValue::MoveTo(point(0.0, 20.0)),
@@ -897,7 +905,7 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
             40.0,
             20.0,
         ),
-        None
+        Some((0.0, 0.0, 0.0))
     );
     let collapsed = OffsetPathValue::Inset(Box::new(whisker_style::ComputedInsetPathValue {
         offsets: whisker_style::Edges {
@@ -908,7 +916,10 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
         },
         radii: None,
     }));
-    assert_eq!(motion_path_state(&collapsed, 0.0, 100.0, 60.0), None);
+    assert_eq!(
+        motion_path_state(&collapsed, 0.0, 100.0, 60.0),
+        Some((50.0, 0.0, 0.0))
+    );
 
     let invalid_offset = OffsetPathValue::Inset(Box::new(whisker_style::ComputedInsetPathValue {
         offsets: whisker_style::Edges {
@@ -933,7 +944,7 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
         }));
     assert_eq!(
         motion_path_state(&vertically_collapsed, 0.0, 100.0, 60.0),
-        None
+        Some((0.0, 30.0, 0.0))
     );
 
     let corner = |horizontal, vertical| whisker_style::ComputedCornerRadius {

--- a/crates/whisker-engine/src/paint/tests.rs
+++ b/crates/whisker-engine/src/paint/tests.rs
@@ -843,6 +843,20 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
     assert!((y - 25.811_388).abs() < 0.001, "{y}");
     assert!((angle - 180.0).abs() < 0.001, "{angle}");
 
+    assert_eq!(
+        motion_path_state(
+            &OffsetPathValue::Circle {
+                radius: ComputedLengthPercentage::new(-1.0, 0.0),
+                center_x: ComputedLengthPercentage::ZERO,
+                center_y: ComputedLengthPercentage::ZERO,
+            },
+            0.0,
+            1.0,
+            1.0,
+        ),
+        None
+    );
+
     let ellipse = OffsetPathValue::Ellipse {
         radius_x: ComputedLengthPercentage::new(0.0, 0.25),
         radius_y: ComputedLengthPercentage::new(0.0, 0.25),
@@ -853,6 +867,30 @@ fn lowers_polyline_motion_progress_auto_rotation_and_post_translation() {
     assert!((x - 20.0).abs() < 0.001, "{x}");
     assert!((y - 15.0).abs() < 0.001, "{y}");
     assert!((angle - 180.0).abs() < 0.001, "{angle}");
+
+    assert_eq!(
+        motion_path_state(
+            &OffsetPathValue::Ellipse {
+                radius_x: ComputedLengthPercentage::new(-1.0, 0.0),
+                radius_y: ComputedLengthPercentage::new(1.0, 0.0),
+                center_x: ComputedLengthPercentage::ZERO,
+                center_y: ComputedLengthPercentage::ZERO,
+            },
+            0.0,
+            1.0,
+            1.0,
+        ),
+        None
+    );
+
+    let overflowing_length = OffsetPathValue::Path(vec![
+        MotionPathCommandValue::MoveTo(point(0.0, 0.0)),
+        MotionPathCommandValue::LineTo(point(1.0e38, 0.0)),
+        MotionPathCommandValue::LineTo(point(0.0, 0.0)),
+        MotionPathCommandValue::LineTo(point(1.0e38, 0.0)),
+        MotionPathCommandValue::LineTo(point(0.0, 0.0)),
+    ]);
+    assert_eq!(motion_path_state(&overflowing_length, 0.0, 1.0, 1.0), None);
 
     let zero = ComputedLengthPercentage::ZERO;
     let ten = ComputedLengthPercentage::new(10.0, 0.0);

--- a/crates/whisker-engine/src/radial_gradient.rs
+++ b/crates/whisker-engine/src/radial_gradient.rs
@@ -230,3 +230,320 @@ pub(super) const fn absolute_length(length: f32) -> PaintLengthPercentage {
         fraction: 0.0,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use whisker_protocol::{
+        BackgroundAttachment, BlendMode, GradientStop, LayoutRect, PaintColor, PaintEdges,
+        PaintPosition, ResourceId,
+    };
+
+    use super::*;
+
+    fn coordinate(length: f32, fraction: f32) -> PaintCoordinate {
+        PaintCoordinate { length, fraction }
+    }
+
+    fn length(length: f32, fraction: f32) -> PaintLengthPercentage {
+        PaintLengthPercentage { length, fraction }
+    }
+
+    fn radial(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        stop: PaintCoordinate,
+    ) -> BackgroundLayer {
+        radial_with_first_stop(shape, extent, radii, Some(coordinate(0.0, 0.0)), stop)
+    }
+
+    fn radial_with_first_stop(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        first_stop: Option<PaintCoordinate>,
+        stop: PaintCoordinate,
+    ) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::RadialGradient {
+                shape,
+                extent,
+                center: PaintPosition {
+                    x: coordinate(0.0, 0.25),
+                    y: coordinate(0.0, 0.75),
+                },
+                radii,
+                repeating: false,
+                stops: vec![
+                    GradientStop {
+                        color: PaintColor::default(),
+                        position: first_stop,
+                    },
+                    GradientStop {
+                        color: PaintColor::default(),
+                        position: Some(stop),
+                    },
+                ],
+            },
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Border,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
+    fn resource() -> BackgroundLayer {
+        let mut layer = radial(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+            None,
+            coordinate(0.0, 1.0),
+        );
+        layer.image = PaintImage::Resource(ResourceId::new(1).expect("resource"));
+        layer
+    }
+
+    fn source(shape: RadialGradientShape, extent: RadialGradientExtent) -> RadialBackgroundSource {
+        RadialBackgroundSource {
+            layer: 0,
+            shape,
+            extent,
+            radii: None,
+            original_stop_positions: None,
+        }
+    }
+
+    #[test]
+    fn source_discovery_skips_non_radial_and_already_canonical_layers() {
+        let absolute = coordinate(0.0, 0.5);
+        let layers = vec![
+            resource(),
+            radial(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::ClosestSide,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                None,
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                absolute,
+            ),
+            radial(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(1.0), absolute_length(1.0))),
+                coordinate(4.0, 0.5),
+            ),
+        ];
+        let found = sources(&layers);
+        assert_eq!(found.len(), 4);
+        assert_eq!(found[0].layer, 1);
+        assert_eq!(found[3].layer, 5);
+        assert!(found[3].original_stop_positions.is_some());
+    }
+
+    #[test]
+    fn canonicalization_tolerates_stale_sources_and_unresolved_explicit_radii() {
+        let geometry = LayoutGeometry::from(LayoutRect {
+            width: 100.0,
+            height: 80.0,
+            ..LayoutRect::default()
+        });
+        let stale = RadialBackgroundSource {
+            layer: 1,
+            ..source(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::ClosestSide,
+            )
+        };
+        let mut no_layer = vec![resource()];
+        canonicalize(&mut no_layer, &[stale], geometry, None);
+
+        let wrong_kind = source(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+        );
+        canonicalize(&mut no_layer, &[wrong_kind], geometry, None);
+
+        let missing_radii = source(RadialGradientShape::Ellipse, RadialGradientExtent::Explicit);
+        let mut layers = vec![radial(
+            RadialGradientShape::Ellipse,
+            RadialGradientExtent::Explicit,
+            None,
+            coordinate(0.0, 0.5),
+        )];
+        let unchanged = layers.clone();
+        canonicalize(&mut layers, &[missing_radii], geometry, None);
+        assert_eq!(layers, unchanged);
+
+        let mut resolved = vec![radial_with_first_stop(
+            RadialGradientShape::Circle,
+            RadialGradientExtent::ClosestSide,
+            None,
+            None,
+            coordinate(0.0, 0.5),
+        )];
+        canonicalize(
+            &mut resolved,
+            &[source(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::ClosestSide,
+            )],
+            geometry,
+            None,
+        );
+        let expected = radial_with_first_stop(
+            RadialGradientShape::Ellipse,
+            RadialGradientExtent::Explicit,
+            Some((absolute_length(20.0), absolute_length(20.0))),
+            None,
+            coordinate(0.0, 0.5),
+        );
+        assert_eq!(resolved[0].image, expected.image);
+    }
+
+    #[test]
+    fn positioning_and_tile_geometry_cover_every_supported_mode() {
+        let geometry = LayoutGeometry {
+            border_box: LayoutRect {
+                width: 100.0,
+                height: 80.0,
+                ..LayoutRect::default()
+            },
+            content_box: LayoutRect {
+                width: 70.0,
+                height: 50.0,
+                ..LayoutRect::default()
+            },
+        };
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Content),
+            [70.0, 50.0]
+        );
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Padding),
+            [100.0, 80.0]
+        );
+        assert_eq!(
+            background_positioning_size(geometry, None, PaintBox::Margin),
+            [100.0, 80.0]
+        );
+
+        let paint = BoxPaint {
+            border_widths: PaintEdges {
+                top: length(2.0, 0.1),
+                right: length(3.0, 0.1),
+                bottom: length(4.0, 0.1),
+                left: length(5.0, 0.1),
+            },
+            ..BoxPaint::default()
+        };
+        assert_eq!(
+            background_positioning_size(geometry, Some(&paint), PaintBox::Padding),
+            [72.0, 58.0]
+        );
+
+        let mut layer = resource();
+        for size in [
+            BackgroundSize::Auto,
+            BackgroundSize::Cover,
+            BackgroundSize::Contain,
+        ] {
+            layer.size = size;
+            assert_eq!(gradient_tile_size(100.0, 80.0, &layer), [100.0, 80.0]);
+        }
+        layer.size = BackgroundSize::Explicit {
+            width: Some(length(10.0, 0.5)),
+            height: None,
+        };
+        layer.repeat_x = ImageRepeat::Round;
+        layer.repeat_y = ImageRepeat::Round;
+        assert_eq!(gradient_tile_size(100.0, 80.0, &layer), [50.0, 80.0]);
+        layer.size = BackgroundSize::Explicit {
+            width: None,
+            height: Some(length(10.0, 0.5)),
+        };
+        assert_eq!(gradient_tile_size(-1.0, -2.0, &layer), [0.0, 9.0]);
+        assert_eq!(rounded_tile_size(0.0, 2.0), 2.0);
+        assert_eq!(rounded_tile_size(2.0, -1.0), 0.0);
+        assert!((rounded_tile_size(100.0, 40.0) - 100.0 / 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn radius_resolution_covers_all_circle_and_ellipse_extents() {
+        let expected = [
+            (RadialGradientExtent::ClosestSide, (20.0, 20.0)),
+            (RadialGradientExtent::FarthestSide, (75.0, 75.0)),
+            (
+                RadialGradientExtent::ClosestCorner,
+                (25.0_f32.hypot(20.0), 25.0_f32.hypot(20.0)),
+            ),
+            (
+                RadialGradientExtent::FarthestCorner,
+                (75.0_f32.hypot(60.0), 75.0_f32.hypot(60.0)),
+            ),
+        ];
+        for (extent, circle_expected) in expected {
+            assert_eq!(
+                resolved_radii(
+                    &source(RadialGradientShape::Circle, extent),
+                    100.0,
+                    80.0,
+                    25.0,
+                    20.0,
+                ),
+                Some(circle_expected)
+            );
+            assert!(
+                resolved_radii(
+                    &source(RadialGradientShape::Ellipse, extent),
+                    100.0,
+                    80.0,
+                    25.0,
+                    20.0,
+                )
+                .is_some()
+            );
+        }
+
+        let explicit_ellipse = RadialBackgroundSource {
+            radii: Some((length(10.0, 0.5), length(4.0, 0.25))),
+            ..source(RadialGradientShape::Ellipse, RadialGradientExtent::Explicit)
+        };
+        assert_eq!(
+            resolved_radii(&explicit_ellipse, 100.0, 80.0, 25.0, 20.0),
+            Some((60.0, 24.0))
+        );
+        let explicit_circle = RadialBackgroundSource {
+            radii: explicit_ellipse.radii,
+            ..source(RadialGradientShape::Circle, RadialGradientExtent::Explicit)
+        };
+        let circle = resolved_radii(&explicit_circle, 100.0, 80.0, 25.0, 20.0).unwrap();
+        assert_eq!(circle.0, circle.1);
+
+        let invalid = RadialBackgroundSource {
+            radii: Some((absolute_length(f32::NAN), absolute_length(1.0))),
+            ..explicit_ellipse
+        };
+        assert_eq!(resolved_radii(&invalid, 100.0, 80.0, 25.0, 20.0), None);
+        assert_eq!(ellipse_corner_scale(0.0, 0.0, 4.0, 3.0), 0.0);
+    }
+}

--- a/crates/whisker-engine/src/radial_gradient.rs
+++ b/crates/whisker-engine/src/radial_gradient.rs
@@ -1,0 +1,232 @@
+//! Layout-dependent canonicalization for the radial-gradient wire subset.
+
+use std::sync::Arc;
+
+use whisker_protocol::{
+    BackgroundLayer, BackgroundSize, BoxPaint, ImageRepeat, LayoutGeometry, PaintBox,
+    PaintCoordinate, PaintImage, PaintLengthPercentage, RadialGradientExtent, RadialGradientShape,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct RadialBackgroundSource {
+    layer: usize,
+    shape: RadialGradientShape,
+    extent: RadialGradientExtent,
+    radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+    original_stop_positions: Option<Arc<[Option<PaintCoordinate>]>>,
+}
+
+pub(super) fn sources(layers: &[BackgroundLayer]) -> Vec<RadialBackgroundSource> {
+    layers
+        .iter()
+        .enumerate()
+        .filter_map(|(layer, background)| {
+            let PaintImage::RadialGradient {
+                shape,
+                extent,
+                radii,
+                stops,
+                ..
+            } = &background.image
+            else {
+                return None;
+            };
+            let already_canonical = *shape == RadialGradientShape::Ellipse
+                && *extent == RadialGradientExtent::Explicit
+                && radii.is_some()
+                && stops
+                    .iter()
+                    .all(|stop| stop.position.is_some_and(|position| position.length == 0.0));
+            (!already_canonical).then_some(RadialBackgroundSource {
+                layer,
+                shape: *shape,
+                extent: *extent,
+                radii: *radii,
+                original_stop_positions: stops
+                    .iter()
+                    .any(|stop| stop.position.is_some_and(|position| position.length != 0.0))
+                    .then(|| stops.iter().map(|stop| stop.position).collect::<Arc<[_]>>()),
+            })
+        })
+        .collect()
+}
+
+pub(super) fn canonicalize(
+    layers: &mut [BackgroundLayer],
+    sources: &[RadialBackgroundSource],
+    geometry: LayoutGeometry,
+    paint: Option<&BoxPaint>,
+) {
+    for source in sources {
+        let Some(layer) = layers.get_mut(source.layer) else {
+            continue;
+        };
+        let [positioning_width, positioning_height] =
+            background_positioning_size(geometry, paint, layer.origin);
+        let [tile_width, tile_height] =
+            gradient_tile_size(positioning_width, positioning_height, layer);
+        let PaintImage::RadialGradient {
+            shape,
+            extent,
+            center,
+            radii,
+            stops,
+            ..
+        } = &mut layer.image
+        else {
+            continue;
+        };
+        let center_x = center.x.length + center.x.fraction * tile_width;
+        let center_y = center.y.length + center.y.fraction * tile_height;
+        let Some((radius_x, radius_y)) =
+            resolved_radii(source, tile_width, tile_height, center_x, center_y)
+        else {
+            continue;
+        };
+        if let Some(originals) = &source.original_stop_positions {
+            for (stop, original) in stops.iter_mut().zip(originals.iter()) {
+                stop.position = *original;
+            }
+        }
+        let gradient_line = radius_x.max(f32::EPSILON);
+        for stop in stops {
+            if let Some(position) = &mut stop.position {
+                position.fraction += position.length / gradient_line;
+                position.length = 0.0;
+            }
+        }
+        *shape = RadialGradientShape::Ellipse;
+        *extent = RadialGradientExtent::Explicit;
+        *radii = Some((absolute_length(radius_x), absolute_length(radius_y)));
+    }
+}
+
+fn background_positioning_size(
+    geometry: LayoutGeometry,
+    paint: Option<&BoxPaint>,
+    origin: PaintBox,
+) -> [f32; 2] {
+    let border = geometry.border_box;
+    match origin {
+        PaintBox::Content => [geometry.content_box.width, geometry.content_box.height],
+        PaintBox::Padding => {
+            let Some(paint) = paint else {
+                return [border.width, border.height];
+            };
+            let horizontal = resolve_length(paint.border_widths.left, border.width)
+                + resolve_length(paint.border_widths.right, border.width);
+            let vertical = resolve_length(paint.border_widths.top, border.height)
+                + resolve_length(paint.border_widths.bottom, border.height);
+            [
+                (border.width - horizontal).max(0.0),
+                (border.height - vertical).max(0.0),
+            ]
+        }
+        _ => [border.width, border.height],
+    }
+}
+
+fn gradient_tile_size(width: f32, height: f32, layer: &BackgroundLayer) -> [f32; 2] {
+    let [mut tile_width, mut tile_height] = match layer.size {
+        BackgroundSize::Auto | BackgroundSize::Cover | BackgroundSize::Contain => [width, height],
+        BackgroundSize::Explicit {
+            width: explicit_width,
+            height: explicit_height,
+        } => [
+            explicit_width.map_or(width, |value| resolve_length(value, width)),
+            explicit_height.map_or(height, |value| resolve_length(value, height)),
+        ],
+    };
+    if layer.repeat_x == ImageRepeat::Round {
+        tile_width = rounded_tile_size(width, tile_width);
+    }
+    if layer.repeat_y == ImageRepeat::Round {
+        tile_height = rounded_tile_size(height, tile_height);
+    }
+    [tile_width.max(0.0), tile_height.max(0.0)]
+}
+
+fn rounded_tile_size(area: f32, tile: f32) -> f32 {
+    if area <= 0.0 || tile <= 0.0 {
+        return tile.max(0.0);
+    }
+    let count = (area / tile).round().max(1.0);
+    area / count
+}
+
+fn resolved_radii(
+    source: &RadialBackgroundSource,
+    width: f32,
+    height: f32,
+    center_x: f32,
+    center_y: f32,
+) -> Option<(f32, f32)> {
+    let left = center_x.abs();
+    let right = (width - center_x).abs();
+    let top = center_y.abs();
+    let bottom = (height - center_y).abs();
+    let closest_x = left.min(right);
+    let farthest_x = left.max(right);
+    let closest_y = top.min(bottom);
+    let farthest_y = top.max(bottom);
+    let circle = source.shape == RadialGradientShape::Circle;
+    let radii = match source.extent {
+        RadialGradientExtent::Explicit => {
+            let (radius_x, radius_y) = source.radii?;
+            if circle {
+                let basis = width.hypot(height) / 2.0_f32.sqrt();
+                let radius = resolve_length(radius_x, basis);
+                (radius, radius)
+            } else {
+                (
+                    resolve_length(radius_x, width),
+                    resolve_length(radius_y, height),
+                )
+            }
+        }
+        RadialGradientExtent::ClosestSide if circle => {
+            let radius = closest_x.min(closest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::FarthestSide if circle => {
+            let radius = farthest_x.max(farthest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::ClosestCorner if circle => {
+            let radius = closest_x.hypot(closest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::FarthestCorner if circle => {
+            let radius = farthest_x.hypot(farthest_y);
+            (radius, radius)
+        }
+        RadialGradientExtent::ClosestSide => (closest_x, closest_y),
+        RadialGradientExtent::FarthestSide => (farthest_x, farthest_y),
+        RadialGradientExtent::ClosestCorner => {
+            let scale = ellipse_corner_scale(closest_x, closest_y, closest_x, closest_y);
+            (closest_x * scale, closest_y * scale)
+        }
+        RadialGradientExtent::FarthestCorner => {
+            let scale = ellipse_corner_scale(farthest_x, farthest_y, farthest_x, farthest_y);
+            (farthest_x * scale, farthest_y * scale)
+        }
+    };
+    (radii.0.is_finite() && radii.1.is_finite()).then_some(radii)
+}
+
+fn ellipse_corner_scale(radius_x: f32, radius_y: f32, x: f32, y: f32) -> f32 {
+    let normalized_x = if radius_x > 0.0 { x / radius_x } else { 0.0 };
+    let normalized_y = if radius_y > 0.0 { y / radius_y } else { 0.0 };
+    normalized_x.hypot(normalized_y)
+}
+
+fn resolve_length(value: PaintLengthPercentage, extent: f32) -> f32 {
+    value.length + value.fraction * extent
+}
+
+pub(super) const fn absolute_length(length: f32) -> PaintLengthPercentage {
+    PaintLengthPercentage {
+        length,
+        fraction: 0.0,
+    }
+}

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -1118,13 +1118,15 @@ impl Scene {
 
     fn snapshot_operations(&self) -> Vec<Operation> {
         let mut operations = Vec::new();
-        for (node, state) in &self.nodes {
+        let mut nodes: Vec<_> = self.nodes.iter().collect();
+        nodes.sort_unstable_by_key(|(node, _)| node.get());
+        for (node, state) in nodes.iter().copied() {
             operations.push(Operation::CreateNode {
                 node: *node,
                 element_type: state.element_type,
             });
         }
-        for (parent, state) in &self.nodes {
+        for (parent, state) in nodes.iter().copied() {
             for (index, child) in state.children.iter().enumerate() {
                 operations.push(Operation::InsertChild {
                     parent: *parent,
@@ -1133,7 +1135,7 @@ impl Scene {
                 });
             }
         }
-        for (node, state) in &self.nodes {
+        for (node, state) in nodes {
             if let Some(geometry) = state.layout {
                 operations.push(Operation::SetLayout {
                     node: *node,
@@ -1841,6 +1843,27 @@ mod tests {
         let packet = scene.prepare_frame(1).unwrap().unwrap();
 
         assert_eq!(packet.header.version, protocol);
+    }
+
+    #[test]
+    fn snapshots_create_nodes_in_allocation_order() {
+        let mut scene = Scene::new(surface());
+        let expected: Vec<_> = (0..64)
+            .map(|_| scene.create_node(element_type(1)).expect("node"))
+            .collect();
+        scene.set_opacity(expected[0], 0.5).expect("opacity");
+
+        let snapshot = prepared(&mut scene);
+        let actual: Vec<_> = snapshot
+            .operations
+            .iter()
+            .filter_map(|operation| match operation {
+                Operation::CreateNode { node, .. } => Some(*node),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -4,16 +4,22 @@ use std::{collections::HashMap, error::Error, fmt};
 
 use whisker_layout::{IntrinsicMeasurer, LayoutError, LayoutSize, LayoutSnapshot, LayoutTree};
 use whisker_protocol::{
-    Accessibility, ApplyResult, BoxPaint, CommandId, Cursor, CursorKeyword, ElementTypeId,
-    FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, MeasurementMetrics, MeasurementReady,
-    MeasurementResponse, MeasurementSpec, NodeId, PointerId, PropertyId, SurfaceId, TextContent,
-    WhiskerValue,
+    Accessibility, ApplyResult, BackgroundLayer, BoxPaint, CommandId, Cursor, CursorKeyword,
+    ElementTypeId, FramePacket, HitTestBehavior, InputPoint, LayoutGeometry, MeasurementMetrics,
+    MeasurementReady, MeasurementResponse, MeasurementSpec, NodeId, PointerId, PropertyId,
+    SurfaceId, TextContent, WhiskerValue,
 };
 use whisker_style::{
     ComputedLayoutStyle, ComputedStyle, ComputedTransformStyle, CursorValue, PointerEventsValue,
     PropertyImpactSet,
 };
 
+#[cfg(test)]
+use crate::radial_gradient::absolute_length;
+use crate::radial_gradient::{
+    RadialBackgroundSource, canonicalize as canonicalize_radial_backgrounds,
+    sources as radial_background_sources,
+};
 use crate::{
     DeferredMeasurementApply, FrameSink, LayoutProgress, MeasurementApply, MeasurementError,
     PlainTextInput, Scene, SceneError, SceneNode, lower_paint, lower_plain_text, lower_text_style,
@@ -204,6 +210,7 @@ pub struct SurfaceEngine {
     layout_dirty: bool,
     layout_provisional: bool,
     transforms: HashMap<NodeId, ComputedTransformStyle>,
+    radial_backgrounds: HashMap<NodeId, Vec<RadialBackgroundSource>>,
     measurements: MeasurementCoordinator,
 }
 
@@ -223,6 +230,7 @@ impl SurfaceEngine {
             layout_dirty: false,
             layout_provisional: false,
             transforms: HashMap::new(),
+            radial_backgrounds: HashMap::new(),
             measurements: MeasurementCoordinator::default(),
         }
     }
@@ -439,6 +447,7 @@ impl SurfaceEngine {
             .expect("scene and layout trees remain structurally synchronized");
         for removed in removed {
             self.transforms.remove(&removed);
+            self.radial_backgrounds.remove(&removed);
             self.measurements.remove_node(removed);
         }
         self.layout_dirty = true;
@@ -595,10 +604,25 @@ impl SurfaceEngine {
     pub fn set_background_layers(
         &mut self,
         node: NodeId,
-        layers: Vec<whisker_protocol::BackgroundLayer>,
+        mut layers: Vec<BackgroundLayer>,
     ) -> Result<(), SurfaceError> {
         self.ensure_mutable()?;
+        let sources = radial_background_sources(&layers);
+        if let Some(geometry) = self
+            .last_layout
+            .as_ref()
+            .and_then(|layout| layout.get(node))
+            .copied()
+        {
+            let paint = self.scene.node(node).and_then(SceneNode::box_paint);
+            canonicalize_radial_backgrounds(&mut layers, &sources, geometry, paint);
+        }
         self.scene.set_background_layers(node, layers)?;
+        if sources.is_empty() {
+            self.radial_backgrounds.remove(&node);
+        } else {
+            self.radial_backgrounds.insert(node, sources);
+        }
         Ok(())
     }
 
@@ -943,6 +967,24 @@ impl SurfaceEngine {
                     .map(Option::flatten)
             })
             .collect::<Result<Vec<_>, SurfaceError>>()?;
+        let radial_backgrounds = if self.radial_backgrounds.is_empty() {
+            Vec::new()
+        } else {
+            changed
+                .iter()
+                .filter_map(|(node, geometry)| {
+                    let sources = self.radial_backgrounds.get(node)?;
+                    let mut layers = self.scene.node(*node)?.background_layers().to_vec();
+                    canonicalize_radial_backgrounds(
+                        &mut layers,
+                        sources,
+                        *geometry,
+                        self.scene.node(*node).and_then(SceneNode::box_paint),
+                    );
+                    Some((*node, layers))
+                })
+                .collect::<Vec<_>>()
+        };
         for ((node, rect), transform) in changed.iter().zip(transforms) {
             self.scene
                 .set_layout(*node, *rect)
@@ -952,6 +994,11 @@ impl SurfaceEngine {
                     .set_transform(*node, transform)
                     .expect("the transform was validated before layout projection");
             }
+        }
+        for (node, layers) in radial_backgrounds {
+            self.scene
+                .set_background_layers(node, layers)
+                .expect("canonical radial backgrounds preserve protocol validity");
         }
         self.last_layout = Some(snapshot);
         self.last_inputs = Some(inputs);
@@ -1047,7 +1094,8 @@ mod tests {
         MeasuredSize, MeasurementKey, MeasurementKind, MeasurementMetrics, MeasurementPayload,
         MeasurementReady, MeasurementRequestId, MeasurementResponse, MeasurementSpec,
         NativeControlMeasurePayload, NodeId, Operation, PaintBox, PaintCoordinate, PaintImage,
-        PaintPosition, PendingMeasurePolicy, PointerId, ReplacedContentMeasurePayload, ResourceId,
+        PaintLengthPercentage, PaintPosition, PendingMeasurePolicy, PointerId,
+        RadialGradientExtent, RadialGradientShape, ReplacedContentMeasurePayload, ResourceId,
         SurfaceId, TextMeasurePayload, TextMeasureStyle, UnsupportedMeasurementReason,
     };
     use whisker_style::{
@@ -1094,6 +1142,159 @@ mod tests {
             attachment: BackgroundAttachment::Scroll,
             blend_mode: BlendMode::Normal,
         }
+    }
+
+    fn radial_background(
+        shape: RadialGradientShape,
+        extent: RadialGradientExtent,
+        radii: Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+    ) -> BackgroundLayer {
+        BackgroundLayer {
+            image: PaintImage::RadialGradient {
+                shape,
+                extent,
+                center: PaintPosition {
+                    x: PaintCoordinate {
+                        length: 0.0,
+                        fraction: 0.5,
+                    },
+                    y: PaintCoordinate {
+                        length: 0.0,
+                        fraction: 0.5,
+                    },
+                },
+                radii,
+                repeating: false,
+                stops: vec![
+                    whisker_protocol::GradientStop {
+                        color: Default::default(),
+                        position: Some(PaintCoordinate {
+                            length: 0.0,
+                            fraction: 0.0,
+                        }),
+                    },
+                    whisker_protocol::GradientStop {
+                        color: Default::default(),
+                        position: Some(PaintCoordinate {
+                            length: 25.0,
+                            fraction: 0.0,
+                        }),
+                    },
+                ],
+            },
+            position: PaintPosition::default(),
+            size: BackgroundSize::Auto,
+            repeat_x: ImageRepeat::Repeat,
+            repeat_y: ImageRepeat::Repeat,
+            origin: PaintBox::Border,
+            clip: PaintBox::Border,
+            attachment: BackgroundAttachment::Scroll,
+            blend_mode: BlendMode::Normal,
+        }
+    }
+
+    #[test]
+    fn layout_canonicalizes_radial_keyword_geometry_and_absolute_stops() {
+        let mut surface = SurfaceEngine::new(surface_id());
+        let root = surface
+            .create_node(element_type(), sized(200.0, 100.0))
+            .expect("root");
+        surface
+            .set_background_layers(
+                root,
+                vec![radial_background(
+                    RadialGradientShape::Circle,
+                    RadialGradientExtent::FarthestCorner,
+                    None,
+                )],
+            )
+            .expect("background");
+        surface
+            .compute_layout(root, LayoutSize::new(200.0, 100.0), &mut zero_measure)
+            .expect("layout");
+
+        let PaintImage::RadialGradient {
+            shape,
+            extent,
+            radii: Some((radius_x, radius_y)),
+            stops,
+            ..
+        } = &surface.node(root).unwrap().background_layers()[0].image
+        else {
+            panic!("expected canonical radial gradient")
+        };
+        let expected_radius = 100.0_f32.hypot(50.0);
+        assert_eq!(*shape, RadialGradientShape::Ellipse);
+        assert_eq!(*extent, RadialGradientExtent::Explicit);
+        assert!((radius_x.length - expected_radius).abs() < 0.001);
+        assert_eq!(*radius_x, *radius_y);
+        assert_eq!(radius_x.fraction, 0.0);
+        assert_eq!(stops[1].position.unwrap().length, 0.0);
+        assert!((stops[1].position.unwrap().fraction - 25.0 / expected_radius).abs() < 0.0001);
+
+        surface
+            .update_layout_style(root, sized(100.0, 100.0))
+            .expect("resize style");
+        surface
+            .compute_layout(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
+            .expect("resized layout");
+        let PaintImage::RadialGradient {
+            radii: Some((resized_radius, _)),
+            stops: resized_stops,
+            ..
+        } = &surface.node(root).unwrap().background_layers()[0].image
+        else {
+            panic!("expected resized radial gradient")
+        };
+        let resized_expected = 50.0_f32.hypot(50.0);
+        assert!((resized_radius.length - resized_expected).abs() < 0.001);
+        assert!(
+            (resized_stops[1].position.unwrap().fraction - 25.0 / resized_expected).abs() < 0.0001
+        );
+    }
+
+    #[test]
+    fn radial_canonicalization_preserves_ellipse_aspect_ratio_and_circle_radius() {
+        let geometry = LayoutGeometry::from(LayoutRect {
+            width: 200.0,
+            height: 100.0,
+            ..LayoutRect::default()
+        });
+        let mut layers = vec![
+            radial_background(
+                RadialGradientShape::Ellipse,
+                RadialGradientExtent::FarthestCorner,
+                None,
+            ),
+            radial_background(
+                RadialGradientShape::Circle,
+                RadialGradientExtent::Explicit,
+                Some((absolute_length(20.0), absolute_length(20.0))),
+            ),
+        ];
+        let sources = radial_background_sources(&layers);
+        canonicalize_radial_backgrounds(&mut layers, &sources, geometry, None);
+
+        let PaintImage::RadialGradient {
+            radii: Some((ellipse_x, ellipse_y)),
+            ..
+        } = layers[0].image
+        else {
+            panic!("expected ellipse")
+        };
+        assert!((ellipse_x.length - 100.0 * 2.0_f32.sqrt()).abs() < 0.001);
+        assert!((ellipse_y.length - 50.0 * 2.0_f32.sqrt()).abs() < 0.001);
+        let PaintImage::RadialGradient {
+            shape,
+            radii: Some((circle_x, circle_y)),
+            ..
+        } = layers[1].image
+        else {
+            panic!("expected circle")
+        };
+        assert_eq!(shape, RadialGradientShape::Ellipse);
+        assert_eq!(circle_x, absolute_length(20.0));
+        assert_eq!(circle_y, absolute_length(20.0));
     }
 
     fn zero_measure(_: NodeId, _: MeasureRequest) -> LayoutSize {

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -974,7 +974,12 @@ impl SurfaceEngine {
                 .iter()
                 .filter_map(|(node, geometry)| {
                     let sources = self.radial_backgrounds.get(node)?;
-                    let mut layers = self.scene.node(*node)?.background_layers().to_vec();
+                    let mut layers = self
+                        .scene
+                        .node(*node)
+                        .expect("radial background owners remain live")
+                        .background_layers()
+                        .to_vec();
                     canonicalize_radial_backgrounds(
                         &mut layers,
                         sources,
@@ -1193,12 +1198,37 @@ mod tests {
         }
     }
 
+    type RadialParts<'a> = (
+        RadialGradientShape,
+        RadialGradientExtent,
+        Option<(PaintLengthPercentage, PaintLengthPercentage)>,
+        &'a [whisker_protocol::GradientStop],
+    );
+
+    fn radial_parts(image: &PaintImage) -> Option<RadialParts<'_>> {
+        match image {
+            PaintImage::RadialGradient {
+                shape,
+                extent,
+                radii,
+                stops,
+                ..
+            } => Some((*shape, *extent, *radii, stops)),
+            _ => None,
+        }
+    }
+
     #[test]
     fn layout_canonicalizes_radial_keyword_geometry_and_absolute_stops() {
+        assert!(radial_parts(&PaintImage::None).is_none());
         let mut surface = SurfaceEngine::new(surface_id());
         let root = surface
             .create_node(element_type(), sized(200.0, 100.0))
             .expect("root");
+        let plain_child = surface
+            .create_node(element_type(), sized(10.0, 10.0))
+            .expect("plain child");
+        surface.insert_child(root, plain_child, 0).expect("insert");
         surface
             .set_background_layers(
                 root,
@@ -1212,22 +1242,26 @@ mod tests {
         surface
             .compute_layout(root, LayoutSize::new(200.0, 100.0), &mut zero_measure)
             .expect("layout");
+        surface
+            .set_background_layers(
+                root,
+                vec![radial_background(
+                    RadialGradientShape::Circle,
+                    RadialGradientExtent::FarthestCorner,
+                    None,
+                )],
+            )
+            .expect("post-layout background");
 
-        let PaintImage::RadialGradient {
-            shape,
-            extent,
-            radii: Some((radius_x, radius_y)),
-            stops,
-            ..
-        } = &surface.node(root).unwrap().background_layers()[0].image
-        else {
-            panic!("expected canonical radial gradient")
-        };
+        let (shape, extent, radii, stops) =
+            radial_parts(&surface.node(root).unwrap().background_layers()[0].image)
+                .expect("canonical radial gradient");
+        let (radius_x, radius_y) = radii.expect("canonical radii");
         let expected_radius = 100.0_f32.hypot(50.0);
-        assert_eq!(*shape, RadialGradientShape::Ellipse);
-        assert_eq!(*extent, RadialGradientExtent::Explicit);
+        assert_eq!(shape, RadialGradientShape::Ellipse);
+        assert_eq!(extent, RadialGradientExtent::Explicit);
         assert!((radius_x.length - expected_radius).abs() < 0.001);
-        assert_eq!(*radius_x, *radius_y);
+        assert_eq!(radius_x, radius_y);
         assert_eq!(radius_x.fraction, 0.0);
         assert_eq!(stops[1].position.unwrap().length, 0.0);
         assert!((stops[1].position.unwrap().fraction - 25.0 / expected_radius).abs() < 0.0001);
@@ -1238,14 +1272,10 @@ mod tests {
         surface
             .compute_layout(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
             .expect("resized layout");
-        let PaintImage::RadialGradient {
-            radii: Some((resized_radius, _)),
-            stops: resized_stops,
-            ..
-        } = &surface.node(root).unwrap().background_layers()[0].image
-        else {
-            panic!("expected resized radial gradient")
-        };
+        let (_, _, resized_radii, resized_stops) =
+            radial_parts(&surface.node(root).unwrap().background_layers()[0].image)
+                .expect("resized radial gradient");
+        let (resized_radius, _) = resized_radii.expect("resized radii");
         let resized_expected = 50.0_f32.hypot(50.0);
         assert!((resized_radius.length - resized_expected).abs() < 0.001);
         assert!(
@@ -1275,23 +1305,12 @@ mod tests {
         let sources = radial_background_sources(&layers);
         canonicalize_radial_backgrounds(&mut layers, &sources, geometry, None);
 
-        let PaintImage::RadialGradient {
-            radii: Some((ellipse_x, ellipse_y)),
-            ..
-        } = layers[0].image
-        else {
-            panic!("expected ellipse")
-        };
+        let (_, _, ellipse_radii, _) = radial_parts(&layers[0].image).expect("ellipse");
+        let (ellipse_x, ellipse_y) = ellipse_radii.expect("ellipse radii");
         assert!((ellipse_x.length - 100.0 * 2.0_f32.sqrt()).abs() < 0.001);
         assert!((ellipse_y.length - 50.0 * 2.0_f32.sqrt()).abs() < 0.001);
-        let PaintImage::RadialGradient {
-            shape,
-            radii: Some((circle_x, circle_y)),
-            ..
-        } = layers[1].image
-        else {
-            panic!("expected circle")
-        };
+        let (shape, _, circle_radii, _) = radial_parts(&layers[1].image).expect("circle");
+        let (circle_x, circle_y) = circle_radii.expect("circle radii");
         assert_eq!(shape, RadialGradientShape::Ellipse);
         assert_eq!(circle_x, absolute_length(20.0));
         assert_eq!(circle_y, absolute_length(20.0));

--- a/crates/whisker-engine/src/text.rs
+++ b/crates/whisker-engine/src/text.rs
@@ -134,6 +134,13 @@ pub fn lower_plain_text(input: &PlainTextInput, style: &ComputedStyle) -> Lowere
                 logical_pixels: 0.0,
                 percentage: value.get(),
             },
+            ComputedTextIndent::LengthPercentage {
+                logical_pixels,
+                percentage,
+            } => MeasureTextIndent {
+                logical_pixels: logical_pixels.get(),
+                percentage: percentage.get(),
+            },
         },
         wrap: match style.white_space() {
             WhiteSpaceValue::Normal => MeasureTextWrap::Wrap,
@@ -250,10 +257,10 @@ mod tests {
     use super::*;
     use whisker_protocol::PaintColor;
     use whisker_style::{
-        ColorValue, FontFeatureValue, FontOpticalSizingValue, FontVariationValue, FontWeightValue,
-        LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, OpenTypeTagValue,
-        SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber, StyleProperty, StyleValue,
-        TextDecorationValue, TextShadowValue, resolve_style,
+        CalcExpression, ColorValue, FontFeatureValue, FontOpticalSizingValue, FontVariationValue,
+        FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
+        OpenTypeTagValue, SpecifiedStyle, StyleDeclaration, StyleEnvironment, StyleNumber,
+        StyleProperty, StyleValue, TextDecorationValue, TextShadowValue, resolve_style,
     };
 
     fn resolved(declarations: Vec<StyleDeclaration>) -> whisker_style::ResolvedNodeStyle {
@@ -514,6 +521,26 @@ mod tests {
         let percentage = lower_plain_text(&input, percentage.computed());
         assert_eq!(percentage.content().payload.indent.logical_pixels, 0.0);
         assert_eq!(percentage.content().payload.indent.percentage, 15.0);
+
+        let calculated = resolved(vec![StyleDeclaration::new(
+            StyleProperty::TextIndent,
+            StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                CalcExpression::Add(
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Length(LengthValue::Dimension {
+                            value: StyleNumber::new(4.0),
+                            unit: LengthUnit::Px,
+                        }),
+                    ))),
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Percentage(StyleNumber::new(10.0)),
+                    ))),
+                ),
+            ))),
+        )]);
+        let calculated = lower_plain_text(&input, calculated.computed());
+        assert_eq!(calculated.content().payload.indent.logical_pixels, 4.0);
+        assert_eq!(calculated.content().payload.indent.percentage, 10.0);
     }
 
     #[test]

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -6,7 +6,11 @@
 
 #![warn(missing_docs)]
 
-use std::{collections::BTreeMap, error::Error, fmt};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    fmt,
+};
 
 use taffy::{
     AlignContent, AlignItems, AvailableSpace as TaffyAvailableSpace, BoxSizing,
@@ -507,7 +511,7 @@ impl LayoutTree {
                 .expect("retained surface and application roots");
             self.surface_child = Some(root);
         }
-        let mut invalid_measurement = None;
+        let mut invalid_measurements = BTreeSet::new();
         self.backend
             .compute_layout_with_measure(
                 self.surface_root,
@@ -530,7 +534,7 @@ impl LayoutTree {
                         },
                     );
                     if !measured.is_valid() {
-                        invalid_measurement.get_or_insert(node);
+                        invalid_measurements.insert(node);
                         Size::ZERO
                     } else {
                         Size {
@@ -541,10 +545,17 @@ impl LayoutTree {
                 },
             )
             .expect("retained backend root");
-        if let Some(node) = invalid_measurement {
-            self.backend
-                .mark_dirty(backend_root)
-                .expect("retained backend root");
+        if let Some(node) = invalid_measurements.first().copied() {
+            for invalid in invalid_measurements {
+                let backend = self
+                    .nodes
+                    .get(&invalid)
+                    .expect("measurement context belongs to a retained node")
+                    .backend;
+                self.backend
+                    .mark_dirty(backend)
+                    .expect("retained backend node");
+            }
             return Err(LayoutError::InvalidMeasurement(node));
         }
         let mut snapshot = LayoutSnapshot::default();
@@ -1627,6 +1638,43 @@ mod tests {
             .unwrap();
         assert_eq!(snapshot.get(root).unwrap().border_box.width, 100.0);
         assert_eq!(snapshot.get(root).unwrap().border_box.height, 0.0);
+    }
+
+    #[test]
+    fn invalid_nested_measurement_is_retried_on_the_measured_leaf() {
+        use std::cell::Cell;
+
+        let root = id(1);
+        let child = id(2);
+        let mut tree = LayoutTree::default();
+        tree.create_node(root, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.create_node(child, ComputedLayoutStyle::default())
+            .unwrap();
+        tree.set_measurable(child, true).unwrap();
+        tree.set_children(root, &[child]).unwrap();
+
+        let invalid_calls = Cell::new(0);
+        assert_eq!(
+            tree.compute(root, LayoutSize::new(100.0, 100.0), &mut |node, _| {
+                assert_eq!(node, child);
+                invalid_calls.set(invalid_calls.get() + 1);
+                LayoutSize::new(f32::NAN, 1.0)
+            }),
+            Err(LayoutError::InvalidMeasurement(child))
+        );
+        assert!(invalid_calls.get() > 0);
+
+        let retry_calls = Cell::new(0);
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 100.0), &mut |node, _| {
+                assert_eq!(node, child);
+                retry_calls.set(retry_calls.get() + 1);
+                LayoutSize::new(12.0, 8.0)
+            })
+            .unwrap();
+        assert!(retry_calls.get() > 0);
+        assert_eq!(snapshot.get(child).unwrap().border_box.height, 8.0);
     }
 
     #[test]

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -290,12 +290,16 @@ impl LayoutTree {
         };
         let backend_node = retained.backend;
         let parent = retained.parent;
+        let display_changed = retained.style.display != style.display;
         self.backend
             .set_style(backend_node, converted)
             .expect("retained backend node");
         self.nodes.get_mut(&node).expect("checked above").style = style;
         if let Some(parent) = parent {
             self.sync_backend_children(parent);
+        }
+        if display_changed {
+            self.sync_backend_children(node);
         }
         Ok(impact)
     }
@@ -576,12 +580,24 @@ impl LayoutTree {
     fn sync_backend_children(&mut self, parent: NodeId) {
         let retained = self.nodes.get(&parent).expect("retained parent");
         let backend_parent = retained.backend;
-        let mut children = retained.children.clone();
-        children.sort_by_key(|child| self.nodes.get(child).expect("retained child").style.order);
-        let backend_children = children
-            .iter()
-            .map(|child| self.nodes.get(child).expect("retained child").backend)
-            .collect::<Vec<_>>();
+        let backend_children = if matches!(
+            retained.style.display,
+            DisplayValue::Flex | DisplayValue::Grid
+        ) {
+            let mut children = retained.children.clone();
+            children
+                .sort_by_key(|child| self.nodes.get(child).expect("retained child").style.order);
+            children
+                .iter()
+                .map(|child| self.nodes.get(child).expect("retained child").backend)
+                .collect::<Vec<_>>()
+        } else {
+            retained
+                .children
+                .iter()
+                .map(|child| self.nodes.get(child).expect("retained child").backend)
+                .collect::<Vec<_>>()
+        };
         self.backend
             .set_children(backend_parent, &backend_children)
             .expect("retained backend nodes");
@@ -1590,6 +1606,87 @@ mod tests {
 
         let cloned = tree.clone();
         assert_eq!(cloned.len(), tree.len());
+    }
+
+    #[test]
+    fn block_children_ignore_order_and_keep_source_order() {
+        let root = id(1);
+        let first = id(2);
+        let second = id(3);
+        let mut tree = LayoutTree::new();
+        tree.create_node(
+            root,
+            ComputedLayoutStyle {
+                display: DisplayValue::Block,
+                ..sized(100.0, 40.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            first,
+            ComputedLayoutStyle {
+                order: 1,
+                ..sized(10.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            second,
+            ComputedLayoutStyle {
+                order: -1,
+                ..sized(10.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[first, second]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 40.0), &mut zero_measure)
+            .unwrap();
+
+        assert_eq!(snapshot.get(first).unwrap().border_box.y, 0.0);
+        assert_eq!(snapshot.get(second).unwrap().border_box.y, 10.0);
+    }
+
+    #[test]
+    fn changing_a_container_to_block_restores_source_order() {
+        let root = id(1);
+        let first = id(2);
+        let second = id(3);
+        let mut tree = LayoutTree::new();
+        tree.create_node(root, sized(100.0, 40.0)).unwrap();
+        tree.create_node(
+            first,
+            ComputedLayoutStyle {
+                order: 1,
+                ..sized(10.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(
+            second,
+            ComputedLayoutStyle {
+                order: -1,
+                ..sized(10.0, 10.0)
+            },
+        )
+        .unwrap();
+        tree.set_children(root, &[first, second]).unwrap();
+
+        tree.update_style(
+            root,
+            ComputedLayoutStyle {
+                display: DisplayValue::Block,
+                ..sized(100.0, 40.0)
+            },
+        )
+        .unwrap();
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 40.0), &mut zero_measure)
+            .unwrap();
+
+        assert_eq!(snapshot.get(first).unwrap().border_box.y, 0.0);
+        assert_eq!(snapshot.get(second).unwrap().border_box.y, 10.0);
     }
 
     #[test]

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -306,9 +306,17 @@ impl RenderCapabilities {
     /// Returns how the Host implements a feature; omitted features are unsupported.
     pub fn support(&self, capability: RenderCapability) -> CapabilitySupport {
         let bit = capability.mask();
+        let background_subset = is_background_layer_subset(capability);
         if self.native & bit != 0 {
             CapabilitySupport::Native
         } else if self.emulated & bit != 0 {
+            CapabilitySupport::Emulated
+        } else if background_subset && self.native & RenderCapability::BackgroundLayers.mask() != 0
+        {
+            CapabilitySupport::Native
+        } else if background_subset
+            && self.emulated & RenderCapability::BackgroundLayers.mask() != 0
+        {
             CapabilitySupport::Emulated
         } else {
             CapabilitySupport::Unsupported
@@ -331,6 +339,18 @@ impl RenderCapabilities {
         }
         None
     }
+}
+
+const fn is_background_layer_subset(capability: RenderCapability) -> bool {
+    matches!(
+        capability,
+        RenderCapability::LinearGradients
+            | RenderCapability::RadialGradients
+            | RenderCapability::ConicGradients
+            | RenderCapability::BackgroundGeometry
+            | RenderCapability::BackgroundLayerStacking
+            | RenderCapability::BackgroundImageResources
+    )
 }
 
 impl FramePacket {
@@ -866,6 +886,65 @@ mod tests {
             }])
             .required_capabilities()
             .is_empty()
+        );
+    }
+
+    #[test]
+    fn complete_background_layer_support_satisfies_granular_requirements() {
+        let node = NodeId::new(1).unwrap();
+        let profile = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [CapabilityEntry {
+                capability: RenderCapability::BackgroundLayers,
+                support: CapabilitySupport::Native,
+            }],
+        )
+        .unwrap();
+        let packet = packet(vec![Operation::SetBackgroundLayers {
+            node,
+            layers: vec![explicit_no_repeat(basic_linear_layer())],
+        }]);
+
+        assert_eq!(
+            profile.support(RenderCapability::LinearGradients),
+            CapabilitySupport::Native
+        );
+        assert_eq!(
+            profile.support(RenderCapability::BackgroundGeometry),
+            CapabilitySupport::Native
+        );
+        assert_eq!(profile.first_unsupported(&packet), None);
+
+        let emulated = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [CapabilityEntry {
+                capability: RenderCapability::BackgroundLayers,
+                support: CapabilitySupport::Emulated,
+            }],
+        )
+        .unwrap();
+        assert_eq!(
+            emulated.support(RenderCapability::ConicGradients),
+            CapabilitySupport::Emulated
+        );
+
+        let granular_override = RenderCapabilities::new(
+            ProtocolVersion::CURRENT,
+            [
+                CapabilityEntry {
+                    capability: RenderCapability::BackgroundLayers,
+                    support: CapabilitySupport::Emulated,
+                },
+                CapabilityEntry {
+                    capability: RenderCapability::LinearGradients,
+                    support: CapabilitySupport::Native,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            granular_override.support(RenderCapability::LinearGradients),
+            CapabilitySupport::Native
         );
     }
 

--- a/crates/whisker-protocol/src/capability.rs
+++ b/crates/whisker-protocol/src/capability.rs
@@ -27,8 +27,8 @@ pub enum RenderCapability {
     /// One resolved, non-repeating linear-gradient background image using the
     /// initial layer geometry and explicit color-stop positions.
     LinearGradients = 8,
-    /// One resolved, non-repeating explicit radial-gradient background image
-    /// using the initial layer geometry and explicit color-stop positions.
+    /// One resolved, non-repeating elliptical radial-gradient background image
+    /// with explicit radii and explicit fractional color-stop positions.
     RadialGradients = 9,
     /// One resolved, non-repeating conic-gradient background image using the
     /// initial layer geometry and explicit fractional color-stop positions.

--- a/crates/whisker-protocol/src/id.rs
+++ b/crates/whisker-protocol/src/id.rs
@@ -28,7 +28,7 @@ define_id!(
 define_id!(
     NodeId,
     u64,
-    "Identifies one scene node within a scene epoch"
+    "Identifies one scene node; allocations strictly increase within a scene epoch"
 );
 define_id!(
     ElementTypeId,

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -225,19 +225,24 @@ impl SceneProjection {
             });
         }
 
-        let mut next = if packet.header.mode == FrameMode::Snapshot {
-            Self::new(self.surface)
+        if packet.header.mode == FrameMode::Snapshot {
+            let mut next = Self::new(self.surface);
+            next.scene_epoch = Some(packet.header.scene_epoch);
+            for operation in &packet.operations {
+                next.apply_operation(operation)?;
+            }
+            next.revision = packet.header.target_revision;
+            *self = next;
         } else {
-            self.clone()
-        };
-        next.scene_epoch = Some(packet.header.scene_epoch);
-
-        for operation in &packet.operations {
-            next.apply_operation(operation)?;
+            let mut transaction = ProjectionTransaction::new(self);
+            for operation in &packet.operations {
+                if let Err(error) = transaction.apply_operation(operation) {
+                    transaction.rollback();
+                    return Err(error);
+                }
+            }
+            transaction.commit(packet.header.scene_epoch, packet.header.target_revision);
         }
-
-        next.revision = packet.header.target_revision;
-        *self = next;
         Ok(ApplyResult::Accepted {
             revision: self.revision,
         })
@@ -515,6 +520,93 @@ impl SceneProjection {
     }
 }
 
+struct ProjectionTransaction<'a> {
+    projection: &'a mut SceneProjection,
+    original_nodes: HashMap<NodeId, Option<NodeProjection>>,
+    newly_allocated: Vec<NodeId>,
+}
+
+impl<'a> ProjectionTransaction<'a> {
+    fn new(projection: &'a mut SceneProjection) -> Self {
+        Self {
+            projection,
+            original_nodes: HashMap::new(),
+            newly_allocated: Vec::new(),
+        }
+    }
+
+    fn apply_operation(&mut self, operation: &Operation) -> Result<(), ValidationError> {
+        match operation {
+            Operation::CreateNode { node, .. } => {
+                if self.projection.allocated_nodes.contains(node) {
+                    return Err(ValidationError::DuplicateNode { node: *node });
+                }
+                self.remember(*node);
+                self.projection.apply_operation(operation)?;
+                self.newly_allocated.push(*node);
+            }
+            Operation::DeleteNode { node } => {
+                self.remember_subtree(*node)?;
+                self.projection.apply_operation(operation)?;
+            }
+            Operation::InsertChild { parent, child, .. }
+            | Operation::RemoveChild { parent, child } => {
+                self.remember(*parent);
+                self.remember(*child);
+                self.projection.apply_operation(operation)?;
+            }
+            Operation::MoveChild { parent, .. } => {
+                self.remember(*parent);
+                self.projection.apply_operation(operation)?;
+            }
+            _ => self.projection.apply_operation(operation)?,
+        }
+        Ok(())
+    }
+
+    fn remember(&mut self, node: NodeId) {
+        self.original_nodes
+            .entry(node)
+            .or_insert_with(|| self.projection.nodes.get(&node).cloned());
+    }
+
+    fn remember_subtree(&mut self, node: NodeId) -> Result<(), ValidationError> {
+        let state = self.projection.require_node(node)?;
+        let parent = state.parent;
+        let mut pending = vec![node];
+        if let Some(parent) = parent {
+            self.remember(parent);
+        }
+        while let Some(current) = pending.pop() {
+            let children = self.projection.require_node(current)?.children.clone();
+            self.remember(current);
+            pending.extend(children);
+        }
+        Ok(())
+    }
+
+    fn rollback(self) {
+        for (node, original) in self.original_nodes {
+            match original {
+                Some(state) => {
+                    self.projection.nodes.insert(node, state);
+                }
+                None => {
+                    self.projection.nodes.remove(&node);
+                }
+            }
+        }
+        for node in self.newly_allocated {
+            self.projection.allocated_nodes.remove(&node);
+        }
+    }
+
+    fn commit(self, scene_epoch: u32, revision: u64) {
+        self.projection.scene_epoch = Some(scene_epoch);
+        self.projection.revision = revision;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -707,6 +799,24 @@ mod tests {
     }
 
     #[test]
+    fn non_structural_delta_does_not_rebuild_retained_structure() {
+        let (mut scene, root, _) = initial_tree();
+        let before = scene.node(root).expect("root") as *const NodeProjection;
+
+        apply_next(
+            &mut scene,
+            vec![Operation::SetOpacity {
+                node: root,
+                opacity: 0.5,
+            }],
+        )
+        .expect("valid non-structural delta");
+
+        let after = scene.node(root).expect("root") as *const NodeProjection;
+        assert_eq!(before, after);
+    }
+
+    #[test]
     fn malformed_operation_rolls_back_the_complete_packet() {
         let (mut scene, root, child) = initial_tree();
         let new_child = node(3);
@@ -744,6 +854,16 @@ mod tests {
         assert_eq!(scene.node_count(), 2);
         assert_eq!(scene.node(root).expect("root").children(), &[child]);
         assert_eq!(scene.node(new_child), None);
+
+        apply_next(
+            &mut scene,
+            vec![Operation::CreateNode {
+                node: new_child,
+                element_type: element_type(),
+            }],
+        )
+        .expect("a rejected transaction must not retire newly allocated IDs");
+        assert!(scene.node(new_child).is_some());
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -213,6 +213,11 @@ impl SceneProjection {
         self.nodes.get(&node)
     }
 
+    #[cfg(test)]
+    fn allocation_tracking_entries(&self) -> usize {
+        self.allocated_nodes.len()
+    }
+
     /// Validates and atomically applies a packet.
     ///
     /// Revision or epoch drift on a delta returns [`ApplyResult::NeedSnapshot`]
@@ -1054,6 +1059,24 @@ mod tests {
         ));
 
         assert_eq!(result, Ok(ApplyResult::Accepted { revision: 2 }));
+    }
+
+    #[test]
+    fn retired_node_tracking_is_constant_space() {
+        let (mut scene, _, _) = initial_tree();
+        let mut operations = Vec::new();
+        for raw in 3..259 {
+            let retired = node(raw);
+            operations.push(Operation::CreateNode {
+                node: retired,
+                element_type: element_type(),
+            });
+            operations.push(Operation::DeleteNode { node: retired });
+        }
+        apply_next(&mut scene, operations).expect("monotonic allocation sequence");
+
+        assert_eq!(scene.node_count(), 2);
+        assert_eq!(scene.allocation_tracking_entries(), 1);
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -1,6 +1,6 @@
 //! Transactional reference validation for semantic frame packets.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
@@ -88,10 +88,12 @@ pub enum ValidationError {
         /// Reused scene epoch.
         epoch: u32,
     },
-    /// Node identifier was created more than once in one epoch.
-    DuplicateNode {
-        /// Duplicate identifier.
-        node: NodeId,
+    /// A created node identifier did not strictly advance within its epoch.
+    NodeIdDidNotAdvance {
+        /// Highest identifier accepted in this epoch.
+        previous: NodeId,
+        /// Non-advancing identifier received next.
+        received: NodeId,
     },
     /// An operation referenced a node that does not exist at that point.
     UnknownNode {
@@ -173,7 +175,7 @@ pub struct SceneProjection {
     scene_epoch: Option<u32>,
     revision: u64,
     nodes: HashMap<NodeId, NodeProjection>,
-    allocated_nodes: HashSet<NodeId>,
+    last_allocated_node: Option<NodeId>,
 }
 
 impl SceneProjection {
@@ -184,7 +186,7 @@ impl SceneProjection {
             scene_epoch: None,
             revision: 0,
             nodes: HashMap::new(),
-            allocated_nodes: HashSet::new(),
+            last_allocated_node: None,
         }
     }
 
@@ -215,7 +217,7 @@ impl SceneProjection {
 
     #[cfg(test)]
     fn allocation_tracking_entries(&self) -> usize {
-        self.allocated_nodes.len()
+        usize::from(self.last_allocated_node.is_some())
     }
 
     /// Validates and atomically applies a packet.
@@ -301,9 +303,15 @@ impl SceneProjection {
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), ValidationError> {
         match operation {
             Operation::CreateNode { node, element_type } => {
-                if !self.allocated_nodes.insert(*node) {
-                    return Err(ValidationError::DuplicateNode { node: *node });
+                if let Some(previous) = self.last_allocated_node
+                    && *node <= previous
+                {
+                    return Err(ValidationError::NodeIdDidNotAdvance {
+                        previous,
+                        received: *node,
+                    });
                 }
+                self.last_allocated_node = Some(*node);
                 self.nodes.insert(
                     *node,
                     NodeProjection {
@@ -549,15 +557,16 @@ impl SceneProjection {
 struct ProjectionTransaction<'a> {
     projection: &'a mut SceneProjection,
     original_nodes: HashMap<NodeId, Option<NodeProjection>>,
-    newly_allocated: Vec<NodeId>,
+    initial_last_allocated_node: Option<NodeId>,
 }
 
 impl<'a> ProjectionTransaction<'a> {
     fn new(projection: &'a mut SceneProjection) -> Self {
+        let initial_last_allocated_node = projection.last_allocated_node;
         Self {
             projection,
             original_nodes: HashMap::new(),
-            newly_allocated: Vec::new(),
+            initial_last_allocated_node,
         }
     }
 
@@ -566,7 +575,6 @@ impl<'a> ProjectionTransaction<'a> {
             Operation::CreateNode { node, .. } => {
                 self.remember(*node);
                 self.projection.apply_operation(operation)?;
-                self.newly_allocated.push(*node);
             }
             Operation::DeleteNode { node } => {
                 self.remember_subtree(*node)?;
@@ -631,9 +639,7 @@ impl<'a> ProjectionTransaction<'a> {
                 }
             }
         }
-        for node in self.newly_allocated {
-            self.projection.allocated_nodes.remove(&node);
-        }
+        self.projection.last_allocated_node = self.initial_last_allocated_node;
     }
 
     fn commit(self, scene_epoch: u32, revision: u64) {
@@ -1008,7 +1014,13 @@ mod tests {
                 }],
             ))
             .expect_err("retired ID must remain unavailable");
-        assert_eq!(error, ValidationError::DuplicateNode { node: child });
+        assert_eq!(
+            error,
+            ValidationError::NodeIdDidNotAdvance {
+                previous: child,
+                received: child,
+            }
+        );
         assert_eq!(scene.revision(), 2);
         assert!(scene.node(child).is_none());
     }
@@ -1077,6 +1089,39 @@ mod tests {
 
         assert_eq!(scene.node_count(), 2);
         assert_eq!(scene.allocation_tracking_entries(), 1);
+    }
+
+    #[test]
+    fn node_allocations_must_strictly_increase_within_an_epoch() {
+        let mut scene = SceneProjection::new(surface());
+        let error = scene
+            .apply(&packet(
+                FrameMode::Snapshot,
+                1,
+                0,
+                1,
+                vec![
+                    Operation::CreateNode {
+                        node: node(2),
+                        element_type: element_type(),
+                    },
+                    Operation::CreateNode {
+                        node: node(1),
+                        element_type: element_type(),
+                    },
+                ],
+            ))
+            .expect_err("out-of-order node IDs must be rejected");
+
+        assert_eq!(
+            error,
+            ValidationError::NodeIdDidNotAdvance {
+                previous: node(2),
+                received: node(1),
+            }
+        );
+        assert_eq!(scene.revision(), 0);
+        assert_eq!(scene.node_count(), 0);
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -147,6 +147,11 @@ pub enum ValidationError {
         /// Stable invalid-input category.
         error: TextContentError,
     },
+    /// A property or command payload contained the reserved error variant.
+    InvalidDataValue {
+        /// Target node of the rejected operation.
+        node: NodeId,
+    },
 }
 
 impl fmt::Display for ValidationError {
@@ -363,14 +368,18 @@ impl SceneProjection {
                     .validate()
                     .map_err(|error| ValidationError::InvalidText { error })?;
             }
-            Operation::InvokeCommand { node, .. } => {
+            Operation::InvokeCommand {
+                node, arguments, ..
+            } => {
                 self.require_node(*node)?;
+                if !arguments.is_data() {
+                    return Err(ValidationError::InvalidDataValue { node: *node });
+                }
             }
             Operation::SetClip { node, .. }
             | Operation::SetVisibility { node, .. }
             | Operation::SetZOrder { node, .. }
             | Operation::SetAccessibility { node, .. }
-            | Operation::SetProperty { node, .. }
             | Operation::ClearProperty { node, .. }
             | Operation::SetEventMask { node, .. }
             | Operation::SetHitTest { node, .. }
@@ -378,6 +387,12 @@ impl SceneProjection {
             | Operation::SetPointerCapture { node, .. }
             | Operation::ReleasePointerCapture { node, .. } => {
                 self.require_node(*node)?;
+            }
+            Operation::SetProperty { node, value, .. } => {
+                self.require_node(*node)?;
+                if !value.is_data() {
+                    return Err(ValidationError::InvalidDataValue { node: *node });
+                }
             }
         }
         Ok(())
@@ -863,6 +878,48 @@ mod tests {
         )
         .expect("a rejected transaction must not retire newly allocated IDs");
         assert!(scene.node(new_child).is_some());
+    }
+
+    #[test]
+    fn property_and_command_payloads_reject_error_values_recursively() {
+        let property = PropertyId::new(1).expect("test property");
+        let command = CommandId::new(1).expect("test command");
+        let invalid_values = [
+            WhiskerValue::Error("top-level failure".to_owned()),
+            WhiskerValue::Array(vec![WhiskerValue::Error("nested failure".to_owned())]),
+            WhiskerValue::map([("nested", WhiskerValue::Error("nested failure".to_owned()))]),
+        ];
+
+        for value in invalid_values {
+            let (mut scene, root, _) = initial_tree();
+            let property_error = apply_next(
+                &mut scene,
+                vec![Operation::SetProperty {
+                    node: root,
+                    property,
+                    value: value.clone(),
+                }],
+            );
+            assert_eq!(
+                property_error,
+                Err(ValidationError::InvalidDataValue { node: root })
+            );
+            assert_eq!(scene.revision(), 1);
+
+            let command_error = apply_next(
+                &mut scene,
+                vec![Operation::InvokeCommand {
+                    node: root,
+                    command,
+                    arguments: value,
+                }],
+            );
+            assert_eq!(
+                command_error,
+                Err(ValidationError::InvalidDataValue { node: root })
+            );
+            assert_eq!(scene.revision(), 1);
+        }
     }
 
     #[test]

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -1048,7 +1048,10 @@ mod tests {
 
         assert_eq!(
             error,
-            Err(ValidationError::DuplicateNode { node: duplicate })
+            Err(ValidationError::NodeIdDidNotAdvance {
+                previous: duplicate,
+                received: duplicate,
+            })
         );
     }
 

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -507,7 +507,6 @@ impl SceneProjection {
                 .children;
             siblings.retain(|candidate| *candidate != node);
         }
-
         let mut pending = vec![node];
         while let Some(current) = pending.pop() {
             let state = self

--- a/crates/whisker-protocol/src/validation.rs
+++ b/crates/whisker-protocol/src/validation.rs
@@ -308,7 +308,7 @@ impl SceneProjection {
                     },
                 );
             }
-            Operation::DeleteNode { node } => self.delete_subtree(*node)?,
+            Operation::DeleteNode { node } => self.delete_subtree(*node),
             Operation::InsertChild {
                 parent,
                 child,
@@ -512,8 +512,16 @@ impl SceneProjection {
         false
     }
 
-    fn delete_subtree(&mut self, node: NodeId) -> Result<(), ValidationError> {
-        let state = self.require_node(node)?.clone();
+    fn delete_subtree(&mut self, node: NodeId) {
+        let state = self
+            .nodes
+            .get(&node)
+            .expect("frame validation guarantees the deleted node exists")
+            .clone();
+        self.delete_known_subtree(node, state);
+    }
+
+    fn delete_known_subtree(&mut self, node: NodeId, state: NodeProjection) {
         if let Some(parent) = state.parent {
             let siblings = &mut self
                 .nodes
@@ -530,7 +538,6 @@ impl SceneProjection {
                 .expect("subtree children exist while parent exists");
             pending.extend(state.children);
         }
-        Ok(())
     }
 }
 
@@ -552,16 +559,19 @@ impl<'a> ProjectionTransaction<'a> {
     fn apply_operation(&mut self, operation: &Operation) -> Result<(), ValidationError> {
         match operation {
             Operation::CreateNode { node, .. } => {
-                if self.projection.allocated_nodes.contains(node) {
-                    return Err(ValidationError::DuplicateNode { node: *node });
-                }
                 self.remember(*node);
                 self.projection.apply_operation(operation)?;
                 self.newly_allocated.push(*node);
             }
             Operation::DeleteNode { node } => {
                 self.remember_subtree(*node)?;
-                self.projection.apply_operation(operation)?;
+                let state = self
+                    .projection
+                    .nodes
+                    .get(node)
+                    .expect("remembered subtree root remains present")
+                    .clone();
+                self.projection.delete_known_subtree(*node, state);
             }
             Operation::InsertChild { parent, child, .. }
             | Operation::RemoveChild { parent, child } => {
@@ -592,7 +602,13 @@ impl<'a> ProjectionTransaction<'a> {
             self.remember(parent);
         }
         while let Some(current) = pending.pop() {
-            let children = self.projection.require_node(current)?.children.clone();
+            let children = self
+                .projection
+                .nodes
+                .get(&current)
+                .expect("retained child exists while its parent exists")
+                .children
+                .clone();
             self.remember(current);
             pending.extend(children);
         }
@@ -884,13 +900,7 @@ mod tests {
     fn property_and_command_payloads_reject_error_values_recursively() {
         let property = PropertyId::new(1).expect("test property");
         let command = CommandId::new(1).expect("test command");
-        let invalid_values = [
-            WhiskerValue::Error("top-level failure".to_owned()),
-            WhiskerValue::Array(vec![WhiskerValue::Error("nested failure".to_owned())]),
-            WhiskerValue::map([("nested", WhiskerValue::Error("nested failure".to_owned()))]),
-        ];
-
-        for value in invalid_values {
+        fn check_invalid(property: PropertyId, command: CommandId, value: WhiskerValue) {
             let (mut scene, root, _) = initial_tree();
             let property_error = apply_next(
                 &mut scene,
@@ -920,6 +930,22 @@ mod tests {
             );
             assert_eq!(scene.revision(), 1);
         }
+
+        check_invalid(
+            property,
+            command,
+            WhiskerValue::Error("top-level failure".to_owned()),
+        );
+        check_invalid(
+            property,
+            command,
+            WhiskerValue::Array(vec![WhiskerValue::Error("nested failure".to_owned())]),
+        );
+        check_invalid(
+            property,
+            command,
+            WhiskerValue::map([("nested", WhiskerValue::Error("nested failure".to_owned()))]),
+        );
     }
 
     #[test]
@@ -980,6 +1006,54 @@ mod tests {
         assert_eq!(error, ValidationError::DuplicateNode { node: child });
         assert_eq!(scene.revision(), 2);
         assert!(scene.node(child).is_none());
+    }
+
+    #[test]
+    fn replacement_snapshot_rejects_duplicate_node_creation_without_mutating_the_scene() {
+        let (mut scene, _, _) = initial_tree();
+        let duplicate = node(3);
+        let error = scene.apply(&packet(
+            FrameMode::Snapshot,
+            2,
+            0,
+            2,
+            vec![
+                Operation::CreateNode {
+                    node: duplicate,
+                    element_type: element_type(),
+                },
+                Operation::CreateNode {
+                    node: duplicate,
+                    element_type: element_type(),
+                },
+            ],
+        ));
+
+        assert_eq!(
+            error,
+            Err(ValidationError::DuplicateNode { node: duplicate })
+        );
+    }
+
+    #[test]
+    fn replacement_snapshot_can_create_and_delete_an_unattached_node() {
+        let (mut scene, _, _) = initial_tree();
+        let temporary = node(99);
+        let result = scene.apply(&packet(
+            FrameMode::Snapshot,
+            2,
+            0,
+            2,
+            vec![
+                Operation::CreateNode {
+                    node: temporary,
+                    element_type: element_type(),
+                },
+                Operation::DeleteNode { node: temporary },
+            ],
+        ));
+
+        assert_eq!(result, Ok(ApplyResult::Accepted { revision: 2 }));
     }
 
     #[test]

--- a/crates/whisker-style/src/layout.rs
+++ b/crates/whisker-style/src/layout.rs
@@ -476,7 +476,8 @@ pub(crate) fn resolve_layout_style(
         direction: inherited_direction,
         ..ComputedLayoutStyle::default()
     };
-    let declarations = LayoutDeclarations::from_specified(specified);
+    let resolved_declarations = specified.resolved();
+    let declarations = LayoutDeclarations::from_resolved(&resolved_declarations);
 
     style.display = copied(
         declarations.display,
@@ -596,67 +597,32 @@ pub(crate) fn resolve_layout_style(
         StyleProperty::MaxHeight,
     )?;
 
-    style.margin.top = resolve_optional_auto(
-        declarations.margin_top,
-        style.margin.top,
+    style.margin = resolve_margins(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::MarginTop,
     )?;
-    style.margin.right = resolve_optional_auto(
-        declarations.margin_right,
-        style.margin.right,
+    style.padding = resolve_paddings(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::MarginRight,
-    )?;
-    style.margin.bottom = resolve_optional_auto(
-        declarations.margin_bottom,
-        style.margin.bottom,
-        font_size,
-        environment,
-        StyleProperty::MarginBottom,
-    )?;
-    style.margin.left = resolve_optional_auto(
-        declarations.margin_left,
-        style.margin.left,
-        font_size,
-        environment,
-        StyleProperty::MarginLeft,
     )?;
 
-    style.padding.top = resolve_optional_length_percentage(
-        declarations.padding_top,
-        style.padding.top,
+    style.border = resolve_borders(
+        &resolved_declarations,
+        style.direction,
         font_size,
         environment,
-        StyleProperty::PaddingTop,
-    )?;
-    style.padding.right = resolve_optional_length_percentage(
-        declarations.padding_right,
-        style.padding.right,
-        font_size,
-        environment,
-        StyleProperty::PaddingRight,
-    )?;
-    style.padding.bottom = resolve_optional_length_percentage(
-        declarations.padding_bottom,
-        style.padding.bottom,
-        font_size,
-        environment,
-        StyleProperty::PaddingBottom,
-    )?;
-    style.padding.left = resolve_optional_length_percentage(
-        declarations.padding_left,
-        style.padding.left,
-        font_size,
-        environment,
-        StyleProperty::PaddingLeft,
     )?;
 
-    style.border = resolve_borders(specified, style.direction, font_size, environment)?;
-
-    style.inset = resolve_insets(specified, style.direction, font_size, environment)?;
+    style.inset = resolve_insets(
+        &resolved_declarations,
+        style.direction,
+        font_size,
+        environment,
+    )?;
 
     style.flex_direction = copied(
         declarations.flex_direction,

--- a/crates/whisker-style/src/layout/resolution.rs
+++ b/crates/whisker-style/src/layout/resolution.rs
@@ -274,13 +274,13 @@ pub(super) fn resolve_non_negative_length_percentage(
 }
 
 pub(super) fn resolve_insets(
-    specified: &SpecifiedStyle,
+    declarations: &[&crate::StyleDeclaration],
     direction: DirectionValue,
     font_size: f32,
     environment: StyleEnvironment,
 ) -> Result<Edges<ComputedLengthPercentageAuto>, StyleResolutionError> {
     let mut inset = Edges::all(ComputedLengthPercentageAuto::Auto);
-    for declaration in specified.resolved() {
+    for declaration in declarations {
         let (edge, property) = match declaration.property() {
             StyleProperty::Top => (&mut inset.top, StyleProperty::Top),
             StyleProperty::Right => (&mut inset.right, StyleProperty::Right),
@@ -312,14 +312,88 @@ pub(super) fn resolve_insets(
     Ok(inset)
 }
 
+pub(super) fn resolve_margins(
+    declarations: &[&crate::StyleDeclaration],
+    direction: DirectionValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+) -> Result<Edges<ComputedLengthPercentageAuto>, StyleResolutionError> {
+    let mut margin = Edges::all(ComputedLengthPercentageAuto::Value(
+        ComputedLengthPercentage::ZERO,
+    ));
+    for declaration in declarations {
+        let (edge, property) = match declaration.property() {
+            StyleProperty::MarginTop => (&mut margin.top, StyleProperty::MarginTop),
+            StyleProperty::MarginRight => (&mut margin.right, StyleProperty::MarginRight),
+            StyleProperty::MarginBottom => (&mut margin.bottom, StyleProperty::MarginBottom),
+            StyleProperty::MarginLeft => (&mut margin.left, StyleProperty::MarginLeft),
+            StyleProperty::MarginInlineStart if direction == DirectionValue::Ltr => {
+                (&mut margin.left, StyleProperty::MarginInlineStart)
+            }
+            StyleProperty::MarginInlineStart => {
+                (&mut margin.right, StyleProperty::MarginInlineStart)
+            }
+            StyleProperty::MarginInlineEnd if direction == DirectionValue::Ltr => {
+                (&mut margin.right, StyleProperty::MarginInlineEnd)
+            }
+            StyleProperty::MarginInlineEnd => (&mut margin.left, StyleProperty::MarginInlineEnd),
+            _ => continue,
+        };
+        *edge = resolve_optional_auto(
+            Some(declaration.value()),
+            *edge,
+            font_size,
+            environment,
+            property,
+        )?;
+    }
+    Ok(margin)
+}
+
+pub(super) fn resolve_paddings(
+    declarations: &[&crate::StyleDeclaration],
+    direction: DirectionValue,
+    font_size: f32,
+    environment: StyleEnvironment,
+) -> Result<Edges<ComputedLengthPercentage>, StyleResolutionError> {
+    let mut padding = Edges::all(ComputedLengthPercentage::ZERO);
+    for declaration in declarations {
+        let (edge, property) = match declaration.property() {
+            StyleProperty::PaddingTop => (&mut padding.top, StyleProperty::PaddingTop),
+            StyleProperty::PaddingRight => (&mut padding.right, StyleProperty::PaddingRight),
+            StyleProperty::PaddingBottom => (&mut padding.bottom, StyleProperty::PaddingBottom),
+            StyleProperty::PaddingLeft => (&mut padding.left, StyleProperty::PaddingLeft),
+            StyleProperty::PaddingInlineStart if direction == DirectionValue::Ltr => {
+                (&mut padding.left, StyleProperty::PaddingInlineStart)
+            }
+            StyleProperty::PaddingInlineStart => {
+                (&mut padding.right, StyleProperty::PaddingInlineStart)
+            }
+            StyleProperty::PaddingInlineEnd if direction == DirectionValue::Ltr => {
+                (&mut padding.right, StyleProperty::PaddingInlineEnd)
+            }
+            StyleProperty::PaddingInlineEnd => (&mut padding.left, StyleProperty::PaddingInlineEnd),
+            _ => continue,
+        };
+        *edge = resolve_optional_length_percentage(
+            Some(declaration.value()),
+            *edge,
+            font_size,
+            environment,
+            property,
+        )?;
+    }
+    Ok(padding)
+}
+
 pub(super) fn resolve_borders(
-    specified: &SpecifiedStyle,
+    declarations: &[&crate::StyleDeclaration],
     direction: DirectionValue,
     font_size: f32,
     environment: StyleEnvironment,
 ) -> Result<Edges<ComputedLengthPercentage>, StyleResolutionError> {
     let mut border = Edges::all(ComputedLengthPercentage::ZERO);
-    for declaration in specified.resolved() {
+    for declaration in declarations {
         let (edge, property) = match declaration.property() {
             StyleProperty::BorderTopWidth => (&mut border.top, StyleProperty::BorderTopWidth),
             StyleProperty::BorderRightWidth => (&mut border.right, StyleProperty::BorderRightWidth),
@@ -569,14 +643,6 @@ pub(super) struct LayoutDeclarations<'a> {
     pub(super) min_height: Option<&'a StyleValue>,
     pub(super) max_width: Option<&'a StyleValue>,
     pub(super) max_height: Option<&'a StyleValue>,
-    pub(super) margin_top: Option<&'a StyleValue>,
-    pub(super) margin_right: Option<&'a StyleValue>,
-    pub(super) margin_bottom: Option<&'a StyleValue>,
-    pub(super) margin_left: Option<&'a StyleValue>,
-    pub(super) padding_top: Option<&'a StyleValue>,
-    pub(super) padding_right: Option<&'a StyleValue>,
-    pub(super) padding_bottom: Option<&'a StyleValue>,
-    pub(super) padding_left: Option<&'a StyleValue>,
     pub(super) flex_direction: Option<&'a StyleValue>,
     pub(super) flex_wrap: Option<&'a StyleValue>,
     pub(super) flex_grow: Option<&'a StyleValue>,
@@ -605,9 +671,9 @@ pub(super) struct LayoutDeclarations<'a> {
 }
 
 impl<'a> LayoutDeclarations<'a> {
-    pub(super) fn from_specified(specified: &'a SpecifiedStyle) -> Self {
+    pub(super) fn from_resolved(declarations: &'a [&'a crate::StyleDeclaration]) -> Self {
         let mut values = Self::default();
-        for declaration in specified.resolved() {
+        for declaration in declarations {
             let slot = match declaration.property() {
                 StyleProperty::Display => &mut values.display,
                 StyleProperty::Float => &mut values.float,
@@ -623,14 +689,6 @@ impl<'a> LayoutDeclarations<'a> {
                 StyleProperty::MinHeight => &mut values.min_height,
                 StyleProperty::MaxWidth => &mut values.max_width,
                 StyleProperty::MaxHeight => &mut values.max_height,
-                StyleProperty::MarginTop => &mut values.margin_top,
-                StyleProperty::MarginRight => &mut values.margin_right,
-                StyleProperty::MarginBottom => &mut values.margin_bottom,
-                StyleProperty::MarginLeft => &mut values.margin_left,
-                StyleProperty::PaddingTop => &mut values.padding_top,
-                StyleProperty::PaddingRight => &mut values.padding_right,
-                StyleProperty::PaddingBottom => &mut values.padding_bottom,
-                StyleProperty::PaddingLeft => &mut values.padding_left,
                 StyleProperty::FlexDirection => &mut values.flex_direction,
                 StyleProperty::FlexWrap => &mut values.flex_wrap,
                 StyleProperty::FlexGrow => &mut values.flex_grow,

--- a/crates/whisker-style/src/layout/resolution.rs
+++ b/crates/whisker-style/src/layout/resolution.rs
@@ -257,22 +257,6 @@ pub(super) fn resolve_optional_length_percentage(
     }
 }
 
-pub(super) fn resolve_non_negative_length_percentage(
-    value: Option<&StyleValue>,
-    initial: ComputedLengthPercentage,
-    font_size: f32,
-    environment: StyleEnvironment,
-    property: StyleProperty,
-) -> Result<ComputedLengthPercentage, StyleResolutionError> {
-    let resolved =
-        resolve_optional_length_percentage(value, initial, font_size, environment, property)?;
-    if resolved.length() < 0.0 || resolved.fraction() < 0.0 {
-        Err(invalid(property))
-    } else {
-        Ok(resolved)
-    }
-}
-
 pub(super) fn resolve_insets(
     declarations: &[&crate::StyleDeclaration],
     direction: DirectionValue,
@@ -415,15 +399,45 @@ pub(super) fn resolve_borders(
             }
             _ => continue,
         };
-        *edge = resolve_non_negative_length_percentage(
-            Some(declaration.value()),
-            *edge,
-            font_size,
-            environment,
-            property,
-        )?;
+        let resolved = match declaration.value() {
+            StyleValue::Length(value) => resolve_affine(
+                &LengthPercentageValue::Length(*value),
+                font_size,
+                environment,
+                property,
+            )?,
+            StyleValue::LengthPercentage(value) if is_length_only(value) => {
+                resolve_affine(value, font_size, environment, property)?
+            }
+            _ => return Err(invalid(property)),
+        };
+        if resolved.length() < 0.0 {
+            return Err(invalid(property));
+        }
+        *edge = resolved;
     }
     Ok(border)
+}
+
+fn is_length_only(value: &LengthPercentageValue) -> bool {
+    match value {
+        LengthPercentageValue::Length(_) => true,
+        LengthPercentageValue::Percentage(_) => false,
+        LengthPercentageValue::Calc(expression) => calc_is_length_only(expression),
+    }
+}
+
+fn calc_is_length_only(expression: &CalcExpression) -> bool {
+    match expression {
+        CalcExpression::Value(value) => is_length_only(value),
+        CalcExpression::Number(_) | CalcExpression::Variable(_) => true,
+        CalcExpression::Add(left, right)
+        | CalcExpression::Sub(left, right)
+        | CalcExpression::Mul(left, right)
+        | CalcExpression::Div(left, right) => {
+            calc_is_length_only(left) && calc_is_length_only(right)
+        }
+    }
 }
 
 pub(super) fn resolve_non_negative_number(

--- a/crates/whisker-style/src/layout/resolution.rs
+++ b/crates/whisker-style/src/layout/resolution.rs
@@ -427,7 +427,7 @@ fn is_length_only(value: &LengthPercentageValue) -> bool {
     }
 }
 
-fn calc_is_length_only(expression: &CalcExpression) -> bool {
+pub(super) fn calc_is_length_only(expression: &CalcExpression) -> bool {
     match expression {
         CalcExpression::Value(value) => is_length_only(value),
         CalcExpression::Number(_) | CalcExpression::Variable(_) => true,

--- a/crates/whisker-style/src/layout/tests.rs
+++ b/crates/whisker-style/src/layout/tests.rs
@@ -68,6 +68,70 @@ fn empty_style_uses_the_documented_layout_initials() {
 }
 
 #[test]
+fn optional_auto_preserves_the_supplied_initial_when_unspecified() {
+    let initial = ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(3.0, 0.25));
+    assert_eq!(
+        resolve_optional_auto(
+            None,
+            initial,
+            20.0,
+            StyleEnvironment::default(),
+            StyleProperty::MarginTop,
+        )
+        .unwrap(),
+        initial
+    );
+}
+
+#[test]
+fn border_width_accepts_length_values_and_classifies_calc_expression_shapes() {
+    let style = resolve(&declaration(
+        StyleProperty::BorderTopWidth,
+        StyleValue::Length(length(2.0, LengthUnit::Em)),
+    ))
+    .unwrap();
+    assert_eq!(style.border.top.length(), 40.0);
+    assert_eq!(
+        resolve(&declaration(
+            StyleProperty::BorderTopWidth,
+            StyleValue::Length(length(f32::INFINITY, LengthUnit::Em)),
+        ))
+        .unwrap_err(),
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::BorderTopWidth)
+    );
+    assert_eq!(
+        resolve(&declaration(
+            StyleProperty::BorderTopWidth,
+            StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                CalcExpression::Value(Box::new(LengthPercentageValue::Length(length(
+                    f32::INFINITY,
+                    LengthUnit::Em,
+                )))),
+            ))),
+        ))
+        .unwrap_err(),
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::BorderTopWidth)
+    );
+
+    let scalar = || CalcExpression::Number(number(2.0));
+    let variable = || {
+        CalcExpression::Variable(crate::CustomPropertyReference::new(
+            crate::CustomPropertyName::new("--border-width").unwrap(),
+        ))
+    };
+    assert!(calc_is_length_only(&scalar()));
+    assert!(calc_is_length_only(&variable()));
+    for expression in [
+        CalcExpression::Add(Box::new(scalar()), Box::new(variable())),
+        CalcExpression::Sub(Box::new(scalar()), Box::new(variable())),
+        CalcExpression::Mul(Box::new(scalar()), Box::new(variable())),
+        CalcExpression::Div(Box::new(scalar()), Box::new(variable())),
+    ] {
+        assert!(calc_is_length_only(&expression));
+    }
+}
+
+#[test]
 fn grid_declarations_resolve_to_backend_independent_values() {
     let fixed = |value: LengthPercentageValue| GridTrackSizingValue {
         min: GridMinTrackSizingValue::Fixed(value.clone()),

--- a/crates/whisker-style/src/layout/tests.rs
+++ b/crates/whisker-style/src/layout/tests.rs
@@ -579,7 +579,7 @@ fn complete_box_and_flex_style_resolves_without_backend_types() {
         )
         .push(
             StyleProperty::BorderBottomWidth,
-            StyleValue::LengthPercentage(percent(3.0)),
+            StyleValue::LengthPercentage(px(3.0)),
         )
         .push(
             StyleProperty::BorderLeftWidth,
@@ -649,7 +649,7 @@ fn complete_box_and_flex_style_resolves_without_backend_types() {
     assert_eq!(style.padding.bottom.fraction(), 0.07);
     assert_eq!(style.border.top.length(), 1.0);
     assert_eq!(style.border.right.length(), 2.0);
-    assert_eq!(style.border.bottom.fraction(), 0.03);
+    assert_eq!(style.border.bottom.length(), 3.0);
     assert_eq!(style.border.left.length(), 4.0);
     assert_eq!(style.flex_direction, FlexDirectionValue::Column);
     assert_eq!(style.flex_wrap, FlexWrapValue::Wrap);
@@ -1072,6 +1072,43 @@ fn invalid_numbers_are_rejected_or_clamped_by_property_semantics() {
     }
     assert_eq!(AspectRatioValue::new(4.0, 3.0).width(), 4.0);
     assert_eq!(AspectRatioValue::new(4.0, 3.0).height(), 3.0);
+}
+
+#[test]
+fn border_width_accepts_lengths_and_rejects_percentage_components() {
+    let property = StyleProperty::BorderTopWidth;
+    let pure_length = LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+        Box::new(CalcExpression::Value(Box::new(px(2.0)))),
+        Box::new(CalcExpression::Value(Box::new(px(3.0)))),
+    )));
+    assert_eq!(
+        resolve(&declaration(
+            property,
+            StyleValue::LengthPercentage(pure_length),
+        ))
+        .unwrap()
+        .border
+        .top
+        .length(),
+        5.0
+    );
+
+    for value in [
+        percent(10.0),
+        LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+            Box::new(CalcExpression::Value(Box::new(px(2.0)))),
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+        ))),
+        LengthPercentageValue::Calc(Box::new(CalcExpression::Sub(
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+            Box::new(CalcExpression::Value(Box::new(percent(10.0)))),
+        ))),
+    ] {
+        assert_eq!(
+            resolve(&declaration(property, StyleValue::LengthPercentage(value),)),
+            Err(StyleResolutionError::InvalidPropertyValue(property))
+        );
+    }
 }
 
 #[test]

--- a/crates/whisker-style/src/layout/tests.rs
+++ b/crates/whisker-style/src/layout/tests.rs
@@ -759,6 +759,106 @@ fn logical_insets_resolve_in_final_write_order_for_both_directions() {
 }
 
 #[test]
+fn logical_margin_and_padding_resolve_in_final_write_order_for_both_directions() {
+    let ltr = SpecifiedStyle::new()
+        .push(
+            StyleProperty::MarginLeft,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(1.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineStart,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(2.0))),
+        )
+        .push(
+            StyleProperty::MarginRight,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(3.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineEnd,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::Auto),
+        )
+        .push(
+            StyleProperty::PaddingLeft,
+            StyleValue::LengthPercentage(px(5.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineStart,
+            StyleValue::LengthPercentage(px(6.0)),
+        )
+        .push(
+            StyleProperty::PaddingRight,
+            StyleValue::LengthPercentage(px(7.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineEnd,
+            StyleValue::LengthPercentage(px(8.0)),
+        );
+    let style = resolve(&ltr).unwrap();
+    assert_eq!(
+        style.margin.left,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(2.0, 0.0))
+    );
+    assert_eq!(style.margin.right, ComputedLengthPercentageAuto::Auto);
+    assert_eq!(style.padding.left, ComputedLengthPercentage::new(6.0, 0.0));
+    assert_eq!(style.padding.right, ComputedLengthPercentage::new(8.0, 0.0));
+
+    let rtl = SpecifiedStyle::new()
+        .push(
+            StyleProperty::Direction,
+            StyleValue::Direction(DirectionValue::Rtl),
+        )
+        .push(
+            StyleProperty::MarginInlineStart,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(9.0))),
+        )
+        .push(
+            StyleProperty::MarginRight,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(10.0))),
+        )
+        .push(
+            StyleProperty::MarginInlineEnd,
+            StyleValue::LengthPercentageAuto(LengthPercentageAutoValue::LengthPercentage(px(11.0))),
+        )
+        .push(
+            StyleProperty::PaddingInlineStart,
+            StyleValue::LengthPercentage(px(12.0)),
+        )
+        .push(
+            StyleProperty::PaddingInlineEnd,
+            StyleValue::LengthPercentage(px(13.0)),
+        );
+    let style = resolve(&rtl).unwrap();
+    assert_eq!(
+        style.margin.right,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(10.0, 0.0))
+    );
+    assert_eq!(
+        style.margin.left,
+        ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(11.0, 0.0))
+    );
+    assert_eq!(
+        style.padding.right,
+        ComputedLengthPercentage::new(12.0, 0.0)
+    );
+    assert_eq!(style.padding.left, ComputedLengthPercentage::new(13.0, 0.0));
+
+    for property in [
+        StyleProperty::MarginInlineStart,
+        StyleProperty::MarginInlineEnd,
+        StyleProperty::PaddingInlineStart,
+        StyleProperty::PaddingInlineEnd,
+    ] {
+        assert_eq!(
+            resolve(&declaration(
+                property,
+                StyleValue::Color(crate::ColorValue::Named("red".into())),
+            )),
+            Err(StyleResolutionError::InvalidPropertyValue(property))
+        );
+    }
+}
+
+#[test]
 fn relative_units_become_logical_pixel_components() {
     let environment = StyleEnvironment::new(750.0, 400.0, 2.0, 10.0);
     let cases = [

--- a/crates/whisker-style/src/motion.rs
+++ b/crates/whisker-style/src/motion.rs
@@ -80,7 +80,9 @@ impl MotionEasing {
             Self::Steps { count, position } => {
                 let count = count as f32;
                 match position {
-                    MotionStepPosition::JumpStart => (progress * count).ceil() / count,
+                    MotionStepPosition::JumpStart => {
+                        ((progress * count).floor() + 1.0).min(count) / count
+                    }
                     MotionStepPosition::JumpEnd => (progress * count).floor() / count,
                     MotionStepPosition::JumpNone => {
                         ((progress * count).floor() / (count - 1.0)).clamp(0.0, 1.0)
@@ -925,8 +927,32 @@ mod tests {
                 count: 4,
                 position: MotionStepPosition::JumpStart,
             }
+            .sample(0.0),
+            0.25
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
             .sample(0.49),
             0.5
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
+            .sample(0.5),
+            0.75
+        );
+        assert_eq!(
+            MotionEasing::Steps {
+                count: 4,
+                position: MotionStepPosition::JumpStart,
+            }
+            .sample(1.0),
+            1.0
         );
         assert_eq!(
             MotionEasing::Steps {

--- a/crates/whisker-style/src/paint.rs
+++ b/crates/whisker-style/src/paint.rs
@@ -558,7 +558,7 @@ fn resolve_box_shadow(
             environment,
             property,
         )?),
-        color: component(&value.color).clone(),
+        color: crate::resolution::normalize_color_for(component(&value.color), property)?,
         inset: value.inset,
     })
 }
@@ -813,7 +813,8 @@ pub(crate) fn resolve_paint_style(
                 let StyleValue::Background(value) = value else {
                     return Err(invalid(property));
                 };
-                paint.background_color = component(&value.color).clone();
+                paint.background_color =
+                    crate::resolution::normalize_color_for(component(&value.color), property)?;
                 paint.background_images = value
                     .layers
                     .iter()

--- a/crates/whisker-style/src/paint/tests.rs
+++ b/crates/whisker-style/src/paint/tests.rs
@@ -1309,6 +1309,10 @@ fn logical_borders_resolve_to_physical_edges_and_corners() {
 fn logical_and_physical_border_declarations_share_final_write_order() {
     let resolved = crate::resolve_style(
         &SpecifiedStyle::new()
+            .push(
+                StyleProperty::BorderLeftStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
             .push(StyleProperty::BorderInlineStartWidth, px(2.0))
             .push(StyleProperty::BorderLeftWidth, px(4.0))
             .push(
@@ -1331,6 +1335,10 @@ fn logical_and_physical_border_declarations_share_final_write_order() {
 
     let resolved = crate::resolve_style(
         &SpecifiedStyle::new()
+            .push(
+                StyleProperty::BorderLeftStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
             .push(StyleProperty::BorderLeftWidth, px(4.0))
             .push(StyleProperty::BorderInlineStartWidth, px(6.0))
             .push(

--- a/crates/whisker-style/src/paint/tests.rs
+++ b/crates/whisker-style/src/paint/tests.rs
@@ -167,6 +167,18 @@ fn box_shadow_resolves_every_component_and_rejects_invalid_values() {
         }
         assert_eq!(resolve(StyleValue::BoxShadows(vec![invalid])), expected);
     }
+
+    let mut invalid_color = shadow;
+    invalid_color.color = ComponentValue::Value(ColorValue::Rgba {
+        red: 0,
+        green: 0,
+        blue: 0,
+        alpha: number(f32::NAN),
+    });
+    assert_eq!(
+        resolve(StyleValue::BoxShadows(vec![invalid_color])),
+        expected
+    );
 }
 
 #[test]
@@ -1462,6 +1474,29 @@ fn background_shorthand_resolves_layer_lists_and_empty_initials() {
     .unwrap();
     assert!(empty.computed().paint().background_images.is_empty());
     assert_eq!(empty.computed().paint().background_layers.len(), 1);
+
+    assert_eq!(
+        crate::resolve_style(
+            &SpecifiedStyle::new().push(
+                StyleProperty::Background,
+                StyleValue::Background(BackgroundValue {
+                    layers: Vec::new(),
+                    color: ColorValue::Rgba {
+                        red: 0,
+                        green: 0,
+                        blue: 0,
+                        alpha: number(f32::NAN),
+                    }
+                    .into(),
+                }),
+            ),
+            None,
+            StyleEnvironment::default(),
+        ),
+        Err(StyleResolutionError::InvalidPropertyValue(
+            StyleProperty::Background
+        ))
+    );
 
     let mut invalid_position = layer(
         "invalid-position",

--- a/crates/whisker-style/src/property.rs
+++ b/crates/whisker-style/src/property.rs
@@ -131,6 +131,9 @@ macro_rules! define_style_properties {
                         | Self::Direction
                         | Self::Color
                         | Self::TextAlign
+                        | Self::FontFeatureSettings
+                        | Self::FontOpticalSizing
+                        | Self::FontVariationSettings
                         | Self::TextDecoration
                         | Self::TextShadow
                 );
@@ -585,6 +588,9 @@ mod tests {
                 StyleProperty::LineHeight,
                 StyleProperty::PointerEvents,
                 StyleProperty::TextAlign,
+                StyleProperty::FontFeatureSettings,
+                StyleProperty::FontOpticalSizing,
+                StyleProperty::FontVariationSettings,
                 StyleProperty::TextDecoration,
                 StyleProperty::TextShadow,
             ]

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -820,7 +820,9 @@ fn resolve_style_once(
             style: *style,
             color: decoration_color
                 .as_ref()
-                .map(|color| normalize_color(resolved_component(color)))
+                .map(|color| {
+                    normalize_color_for(resolved_component(color), StyleProperty::TextDecoration)
+                })
                 .transpose()?
                 .unwrap_or_else(|| color.clone()),
         },
@@ -862,7 +864,7 @@ fn resolve_style_once(
                 offset_x: StyleNumber::new(offset_x),
                 offset_y: StyleNumber::new(offset_y),
                 blur_radius: StyleNumber::new(blur_radius),
-                color: normalize_color(resolved_component(color))?,
+                color: normalize_color_for(resolved_component(color), StyleProperty::TextShadow)?,
             })
         }
         Some(_) => return Err(wrong_type(StyleProperty::TextShadow)),

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -4,11 +4,12 @@ use core::fmt;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
-    CalcExpression, ColorValue, ComponentValue, ComputedLayoutStyle, ComputedMotionStyle,
-    ComputedPaintStyle, CursorValue, CustomPropertyName, CustomPropertyReference, DirectionValue,
-    FontFamilyValue, FontFeatureValue, FontOpticalSizingValue, FontStyleValue, FontVariationValue,
-    FontWeightValue, LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue,
-    PointerEventsValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextAlignValue,
+    BorderStyleValue, CalcExpression, ColorValue, ComponentValue, ComputedLayoutStyle,
+    ComputedLengthPercentage, ComputedMotionStyle, ComputedPaintStyle, CursorValue,
+    CustomPropertyName, CustomPropertyReference, DirectionValue, FontFamilyValue, FontFeatureValue,
+    FontOpticalSizingValue, FontStyleValue, FontVariationValue, FontWeightValue,
+    LengthPercentageValue, LengthUnit, LengthValue, LineHeightValue, PointerEventsValue,
+    SpecifiedStyle, StyleNumber, StyleProperty, StyleValue, TextAlignValue,
     TextDecorationLineValue, TextDecorationStyleValue, TextDecorationValue, TextOverflowValue,
     TextShadowValue, WhiteSpaceValue, WordBreakValue,
 };
@@ -917,7 +918,7 @@ fn resolve_style_once(
         None => TextOverflowValue::default(),
     };
 
-    let layout = crate::layout::resolve_layout_style(
+    let mut layout = crate::layout::resolve_layout_style(
         specified,
         font_size.get(),
         base.direction,
@@ -948,6 +949,30 @@ fn resolve_style_once(
         layout.direction,
         environment,
     )?;
+    if matches!(
+        paint.border_styles.top,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.top = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.right,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.right = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.bottom,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.bottom = ComputedLengthPercentage::ZERO;
+    }
+    if matches!(
+        paint.border_styles.left,
+        BorderStyleValue::None | BorderStyleValue::Hidden
+    ) {
+        layout.border.left = ComputedLengthPercentage::ZERO;
+    }
     let motion = crate::motion::resolve_motion_style(specified)?;
 
     Ok(ResolvedNodeStyle {

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -647,9 +647,10 @@ pub fn resolve_style(
     let mut effective = specified.clone();
     loop {
         match resolve_style_once(&effective, parent, environment) {
-            Err(StyleResolutionError::InvalidPropertyValue(property))
-                if variable_properties.remove(&property) =>
-            {
+            Err(
+                StyleResolutionError::InvalidPropertyValue(property)
+                | StyleResolutionError::InvalidCalculation(property),
+            ) if variable_properties.remove(&property) => {
                 effective = without_registered_property(&effective, property);
             }
             result => return result,

--- a/crates/whisker-style/src/resolution.rs
+++ b/crates/whisker-style/src/resolution.rs
@@ -108,6 +108,13 @@ pub enum ComputedTextIndent {
     LogicalPixels(StyleNumber),
     /// Percentage number before the `%` suffix.
     Percentage(StyleNumber),
+    /// Mixed fixed and percentage components produced by `calc()`.
+    LengthPercentage {
+        /// Fixed logical-pixel component.
+        logical_pixels: StyleNumber,
+        /// Percentage number before the `%` suffix.
+        percentage: StyleNumber,
+    },
 }
 
 impl Default for ComputedTextIndent {
@@ -891,9 +898,27 @@ fn resolve_style_once(
                 StyleProperty::TextIndent,
             )?))
         }
-        Some(StyleValue::LengthPercentage(LengthPercentageValue::Calc(_))) | Some(_) => {
-            return Err(wrong_type(StyleProperty::TextIndent));
+        Some(StyleValue::LengthPercentage(value @ LengthPercentageValue::Calc(_))) => {
+            let value = crate::layout::resolve_affine(
+                value,
+                font_size.get(),
+                environment,
+                StyleProperty::TextIndent,
+            )?;
+            let logical_pixels = value.length();
+            let percentage = value.fraction() * 100.0;
+            if percentage == 0.0 {
+                ComputedTextIndent::LogicalPixels(StyleNumber::new(logical_pixels))
+            } else if logical_pixels == 0.0 {
+                ComputedTextIndent::Percentage(StyleNumber::new(percentage))
+            } else {
+                ComputedTextIndent::LengthPercentage {
+                    logical_pixels: StyleNumber::new(logical_pixels),
+                    percentage: StyleNumber::new(percentage),
+                }
+            }
         }
+        Some(_) => return Err(wrong_type(StyleProperty::TextIndent)),
         None => ComputedTextIndent::default(),
     };
     let local_text_value = |property| {

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -795,7 +795,7 @@ fn text_shadow_resolves_inherits_clears_and_rejects_negative_blur() {
     );
     assert_eq!(
         resolve_text_style(&invalid_color, None, environment).unwrap_err(),
-        StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::TextShadow)
     );
 }
 
@@ -847,7 +847,7 @@ fn text_decoration_resolves_current_color_and_inherits() {
     );
     assert_eq!(
         resolve_text_style(&invalid_color, None, environment).unwrap_err(),
-        StyleResolutionError::InvalidPropertyValue(StyleProperty::Color)
+        StyleResolutionError::InvalidPropertyValue(StyleProperty::TextDecoration)
     );
 }
 

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -643,6 +643,33 @@ fn text_indent_resolves_length_percentage_and_calc_without_inheriting() {
             percentage: number(10.0),
         }
     );
+
+    for (value, expected) in [
+        (
+            LengthPercentageValue::Calc(Box::new(CalcExpression::Value(Box::new(
+                LengthPercentageValue::Length(px(6.0)),
+            )))),
+            ComputedTextIndent::LogicalPixels(number(6.0)),
+        ),
+        (
+            LengthPercentageValue::Calc(Box::new(CalcExpression::Value(Box::new(
+                LengthPercentageValue::Percentage(number(12.0)),
+            )))),
+            ComputedTextIndent::Percentage(number(12.0)),
+        ),
+    ] {
+        let resolved = resolve_text_style(
+            &declaration(
+                StyleProperty::TextIndent,
+                StyleValue::LengthPercentage(value),
+            ),
+            None,
+            environment,
+        )
+        .unwrap();
+        assert_eq!(resolved.computed().text_indent(), expected);
+    }
+
     let child = resolve_text_style(
         &SpecifiedStyle::new(),
         Some(length.inherited_for_children()),

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -416,7 +416,6 @@ fn calc_evaluates_scalar_branches_and_rejects_invalid_dimensions() {
         CalcExpression::Sub(Box::new(scalar(3.0)), Box::new(scalar(1.0))),
         CalcExpression::Mul(Box::new(scalar(2.0)), Box::new(scalar(3.0))),
         CalcExpression::Div(Box::new(scalar(6.0)), Box::new(scalar(2.0))),
-        CalcExpression::Div(Box::new(length()), Box::new(length())),
     ] {
         evaluate_calc(
             &expression,
@@ -431,6 +430,7 @@ fn calc_evaluates_scalar_branches_and_rejects_invalid_dimensions() {
         CalcExpression::Add(Box::new(scalar(1.0)), Box::new(length())),
         CalcExpression::Sub(Box::new(length()), Box::new(scalar(1.0))),
         CalcExpression::Mul(Box::new(length()), Box::new(length())),
+        CalcExpression::Div(Box::new(length()), Box::new(length())),
         CalcExpression::Div(Box::new(scalar(1.0)), Box::new(length())),
         CalcExpression::Div(Box::new(length()), Box::new(scalar(0.0))),
         CalcExpression::Div(
@@ -586,7 +586,7 @@ fn direction_resolves_and_inherits_into_layout_and_text_context() {
 }
 
 #[test]
-fn text_indent_resolves_length_and_percentage_without_inheriting() {
+fn text_indent_resolves_length_percentage_and_calc_without_inheriting() {
     let environment = StyleEnvironment::default();
     let length = resolve_text_style(
         &declaration(
@@ -618,6 +618,31 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
         percentage.computed().text_indent(),
         ComputedTextIndent::Percentage(number(-15.0))
     );
+    let calculated = resolve_text_style(
+        &declaration(
+            StyleProperty::TextIndent,
+            StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                CalcExpression::Add(
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Length(px(4.0)),
+                    ))),
+                    Box::new(CalcExpression::Value(Box::new(
+                        LengthPercentageValue::Percentage(number(10.0)),
+                    ))),
+                ),
+            ))),
+        ),
+        Some(length.inherited_for_children()),
+        environment,
+    )
+    .unwrap();
+    assert_eq!(
+        calculated.computed().text_indent(),
+        ComputedTextIndent::LengthPercentage {
+            logical_pixels: number(4.0),
+            percentage: number(10.0),
+        }
+    );
     let child = resolve_text_style(
         &SpecifiedStyle::new(),
         Some(length.inherited_for_children()),
@@ -635,7 +660,6 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
             unit: LengthUnit::Em,
         }),
         LengthPercentageValue::Percentage(number(f32::NAN)),
-        LengthPercentageValue::Calc(Box::new(CalcExpression::Number(number(1.0)))),
     ] {
         assert_eq!(
             resolve_text_style(
@@ -650,6 +674,20 @@ fn text_indent_resolves_length_and_percentage_without_inheriting() {
             StyleResolutionError::InvalidPropertyValue(StyleProperty::TextIndent)
         );
     }
+    assert_eq!(
+        resolve_text_style(
+            &declaration(
+                StyleProperty::TextIndent,
+                StyleValue::LengthPercentage(LengthPercentageValue::Calc(Box::new(
+                    CalcExpression::Number(number(1.0)),
+                ))),
+            ),
+            None,
+            environment,
+        )
+        .unwrap_err(),
+        StyleResolutionError::InvalidCalculation(StyleProperty::TextIndent)
+    );
 }
 
 #[test]

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -1362,6 +1362,49 @@ fn direct_invalid_values_remain_resolution_errors() {
 }
 
 #[test]
+fn none_and_hidden_border_styles_zero_the_corresponding_layout_widths() {
+    let border_width =
+        |value| StyleValue::LengthPercentage(LengthPercentageValue::Length(px(value)));
+    let resolved = resolve_style(
+        &SpecifiedStyle::new()
+            .push(StyleProperty::BorderTopWidth, border_width(1.0))
+            .push(StyleProperty::BorderRightWidth, border_width(2.0))
+            .push(StyleProperty::BorderBottomWidth, border_width(3.0))
+            .push(StyleProperty::BorderLeftWidth, border_width(4.0))
+            .push(
+                StyleProperty::BorderTopStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Solid),
+            )
+            .push(
+                StyleProperty::BorderRightStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Hidden),
+            )
+            .push(
+                StyleProperty::BorderBottomStyle,
+                StyleValue::BorderStyle(BorderStyleValue::Dashed),
+            ),
+        None,
+        StyleEnvironment::default(),
+    )
+    .unwrap();
+
+    let border = &resolved.computed().layout().border;
+    assert_eq!(border.top.length(), 1.0);
+    assert_eq!(border.right, ComputedLengthPercentage::ZERO);
+    assert_eq!(border.bottom.length(), 3.0);
+    assert_eq!(border.left, ComputedLengthPercentage::ZERO);
+    assert_eq!(
+        resolved.computed().paint().border_styles,
+        crate::Edges {
+            top: BorderStyleValue::Solid,
+            right: BorderStyleValue::Hidden,
+            bottom: BorderStyleValue::Dashed,
+            left: BorderStyleValue::None,
+        }
+    );
+}
+
+#[test]
 fn custom_properties_support_forward_references() {
     let a = CustomPropertyName::new("--a").unwrap();
     let b = CustomPropertyName::new("--b").unwrap();

--- a/crates/whisker-style/src/resolution/tests.rs
+++ b/crates/whisker-style/src/resolution/tests.rs
@@ -1317,10 +1317,21 @@ fn missing_composite_variables_invalidate_custom_and_registered_declarations() {
             color: component_variable(&missing),
         })
     };
+    let box_shadow = || {
+        StyleValue::BoxShadows(vec![crate::BoxShadowValue {
+            offset_x: LengthValue::Zero.into(),
+            offset_y: LengthValue::Zero.into(),
+            blur_radius: LengthValue::Zero.into(),
+            spread_radius: LengthValue::Zero.into(),
+            color: component_variable(&missing),
+            inset: false,
+        }])
+    };
     let resolved = resolve_style(
         &SpecifiedStyle::new()
             .push_custom(nested.clone(), shadow())
-            .push(StyleProperty::TextShadow, shadow()),
+            .push(StyleProperty::TextShadow, shadow())
+            .push(StyleProperty::BoxShadow, box_shadow()),
         None,
         StyleEnvironment::default(),
     )
@@ -1333,6 +1344,7 @@ fn missing_composite_variables_invalidate_custom_and_registered_declarations() {
             .is_none()
     );
     assert!(resolved.inherited_for_children().text_shadow().is_none());
+    assert!(resolved.computed().paint().box_shadows.is_empty());
 }
 
 #[test]
@@ -1508,6 +1520,103 @@ fn typed_calc_variable_resolution_covers_arithmetic_and_operand_types() {
         resolved.computed().layout().size.width,
         crate::ComputedSizeValue::Auto
     );
+}
+
+#[test]
+fn invalid_calc_after_custom_property_substitution_drops_only_that_declaration() {
+    let scalar = CustomPropertyName::new("--scalar").unwrap();
+    let invalid_width = LengthPercentageValue::Calc(Box::new(CalcExpression::Add(
+        Box::new(CalcExpression::Value(Box::new(
+            LengthPercentageValue::Length(px(10.0)),
+        ))),
+        Box::new(CalcExpression::Variable(CustomPropertyReference::new(
+            scalar.clone(),
+        ))),
+    )));
+    let resolved = resolve_style(
+        &SpecifiedStyle::new()
+            .push_custom(scalar, StyleValue::Number(number(2.0)))
+            .push(
+                StyleProperty::Width,
+                StyleValue::Size(crate::SizeValue::LengthPercentage(invalid_width)),
+            )
+            .push(
+                StyleProperty::Height,
+                StyleValue::Size(crate::SizeValue::LengthPercentage(
+                    LengthPercentageValue::Length(px(24.0)),
+                )),
+            ),
+        None,
+        StyleEnvironment::default(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved.computed().layout().size.width,
+        crate::ComputedSizeValue::Auto
+    );
+    assert_eq!(
+        resolved.computed().layout().size.height,
+        crate::ComputedSizeValue::Value(crate::ComputedLengthPercentage::new(24.0, 0.0))
+    );
+}
+
+#[test]
+fn custom_properties_materialize_inside_box_shadow_and_clip_path() {
+    let length = CustomPropertyName::new("--length").unwrap();
+    let color = CustomPropertyName::new("--color").unwrap();
+    let clip_coordinate = || {
+        LengthPercentageValue::Calc(Box::new(CalcExpression::Variable(
+            CustomPropertyReference::new(length.clone()),
+        )))
+    };
+    let resolved = resolve_style(
+        &SpecifiedStyle::new()
+            .push_custom(length.clone(), StyleValue::Length(px(6.0)))
+            .push_custom(
+                color.clone(),
+                StyleValue::Color(ColorValue::Named("red".into())),
+            )
+            .push(
+                StyleProperty::BoxShadow,
+                StyleValue::BoxShadows(vec![crate::BoxShadowValue {
+                    offset_x: component_variable(&length),
+                    offset_y: component_variable(&length),
+                    blur_radius: component_variable(&length),
+                    spread_radius: component_variable(&length),
+                    color: component_variable(&color),
+                    inset: false,
+                }]),
+            )
+            .push(
+                StyleProperty::ClipPath,
+                StyleValue::ClipPath(crate::ClipPathValue::Shape {
+                    reference_box: crate::ClipBoxValue::Border,
+                    shape: crate::ClipShapeValue::Circle {
+                        radius: clip_coordinate(),
+                        center_x: clip_coordinate(),
+                        center_y: clip_coordinate(),
+                    },
+                }),
+            ),
+        None,
+        StyleEnvironment::default(),
+    )
+    .unwrap();
+
+    let shadow = &resolved.computed().paint().box_shadows[0];
+    assert_eq!(shadow.offset_x.get(), 6.0);
+    assert_eq!(shadow.offset_y.get(), 6.0);
+    assert_eq!(shadow.blur_radius.get(), 6.0);
+    assert_eq!(shadow.spread_radius.get(), 6.0);
+    assert_eq!(shadow.color, ColorValue::Named("red".into()));
+    assert!(matches!(
+        resolved.computed().paint().clip_path.as_ref().map(|clip| &clip.shape),
+        Some(crate::ComputedClipShape::Circle { radius, center })
+            if *radius == crate::ComputedLengthPercentage::new(6.0, 0.0)
+                && center.x == crate::ComputedLengthPercentage::new(6.0, 0.0)
+                && center.y == crate::ComputedLengthPercentage::new(6.0, 0.0)
+    ));
 }
 
 #[test]

--- a/crates/whisker-style/src/resolution/values.rs
+++ b/crates/whisker-style/src/resolution/values.rs
@@ -193,17 +193,13 @@ pub(super) fn evaluate_calc(
             let left = evaluate_calc(left, percentage_basis, em_basis, environment, property)?;
             let right = evaluate_calc(right, percentage_basis, em_basis, environment, property)?;
             match (left, right) {
-                (_, Quantity::Number(0.0)) | (_, Quantity::Length(0.0)) => Err(invalid()),
+                (_, Quantity::Number(0.0)) | (_, Quantity::Length(_)) => Err(invalid()),
                 (Quantity::Number(left), Quantity::Number(right)) => {
                     Ok(Quantity::Number(left / right))
                 }
                 (Quantity::Length(left), Quantity::Number(right)) => {
                     Ok(Quantity::Length(left / right))
                 }
-                (Quantity::Length(left), Quantity::Length(right)) => {
-                    Ok(Quantity::Number(left / right))
-                }
-                (Quantity::Number(_), Quantity::Length(_)) => Err(invalid()),
             }
         }
     }

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -1120,7 +1120,7 @@ fn is_custom_property_ident_character(character: char) -> bool {
     character == '_'
         || character == '-'
         || character.is_ascii_alphanumeric()
-        || !character.is_ascii()
+        || (!character.is_ascii() && !character.is_whitespace() && !character.is_control())
 }
 
 /// A whole-value `var()` reference retained until computed-style resolution.
@@ -1242,8 +1242,12 @@ mod tests {
         assert!(CustomPropertyName::new("accent").is_none());
         assert!(CustomPropertyName::new("--").is_none());
         assert!(CustomPropertyName::new("--bad name").is_none());
+        assert!(CustomPropertyName::new("--bad\u{00a0}name").is_none());
+        assert!(CustomPropertyName::new("--bad\u{2028}name").is_none());
+        assert!(CustomPropertyName::new("--bad\u{0085}name").is_none());
         assert!(CustomPropertyName::new("--1bad").is_some());
         assert!(CustomPropertyName::new("--bad:value").is_none());
+        assert!(CustomPropertyName::new("--🎨").is_some());
 
         let unresolved = ComponentValue::<ColorValue>::Variable(CustomPropertyReference::new(
             CustomPropertyName::new("--accent").unwrap(),

--- a/crates/whisker-style/src/value.rs
+++ b/crates/whisker-style/src/value.rs
@@ -1095,8 +1095,8 @@ pub struct CustomPropertyName(String);
 impl CustomPropertyName {
     /// Validates and owns a custom-property name.
     ///
-    /// The common CSS identifier form is accepted, including non-ASCII
-    /// characters. Whitespace, control characters, and a bare `--` are
+    /// The CSS dashed-identifier form is accepted, including every non-ASCII
+    /// identifier code point. ASCII syntax characters and a bare `--` are
     /// rejected so invalid names cannot enter computed style.
     pub fn new(name: impl Into<String>) -> Option<Self> {
         let name = name.into();
@@ -1120,7 +1120,7 @@ fn is_custom_property_ident_character(character: char) -> bool {
     character == '_'
         || character == '-'
         || character.is_ascii_alphanumeric()
-        || (!character.is_ascii() && !character.is_whitespace() && !character.is_control())
+        || !character.is_ascii()
 }
 
 /// A whole-value `var()` reference retained until computed-style resolution.
@@ -1227,7 +1227,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_property_names_require_a_nonempty_whitespace_free_suffix() {
+    fn custom_property_names_follow_css_dashed_identifier_code_points() {
         assert_eq!(
             CustomPropertyName::new("--accent").unwrap().as_str(),
             "--accent"
@@ -1242,9 +1242,9 @@ mod tests {
         assert!(CustomPropertyName::new("accent").is_none());
         assert!(CustomPropertyName::new("--").is_none());
         assert!(CustomPropertyName::new("--bad name").is_none());
-        assert!(CustomPropertyName::new("--bad\u{00a0}name").is_none());
-        assert!(CustomPropertyName::new("--bad\u{2028}name").is_none());
-        assert!(CustomPropertyName::new("--bad\u{0085}name").is_none());
+        assert!(CustomPropertyName::new("--non-breaking\u{00a0}space").is_some());
+        assert!(CustomPropertyName::new("--line\u{2028}separator").is_some());
+        assert!(CustomPropertyName::new("--next-line\u{0085}").is_some());
         assert!(CustomPropertyName::new("--1bad").is_some());
         assert!(CustomPropertyName::new("--bad:value").is_none());
         assert!(CustomPropertyName::new("--🎨").is_some());

--- a/crates/whisker-style/src/value_tree.rs
+++ b/crates/whisker-style/src/value_tree.rs
@@ -1,8 +1,9 @@
 //! Internal traversal of typed values that contain length-percentage leaves.
 
 use crate::{
-    BackgroundImageValue, BackgroundSizeValue, ColorValue, ComponentValue, CustomPropertyReference,
-    GradientValue, GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
+    BackgroundImageValue, BackgroundSizeValue, ClipPathCommandValue, ClipPathValue, ClipPointValue,
+    ClipShapeValue, ColorValue, ComponentValue, CustomPropertyReference, GradientValue,
+    GridMaxTrackSizingValue, GridMinTrackSizingValue, GridTemplateComponentValue,
     LengthPercentageAutoValue, LengthPercentageValue, LengthValue, OffsetPathValue,
     RadialGradientValue, SizeValue, StyleNumber, StyleValue, TextDecorationValue, TextShadowValue,
     TransformFunctionValue,
@@ -36,6 +37,15 @@ pub(crate) fn visit_component_variables<'a>(
         }
         StyleValue::BackdropFilter(crate::BackdropFilterValue::Blur(radius)) => {
             visit_component(radius, visit);
+        }
+        StyleValue::BoxShadows(shadows) => {
+            for shadow in shadows {
+                visit_component(&shadow.offset_x, visit);
+                visit_component(&shadow.offset_y, visit);
+                visit_component(&shadow.blur_radius, visit);
+                visit_component(&shadow.spread_radius, visit);
+                visit_component(&shadow.color, visit);
+            }
         }
         StyleValue::Transform(transform) => {
             for function in &transform.0 {
@@ -80,6 +90,15 @@ pub(crate) fn try_map_component_variables(
         }
         StyleValue::BackdropFilter(crate::BackdropFilterValue::Blur(radius)) => {
             map_length_component(radius, resolve)?;
+        }
+        StyleValue::BoxShadows(shadows) => {
+            for shadow in shadows {
+                map_length_component(&mut shadow.offset_x, resolve)?;
+                map_length_component(&mut shadow.offset_y, resolve)?;
+                map_length_component(&mut shadow.blur_radius, resolve)?;
+                map_length_component(&mut shadow.spread_radius, resolve)?;
+                map_color_component(&mut shadow.color, resolve)?;
+            }
         }
         StyleValue::Transform(transform) => {
             for function in &mut transform.0 {
@@ -358,6 +377,7 @@ pub(crate) fn visit_length_percentages<'a>(
             visit(&origin.horizontal);
             visit(&origin.vertical);
         }
+        StyleValue::ClipPath(path) => visit_clip_path(path, visit),
         StyleValue::OffsetPath(path) => visit_offset_path(path, visit),
         StyleValue::GridTemplate(template) => {
             for component in &template.components {
@@ -500,6 +520,83 @@ fn visit_offset_path<'a>(
     }
 }
 
+fn visit_clip_path<'a>(path: &'a ClipPathValue, visit: &mut dyn FnMut(&'a LengthPercentageValue)) {
+    let ClipPathValue::Shape { shape, .. } = path else {
+        return;
+    };
+    match shape {
+        ClipShapeValue::Inset { offsets, radii } => {
+            for offset in offsets {
+                visit(offset);
+            }
+            if let Some(radii) = radii {
+                for radius in radii {
+                    visit(&radius.horizontal);
+                    visit(&radius.vertical);
+                }
+            }
+        }
+        ClipShapeValue::Circle {
+            radius,
+            center_x,
+            center_y,
+        } => {
+            visit(radius);
+            visit(center_x);
+            visit(center_y);
+        }
+        ClipShapeValue::Ellipse {
+            radius_x,
+            radius_y,
+            center_x,
+            center_y,
+        } => {
+            visit(radius_x);
+            visit(radius_y);
+            visit(center_x);
+            visit(center_y);
+        }
+        ClipShapeValue::Path { commands, .. } => {
+            for command in commands {
+                visit_clip_path_command(command, visit);
+            }
+        }
+    }
+}
+
+fn visit_clip_path_command<'a>(
+    command: &'a ClipPathCommandValue,
+    visit: &mut dyn FnMut(&'a LengthPercentageValue),
+) {
+    match command {
+        ClipPathCommandValue::MoveTo(point) | ClipPathCommandValue::LineTo(point) => {
+            visit_clip_point(point, visit);
+        }
+        ClipPathCommandValue::QuadraticTo { control, end } => {
+            visit_clip_point(control, visit);
+            visit_clip_point(end, visit);
+        }
+        ClipPathCommandValue::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => {
+            visit_clip_point(control_1, visit);
+            visit_clip_point(control_2, visit);
+            visit_clip_point(end, visit);
+        }
+        ClipPathCommandValue::Close => {}
+    }
+}
+
+fn visit_clip_point<'a>(
+    point: &'a ClipPointValue,
+    visit: &mut dyn FnMut(&'a LengthPercentageValue),
+) {
+    visit(&point.x);
+    visit(&point.y);
+}
+
 fn visit_grid_track<'a>(
     track: &'a crate::GridTrackSizingValue,
     visit: &mut dyn FnMut(&'a LengthPercentageValue),
@@ -559,6 +656,7 @@ fn try_visit_length_percentages_mut(
             map_one(&mut origin.horizontal, map)?;
             map_one(&mut origin.vertical, map)?;
         }
+        StyleValue::ClipPath(path) => map_clip_path(path, map)?,
         StyleValue::OffsetPath(path) => map_offset_path(path, map)?,
         StyleValue::GridTemplate(template) => {
             for component in &mut template.components {
@@ -705,6 +803,88 @@ fn map_offset_path(
     Some(())
 }
 
+fn map_clip_path(
+    path: &mut ClipPathValue,
+    map: &mut dyn FnMut(&LengthPercentageValue) -> Option<LengthPercentageValue>,
+) -> Option<()> {
+    let ClipPathValue::Shape { shape, .. } = path else {
+        return Some(());
+    };
+    match shape {
+        ClipShapeValue::Inset { offsets, radii } => {
+            for offset in offsets {
+                map_one(offset, map)?;
+            }
+            if let Some(radii) = radii {
+                for radius in radii {
+                    map_one(&mut radius.horizontal, map)?;
+                    map_one(&mut radius.vertical, map)?;
+                }
+            }
+        }
+        ClipShapeValue::Circle {
+            radius,
+            center_x,
+            center_y,
+        } => {
+            map_one(radius, map)?;
+            map_one(center_x, map)?;
+            map_one(center_y, map)?;
+        }
+        ClipShapeValue::Ellipse {
+            radius_x,
+            radius_y,
+            center_x,
+            center_y,
+        } => {
+            map_one(radius_x, map)?;
+            map_one(radius_y, map)?;
+            map_one(center_x, map)?;
+            map_one(center_y, map)?;
+        }
+        ClipShapeValue::Path { commands, .. } => {
+            for command in commands {
+                map_clip_path_command(command, map)?;
+            }
+        }
+    }
+    Some(())
+}
+
+fn map_clip_path_command(
+    command: &mut ClipPathCommandValue,
+    map: &mut dyn FnMut(&LengthPercentageValue) -> Option<LengthPercentageValue>,
+) -> Option<()> {
+    match command {
+        ClipPathCommandValue::MoveTo(point) | ClipPathCommandValue::LineTo(point) => {
+            map_clip_point(point, map)?;
+        }
+        ClipPathCommandValue::QuadraticTo { control, end } => {
+            map_clip_point(control, map)?;
+            map_clip_point(end, map)?;
+        }
+        ClipPathCommandValue::CubicTo {
+            control_1,
+            control_2,
+            end,
+        } => {
+            map_clip_point(control_1, map)?;
+            map_clip_point(control_2, map)?;
+            map_clip_point(end, map)?;
+        }
+        ClipPathCommandValue::Close => {}
+    }
+    Some(())
+}
+
+fn map_clip_point(
+    point: &mut ClipPointValue,
+    map: &mut dyn FnMut(&LengthPercentageValue) -> Option<LengthPercentageValue>,
+) -> Option<()> {
+    map_one(&mut point.x, map)?;
+    map_one(&mut point.y, map)
+}
+
 fn map_grid_track(
     track: &mut crate::GridTrackSizingValue,
     map: &mut dyn FnMut(&LengthPercentageValue) -> Option<LengthPercentageValue>,
@@ -727,9 +907,10 @@ mod tests {
     use crate::{
         BackgroundAttachmentValue, BackgroundBoxValue, BackgroundLayerValue,
         BackgroundPositionValue, BackgroundRepeatModeValue, BackgroundRepeatValue, BackgroundValue,
-        BorderRadiusValue, ColorValue, CustomPropertyName, GradientStopValue,
-        GridRepetitionCountValue, GridTemplateRepetitionValue, GridTemplateValue,
-        GridTrackSizingValue, InsetPathValue, StyleNumber, TransformOriginValue, TransformValue,
+        BorderRadiusValue, BoxShadowValue, ClipBoxValue, ClipFillRuleValue, ColorValue,
+        CustomPropertyName, GradientStopValue, GridRepetitionCountValue,
+        GridTemplateRepetitionValue, GridTemplateValue, GridTrackSizingValue, InsetPathValue,
+        StyleNumber, TransformOriginValue, TransformValue,
     };
 
     fn lp(value: f32) -> LengthPercentageValue {
@@ -873,6 +1054,17 @@ mod tests {
                 &name,
             ))),
             1,
+        );
+        assert_maps_every_component(
+            StyleValue::BoxShadows(vec![BoxShadowValue {
+                offset_x: component_reference(&name),
+                offset_y: component_reference(&name),
+                blur_radius: component_reference(&name),
+                spread_radius: component_reference(&name),
+                color: component_reference(&name),
+                inset: false,
+            }]),
+            5,
         );
         assert_maps_every_component(
             StyleValue::Transform(TransformValue(vec![
@@ -1137,6 +1329,82 @@ mod tests {
             }))),
             12,
         );
+    }
+
+    #[test]
+    fn clip_path_walk_covers_every_shape_and_command_coordinate() {
+        let point = || ClipPointValue {
+            x: lp(1.0),
+            y: lp(1.0),
+        };
+        let clip = |shape| {
+            StyleValue::ClipPath(ClipPathValue::Shape {
+                reference_box: ClipBoxValue::Border,
+                shape,
+            })
+        };
+        assert_maps_every_leaf(
+            clip(ClipShapeValue::Inset {
+                offsets: [lp(1.0), lp(1.0), lp(1.0), lp(1.0)],
+                radii: Some([
+                    BorderRadiusValue {
+                        horizontal: lp(1.0),
+                        vertical: lp(1.0),
+                    },
+                    BorderRadiusValue {
+                        horizontal: lp(1.0),
+                        vertical: lp(1.0),
+                    },
+                    BorderRadiusValue {
+                        horizontal: lp(1.0),
+                        vertical: lp(1.0),
+                    },
+                    BorderRadiusValue {
+                        horizontal: lp(1.0),
+                        vertical: lp(1.0),
+                    },
+                ]),
+            }),
+            12,
+        );
+        assert_maps_every_leaf(
+            clip(ClipShapeValue::Circle {
+                radius: lp(1.0),
+                center_x: lp(1.0),
+                center_y: lp(1.0),
+            }),
+            3,
+        );
+        assert_maps_every_leaf(
+            clip(ClipShapeValue::Ellipse {
+                radius_x: lp(1.0),
+                radius_y: lp(1.0),
+                center_x: lp(1.0),
+                center_y: lp(1.0),
+            }),
+            4,
+        );
+        assert_maps_every_leaf(
+            clip(ClipShapeValue::Path {
+                fill_rule: ClipFillRuleValue::NonZero,
+                commands: vec![
+                    ClipPathCommandValue::MoveTo(point()),
+                    ClipPathCommandValue::LineTo(point()),
+                    ClipPathCommandValue::QuadraticTo {
+                        control: point(),
+                        end: point(),
+                    },
+                    ClipPathCommandValue::CubicTo {
+                        control_1: point(),
+                        control_2: point(),
+                        end: point(),
+                    },
+                    ClipPathCommandValue::Close,
+                ],
+            }),
+            14,
+        );
+        assert_maps_every_leaf(StyleValue::ClipPath(ClipPathValue::None), 0);
     }
 
     #[test]

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -785,6 +785,39 @@ fn background_gradients_lower_without_host_resources() {
     assert_eq!(radius_x.length, 40.0);
     assert_eq!(radius_y.fraction, 0.25);
 
+    let radial_circle = render_gradient(
+        50,
+        Gradient::Radial {
+            shape: RadialShape::Circle,
+            stops: stops(),
+        },
+    );
+    let PaintImage::RadialGradient {
+        shape,
+        extent,
+        radii: Some((radius_x, radius_y)),
+        stops: circle_stops,
+        ..
+    } = radial_circle
+    else {
+        panic!("expected canonical radial circle")
+    };
+    assert_eq!(
+        shape,
+        whisker_engine::whisker_protocol::RadialGradientShape::Ellipse
+    );
+    assert_eq!(
+        extent,
+        whisker_engine::whisker_protocol::RadialGradientExtent::Explicit
+    );
+    assert!((radius_x.length - 50.0_f32.hypot(50.0)).abs() < 0.001);
+    assert_eq!(radius_x, radius_y);
+    assert!(
+        circle_stops
+            .iter()
+            .all(|stop| stop.position.is_some_and(|position| position.length == 0.0))
+    );
+
     let conic = render_gradient(
         49,
         Gradient::Conic {

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -887,8 +887,9 @@ resource channel once and are not embedded into every frame transaction.
 
 Structural operations must establish a node before later operations reference
 it. Deleting a subtree invalidates its Host handles, subscriptions, pending
-commands, and element-instance state. A `NodeId` is not reused within the same
-scene epoch.
+commands, and element-instance state. `CreateNode` identifiers strictly
+increase within one scene epoch, so a `NodeId` is never reused and receivers
+can validate retirement with a constant-space high-water mark.
 
 ### Incremental updates
 

--- a/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
+++ b/docs/rfcs/0003-typed-inline-style-layout-and-paint.md
@@ -252,23 +252,38 @@ property storage, generated tables, bitsets, interning, and copy-on-write
 values where useful rather than literal public structs with one field per
 property.
 
-### Limited text inheritance
+### Limited inheritance
 
 Only the following properties inherit in version 1:
 
+- `cursor`;
+- `pointer_events`;
+- `direction`;
 - `font_family`;
+- `font_feature_settings`;
+- `font_variation_settings`;
+- `font_optical_sizing`;
 - `font_size`;
 - `font_weight`;
 - `font_style`;
 - `line_height`;
 - `letter_spacing`;
-- `color`.
+- `color`;
+- `text_align`;
+- `text_decoration`;
+- `text_shadow`.
 
-The initial inherited context is platform system font, `14px`, weight `400`,
-`normal` font style, platform-normal line height, zero letter spacing, and
-opaque black. A surface may provide a different root font size through its
-`StyleEnvironment`; `rem` and an otherwise unspecified root `font_size` use
-that value.
+Registered custom properties also inherit by name. They are not entries in the
+closed `StyleProperty` registry and therefore are not counted in the sixteen
+built-in properties above.
+
+The initial inherited context uses the automatic cursor and pointer behavior,
+left-to-right direction, platform system font, `14px`, weight `400`, `normal`
+font style, platform-normal line height, zero letter spacing, opaque black,
+start text alignment, and no decoration or shadow. Extended font settings use
+their engine initial values. A surface may provide a different root font size
+through its `StyleEnvironment`; `rem` and an otherwise unspecified root
+`font_size` use that value.
 
 For each property, resolution is:
 
@@ -278,20 +293,23 @@ explicit value on this node
     ?? engine initial value
 ```
 
-The resulting seven computed values form the `InheritedStyle` passed to all
-children, whether the current node itself draws text or is only a container.
-This makes a parent's `font_size` or `color` the default for descendant text
-without treating arbitrary properties as inherited.
+The resulting sixteen computed values and registered custom properties form
+the `InheritedStyle` passed to all children, whether the current node itself
+draws text or is only a container. This makes a parent's text, direction, and
+input defaults available to descendants without treating arbitrary properties
+as inherited.
 
 Layout, box, background, border, opacity, transform, filter, clip, overflow,
-pointer, and semantics properties do not inherit. Parent opacity and transform
-still affect descendants through scene composition; that is geometric or
-compositing ancestry, not inheritance.
+and semantics properties do not inherit. Pointer hit-test participation is the
+explicit exception through `pointer_events`; `cursor` likewise follows the
+nearest ancestor when omitted. Parent opacity and transform still affect
+descendants through scene composition; that is geometric or compositing
+ancestry, not inheritance.
 
 Version 1 has no public `inherit`, `initial`, `unset`, or `revert` keywords.
-Omitting a text property selects the inherited value. Explicitly specifying a
-value overrides it. New inherited properties require a protocol-compatible
-RFC change because they can invalidate entire subtrees.
+Omitting an inherited property selects the inherited value. Explicitly
+specifying a value overrides it. New inherited properties require a
+protocol-compatible RFC change because they can invalidate entire subtrees.
 
 ### Element defaults and applicability
 
@@ -311,9 +329,9 @@ text-style-consumer categories as defined by RFC 0004. Its public module DSL
 does not expose a Rust `Trait` list, and it does not repeat every common style
 property. Invalid property/element combinations should be compile-time errors
 when statically known and deterministic runtime diagnostics otherwise.
-The seven inherited text properties are valid on containers because they also
-define the inherited context for descendants, even when that container does
-not paint text itself.
+The inherited properties are valid on containers because they also define the
+inherited context for descendants, even when that container does not paint
+text or directly handle input itself.
 
 Element-specific behavior stays in the canonical element schema. For example,
 `Video` uses common width, border, opacity, transform, and clip styles, while
@@ -970,7 +988,8 @@ typed replacements for properties used by maintained Whisker packages.
 3. No public selector, stylesheet, specificity, `!important`, or global
    cascade participates in rendering.
 4. Explicit style fragments compose in order with last declaration winning.
-5. Only the seven listed text properties inherit in version 1.
+5. Only the sixteen listed built-in properties and registered custom
+   properties inherit in version 1.
 6. Taffy is authoritative for interactive layout on every target.
 7. The Host owns shaping and painting, but not style or layout semantics.
 8. Signal and motion updates target the same typed property slots.


### PR DESCRIPTION
## Purpose\nConsolidates the core-only review remediation branches so they can be audited as one coherent change set. This PR is intentionally Draft: inclusion here does not mean every external-review recommendation was accepted unchanged.\n\n## Supersedes after audit\n#571, #573, #576, #577, #578, #579, #580, #581, #582, #583, #584, #585, #586, #589, #591, #592, #593, #594.\n\n## Areas\n- typed style resolution and inheritance\n- Taffy layout lowering\n- paint and motion-path canonicalization\n- retained protocol validation and delta projection performance\n\n## Re-audit decisions\n- Rejected #584's imported Unicode-whitespace restriction. CSS Syntax treats every non-ASCII code point as an identifier code point; explicit NBSP/U+2028/U+0085 coverage was added.\n- Kept #586's constant-space retired-node watermark only after correcting its missing producer invariant: Engine snapshots now emit CreateNode operations in ascending NodeId order instead of arbitrary HashMap order.\n- Added producer- and consumer-side regression tests for the monotonic allocation contract.\n- No package changes are included.\n- Base remains next-architecture; this PR is independent of the Host stack.\n\n## Validation\n- cargo test -p whisker-style -p whisker-layout -p whisker-engine -p whisker-protocol -p whisker-css\n- cargo llvm-cov for whisker-style, whisker-engine, and whisker-protocol: 100% lines, functions, and regions\n- cargo fmt --all --check\n