### PR TITLE
review rollup 3/7: desktop host correctness and hot paths

### DIFF
--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -422,18 +422,17 @@ impl DesktopApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, mut event: InputEvent) {
-        if let Some(host) = &self.host {
-            host.target_input(&mut event);
-        }
+    fn dispatch_input(&mut self, event: InputEvent) {
         let Some(runtime) = &self.runtime else {
             return;
         };
-        let should_request_frame = match self
+        let host = self
             .host
-            .as_ref()
-            .expect("mounted Desktop runtime has a Host")
-            .with_modules(|| runtime.dispatch_input(&event))
+            .as_mut()
+            .expect("mounted Desktop runtime has a Host");
+        let presentation = host.take_presentation_updates();
+        let should_request_frame = match host
+            .with_modules(|| runtime.dispatch_input_with_presentation(&event, &presentation))
         {
             Ok(dispatch) => input_dispatch_needs_frame(dispatch),
             Err(error) => {

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -16,7 +16,7 @@ use whisker::{
     SurfaceRuntime,
 };
 use whisker_protocol::{
-    CursorKeyword, InputEvent, InputEventKind, LayoutRect, SurfaceId, WhiskerValue,
+    CursorKeyword, InputEvent, InputEventKind, LayoutRect, NodeId, SurfaceId, WhiskerValue,
 };
 use whisker_style::StyleEnvironment;
 use winit::application::ApplicationHandler;
@@ -248,7 +248,8 @@ struct DesktopApplication {
     started_at: Instant,
     retrying_failed_frame: bool,
     pointer: DesktopPointerAdapter,
-    pending_scroll_settle: Option<(Instant, [f32; 2])>,
+    pointer_target: Option<NodeId>,
+    pending_scroll_settle: Option<(Instant, NodeId)>,
     modifiers: Modifiers,
     clipboard: Option<arboard::Clipboard>,
 }
@@ -279,6 +280,7 @@ impl DesktopApplication {
             started_at: Instant::now(),
             retrying_failed_frame: false,
             pointer: DesktopPointerAdapter::new(SurfaceId::new(1).unwrap()),
+            pointer_target: None,
             pending_scroll_settle: None,
             modifiers: Modifiers::default(),
             clipboard: arboard::Clipboard::new().ok(),
@@ -422,29 +424,30 @@ impl DesktopApplication {
         self.request_frame();
     }
 
-    fn dispatch_input(&mut self, event: InputEvent) {
+    fn dispatch_input(&mut self, event: InputEvent) -> InputDispatch {
         let Some(runtime) = &self.runtime else {
-            return;
+            return InputDispatch::default();
         };
         let host = self
             .host
             .as_mut()
             .expect("mounted Desktop runtime has a Host");
         let presentation = host.take_presentation_updates();
-        let should_request_frame = match host
+        let dispatch = match host
             .with_modules(|| runtime.dispatch_input_with_presentation(&event, &presentation))
         {
-            Ok(dispatch) => input_dispatch_needs_frame(dispatch),
+            Ok(dispatch) => dispatch,
             Err(error) => {
                 eprintln!("dispatch {TARGET_NAME} input failed: {error}");
                 // A failed transaction may still have committed independent
                 // valid mutations. Rendering gives it a recovery boundary.
-                true
+                InputDispatch::default()
             }
         };
-        if should_request_frame {
+        if input_dispatch_needs_frame(dispatch) {
             self.request_frame();
         }
+        dispatch
     }
 
     fn sync_text_input(&self) {
@@ -672,10 +675,11 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                         self.started_at.elapsed().as_secs_f64() * 1000.0,
                         [logical.x, logical.y],
                     );
-                    self.dispatch_input(input);
+                    let dispatch = self.dispatch_input(input);
+                    self.pointer_target = dispatch.target;
                     if let (Some(window), Some(host)) = (&self.window, &self.host) {
                         let cursor = host
-                            .cursor_at([logical.x, logical.y])
+                            .cursor_for_target(dispatch.target)
                             .unwrap_or(CursorKeyword::Default);
                         window.set_cursor_visible(cursor != CursorKeyword::None);
                         if cursor != CursorKeyword::None {
@@ -685,36 +689,37 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                 }
             }
             WindowEvent::MouseInput { state, button, .. } => {
-                if let Some(input) = self.pointer.mouse_button(
-                    self.started_at.elapsed().as_secs_f64() * 1000.0,
-                    mouse_button(button),
-                    state == ElementState::Pressed,
-                ) {
-                    self.dispatch_input(input);
-                }
+                let dispatch = self
+                    .pointer
+                    .mouse_button(
+                        self.started_at.elapsed().as_secs_f64() * 1000.0,
+                        mouse_button(button),
+                        state == ElementState::Pressed,
+                    )
+                    .map_or_else(InputDispatch::default, |input| self.dispatch_input(input));
+                self.pointer_target = dispatch.target.or(self.pointer_target);
                 if button == MouseButton::Left
                     && state == ElementState::Pressed
-                    && let (Some(position), Some(host)) =
-                        (self.pointer.mouse_position(), self.host.as_mut())
-                    && host.focus_text_input_at([position.x, position.y])
+                    && let Some(host) = self.host.as_mut()
+                    && host.focus_text_input_target(dispatch.target)
                 {
                     self.request_frame();
                     self.sync_text_input();
                 }
             }
             WindowEvent::MouseWheel { delta, phase, .. } => {
-                if let (Some(window), Some(position), Some(host)) =
-                    (&self.window, self.pointer.mouse_position(), &mut self.host)
+                if let (Some(window), Some(target), Some(host)) =
+                    (&self.window, self.pointer_target, &mut self.host)
                 {
-                    let point = [position.x, position.y];
-                    let changed = host.scroll_at(point, scroll_delta(delta, window.scale_factor()));
+                    let changed = host
+                        .scroll_target(Some(target), scroll_delta(delta, window.scale_factor()));
                     let settled = if phase == TouchPhase::Ended {
                         self.pending_scroll_settle = None;
-                        host.settle_scroll_at(point)
+                        host.settle_scroll_target(Some(target))
                     } else {
                         if changed {
                             self.pending_scroll_settle =
-                                Some((Instant::now() + Duration::from_millis(100), point));
+                                Some((Instant::now() + Duration::from_millis(100), target));
                         }
                         false
                     };
@@ -737,6 +742,7 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
                 }
             }
             WindowEvent::CursorLeft { .. } => {
+                self.pointer_target = None;
                 if let Some(window) = &self.window {
                     window.set_cursor_visible(true);
                     window.set_cursor(CursorIcon::Default);
@@ -752,7 +758,7 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
             self.pending_scroll_settle.map(|(deadline, _)| deadline),
             now,
         ));
-        let Some((deadline, point)) = self.pending_scroll_settle else {
+        let Some((deadline, target)) = self.pending_scroll_settle else {
             return;
         };
         if now < deadline {
@@ -762,7 +768,7 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
         if self
             .host
             .as_mut()
-            .is_some_and(|host| host.settle_scroll_at(point))
+            .is_some_and(|host| host.settle_scroll_target(Some(target)))
         {
             self.request_frame();
         }

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 use whisker::runtime::RuntimeWakeHandle;
 use whisker::runtime::module::RustModuleDefinition;
-use whisker::{Element, ElementModuleDefinition, ElementRegistry, RuntimeInstance, SurfaceRuntime};
+use whisker::{
+    Element, ElementModuleDefinition, ElementRegistry, InputDispatch, RuntimeInstance,
+    SurfaceRuntime,
+};
 use whisker_protocol::{
     CursorKeyword, InputEvent, InputEventKind, LayoutRect, SurfaceId, WhiskerValue,
 };
@@ -426,18 +429,23 @@ impl DesktopApplication {
         let Some(runtime) = &self.runtime else {
             return;
         };
-        if let Err(error) = self
+        let should_request_frame = match self
             .host
             .as_ref()
             .expect("mounted Desktop runtime has a Host")
             .with_modules(|| runtime.dispatch_input(&event))
         {
-            eprintln!("dispatch {TARGET_NAME} input failed: {error}");
+            Ok(dispatch) => input_dispatch_needs_frame(dispatch),
+            Err(error) => {
+                eprintln!("dispatch {TARGET_NAME} input failed: {error}");
+                // A failed transaction may still have committed independent
+                // valid mutations. Rendering gives it a recovery boundary.
+                true
+            }
+        };
+        if should_request_frame {
+            self.request_frame();
         }
-        // A failed transaction may still have committed independent valid
-        // mutations. Rendering also gives a transient binding failure its
-        // one-shot recovery boundary.
-        self.request_frame();
     }
 
     fn sync_text_input(&self) {
@@ -772,6 +780,10 @@ fn printable_key_text(text: Option<&str>) -> Option<&str> {
     text.filter(|text| !text.is_empty() && text.chars().all(|character| !character.is_control()))
 }
 
+fn input_dispatch_needs_frame(dispatch: InputDispatch) -> bool {
+    dispatch.consumed || dispatch.queued
+}
+
 fn ime_cursor_area(rect: LayoutRect) -> (winit::dpi::LogicalPosition<f64>, LogicalSize<f64>) {
     (
         winit::dpi::LogicalPosition::new(rect.x as f64, rect.y as f64),
@@ -784,8 +796,10 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{
-        DesktopAppConfig, ime_cursor_area, printable_key_text, scroll_settle_control_flow,
+        DesktopAppConfig, ime_cursor_area, input_dispatch_needs_frame, printable_key_text,
+        scroll_settle_control_flow,
     };
+    use whisker::InputDispatch;
     use whisker_protocol::LayoutRect;
     use winit::event_loop::ControlFlow;
 
@@ -842,5 +856,18 @@ mod tests {
             scroll_settle_control_flow(Some(now + Duration::from_millis(1)), now),
             ControlFlow::WaitUntil(now + Duration::from_millis(1))
         );
+    }
+
+    #[test]
+    fn unhandled_pointer_motion_does_not_request_a_gpu_frame() {
+        assert!(!input_dispatch_needs_frame(InputDispatch::default()));
+        assert!(input_dispatch_needs_frame(InputDispatch {
+            consumed: true,
+            ..InputDispatch::default()
+        }));
+        assert!(input_dispatch_needs_frame(InputDispatch {
+            queued: true,
+            ..InputDispatch::default()
+        }));
     }
 }

--- a/platforms/desktop/src/app.rs
+++ b/platforms/desktop/src/app.rs
@@ -740,11 +740,15 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
     }
 
     fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let now = Instant::now();
+        event_loop.set_control_flow(scroll_settle_control_flow(
+            self.pending_scroll_settle.map(|(deadline, _)| deadline),
+            now,
+        ));
         let Some((deadline, point)) = self.pending_scroll_settle else {
             return;
         };
-        if Instant::now() < deadline {
-            event_loop.set_control_flow(ControlFlow::WaitUntil(deadline));
+        if now < deadline {
             return;
         }
         self.pending_scroll_settle = None;
@@ -756,6 +760,12 @@ impl ApplicationHandler<HostEvent> for DesktopApplication {
             self.request_frame();
         }
     }
+}
+
+fn scroll_settle_control_flow(deadline: Option<Instant>, now: Instant) -> ControlFlow {
+    deadline
+        .filter(|deadline| *deadline > now)
+        .map_or(ControlFlow::Wait, ControlFlow::WaitUntil)
 }
 
 fn printable_key_text(text: Option<&str>) -> Option<&str> {
@@ -771,8 +781,13 @@ fn ime_cursor_area(rect: LayoutRect) -> (winit::dpi::LogicalPosition<f64>, Logic
 
 #[cfg(test)]
 mod tests {
-    use super::{DesktopAppConfig, ime_cursor_area, printable_key_text};
+    use std::time::{Duration, Instant};
+
+    use super::{
+        DesktopAppConfig, ime_cursor_area, printable_key_text, scroll_settle_control_flow,
+    };
     use whisker_protocol::LayoutRect;
+    use winit::event_loop::ControlFlow;
 
     #[test]
     fn default_config_preserves_the_standalone_window_contract() {
@@ -813,5 +828,19 @@ mod tests {
         assert_eq!(position.y, 20.0);
         assert_eq!(size.width, 120.0);
         assert_eq!(size.height, 44.0);
+    }
+
+    #[test]
+    fn scroll_settle_deadlines_return_to_blocking_wait() {
+        let now = Instant::now();
+        assert_eq!(scroll_settle_control_flow(None, now), ControlFlow::Wait);
+        assert_eq!(
+            scroll_settle_control_flow(Some(now - Duration::from_millis(1)), now),
+            ControlFlow::Wait
+        );
+        assert_eq!(
+            scroll_settle_control_flow(Some(now + Duration::from_millis(1)), now),
+            ControlFlow::WaitUntil(now + Duration::from_millis(1))
+        );
     }
 }

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -589,6 +589,10 @@ pub(crate) enum DesktopElementContent {
 }
 
 impl DesktopElementContent {
+    pub(crate) fn is_reusable_presentation(&self) -> bool {
+        matches!(self, Self::Empty | Self::Text(_))
+    }
+
     pub(crate) fn reset_for_presentation_reuse(&mut self) {
         match self {
             Self::Text(text) => *text = None,
@@ -873,15 +877,6 @@ impl DesktopElementRegistry {
         element_type: ElementTypeId,
     ) -> Result<(), DesktopElementError> {
         self.binding(element_type).map(|_| ())
-    }
-
-    pub(crate) fn is_builtin_presentation(&self, element_type: ElementTypeId) -> bool {
-        self.binding(element_type).is_ok_and(|binding| {
-            matches!(
-                binding.registration.name.as_str(),
-                "whisker.ui/View" | "whisker.ui/Text"
-            )
-        })
     }
 
     pub(crate) fn child_policy(

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -1005,10 +1005,9 @@ impl DesktopElementRegistry {
     fn binding(
         &self,
         element_type: ElementTypeId,
-    ) -> Result<DesktopElementBinding, DesktopElementError> {
+    ) -> Result<&DesktopElementBinding, DesktopElementError> {
         self.bindings
             .get(&element_type)
-            .cloned()
             .ok_or(DesktopElementError::UnknownElementType { element_type })
     }
 }

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -155,6 +155,10 @@ impl DesktopElementFactory {
             }
         }
     }
+
+    fn accepts_text_style(&self) -> bool {
+        matches!(&self.kind, DesktopElementFactoryKind::Native(_))
+    }
 }
 
 impl fmt::Debug for DesktopElementFactory {
@@ -864,6 +868,13 @@ impl DesktopElementRegistry {
         Ok(self.binding(element_type)?.factory.create(events))
     }
 
+    pub(crate) fn validate_element_type(
+        &self,
+        element_type: ElementTypeId,
+    ) -> Result<(), DesktopElementError> {
+        self.binding(element_type).map(|_| ())
+    }
+
     pub(crate) fn is_builtin_presentation(&self, element_type: ElementTypeId) -> bool {
         self.binding(element_type).is_ok_and(|binding| {
             matches!(
@@ -916,7 +927,8 @@ impl DesktopElementRegistry {
         &self,
         element_type: ElementTypeId,
     ) -> Result<bool, DesktopElementError> {
-        Ok(self.binding(element_type)?.registration.text_style)
+        let binding = self.binding(element_type)?;
+        Ok(binding.registration.text_style && binding.factory.accepts_text_style())
     }
 
     pub(crate) fn validate_property(

--- a/platforms/desktop/src/element.rs
+++ b/platforms/desktop/src/element.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use whisker::WhiskerModule;
@@ -145,11 +146,36 @@ impl DesktopElementFactory {
             DesktopElementFactoryKind::Presentation => DesktopElementContent::Empty,
             DesktopElementFactoryKind::Text => DesktopElementContent::Text(None),
             DesktopElementFactoryKind::ScrollContainer => DesktopElementContent::ScrollContainer,
-            DesktopElementFactoryKind::Native(create) => DesktopElementContent::Native {
-                implementation: create(events),
-                text: None,
-                plain_text: self.plain_text,
-            },
+            DesktopElementFactoryKind::Native(create) => {
+                let isolates_failures = !matches!(
+                    self.name.as_str(),
+                    "whisker.ui/View" | "whisker.ui/Text" | "whisker.ui/ScrollView"
+                );
+                if isolates_failures {
+                    match catch_unwind(AssertUnwindSafe(|| create(events))) {
+                        Ok(implementation) => DesktopElementContent::Native {
+                            implementation,
+                            text: None,
+                            plain_text: self.plain_text,
+                            isolates_failures,
+                        },
+                        Err(_) => {
+                            eprintln!(
+                                "[whisker] disabled `{}` after its Desktop factory panicked; common presentation remains active",
+                                self.name
+                            );
+                            DesktopElementContent::Failed
+                        }
+                    }
+                } else {
+                    DesktopElementContent::Native {
+                        implementation: create(events),
+                        text: None,
+                        plain_text: self.plain_text,
+                        isolates_failures,
+                    }
+                }
+            }
             DesktopElementFactoryKind::Declared(_) => {
                 unreachable!("Desktop declared factory was not bound at bootstrap")
             }
@@ -581,10 +607,12 @@ pub(crate) enum DesktopElementContent {
     Empty,
     Text(Option<TextContent>),
     ScrollContainer,
+    Failed,
     Native {
         implementation: Box<dyn DesktopNativeElement>,
         text: Option<TextContent>,
         plain_text: bool,
+        isolates_failures: bool,
     },
 }
 
@@ -597,7 +625,7 @@ impl DesktopElementContent {
         match self {
             Self::Text(text) => *text = None,
             Self::Native { text, .. } => *text = None,
-            Self::Empty | Self::ScrollContainer => {}
+            Self::Empty | Self::ScrollContainer | Self::Failed => {}
         }
     }
 
@@ -605,28 +633,28 @@ impl DesktopElementContent {
         match self {
             Self::ScrollContainer => true,
             Self::Native { implementation, .. } => implementation.is_scroll_container(),
-            Self::Empty | Self::Text(_) => false,
+            Self::Empty | Self::Text(_) | Self::Failed => false,
         }
     }
 
     pub(crate) fn scroll_horizontal(&self) -> bool {
         match self {
             Self::Native { implementation, .. } => implementation.scroll_horizontal(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => false,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => false,
         }
     }
 
     pub(crate) fn item_snap(&self) -> Option<(f64, f64)> {
         match self {
             Self::Native { implementation, .. } => implementation.item_snap(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
     pub(crate) fn snap_stop_always(&self) -> bool {
         match self {
             Self::Native { implementation, .. } => implementation.snap_stop_always(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => false,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => false,
         }
     }
 
@@ -634,7 +662,7 @@ impl DesktopElementContent {
         match self {
             Self::Native { implementation, .. } => implementation.scroll_enabled(),
             Self::ScrollContainer => true,
-            Self::Empty | Self::Text(_) => false,
+            Self::Empty | Self::Text(_) | Self::Failed => false,
         }
     }
 
@@ -642,7 +670,7 @@ impl DesktopElementContent {
         match self {
             Self::Text(content) => content.as_ref(),
             Self::Native { text, .. } => text.as_ref(),
-            Self::Empty | Self::ScrollContainer => None,
+            Self::Empty | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -652,7 +680,7 @@ impl DesktopElementContent {
                 Some(implementation.as_ref())
             }
             Self::Native { .. } => None,
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -679,7 +707,7 @@ impl DesktopElementContent {
     pub(crate) fn selected_text(&self) -> Option<String> {
         match self {
             Self::Native { implementation, .. } => implementation.selected_text(),
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -692,7 +720,7 @@ impl DesktopElementContent {
             Self::Native { implementation, .. } => {
                 implementation.text_input_caret_rect(logical_size, scale)
             }
-            Self::Empty | Self::Text(_) | Self::ScrollContainer => None,
+            Self::Empty | Self::Text(_) | Self::ScrollContainer | Self::Failed => None,
         }
     }
 
@@ -714,6 +742,7 @@ impl DesktopElementContent {
                 *text = Some(content);
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::ScrollContainer | Self::Native { .. } => {
                 Err(DesktopElementError::UnexpectedText { node })
             }
@@ -726,10 +755,25 @@ impl DesktopElementContent {
         style: &WhiskerTextStyle,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.set_text_style(style);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.set_text_style(style);
+                } else if catch_unwind(AssertUnwindSafe(|| implementation.set_text_style(style)))
+                    .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after set_text_style panicked; common presentation remains active",
+                        node.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnexpectedText { node })
             }
@@ -743,10 +787,28 @@ impl DesktopElementContent {
         value: &WhiskerValue,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.set_property(property, value);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.set_property(property, value);
+                } else if catch_unwind(AssertUnwindSafe(|| {
+                    implementation.set_property(property, value)
+                }))
+                .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after property {} panicked; common presentation remains active",
+                        node.get(),
+                        property.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedProperty { node, property })
             }
@@ -759,10 +821,26 @@ impl DesktopElementContent {
         property: PropertyId,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.clear_property(property);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.clear_property(property);
+                } else if catch_unwind(AssertUnwindSafe(|| implementation.clear_property(property)))
+                    .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after clearing property {} panicked; common presentation remains active",
+                        node.get(),
+                        property.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedProperty { node, property })
             }
@@ -776,10 +854,28 @@ impl DesktopElementContent {
         arguments: &WhiskerValue,
     ) -> Result<(), DesktopElementError> {
         match self {
-            Self::Native { implementation, .. } => {
-                implementation.invoke_command(command, arguments);
+            Self::Native {
+                implementation,
+                isolates_failures,
+                ..
+            } => {
+                if !*isolates_failures {
+                    implementation.invoke_command(command, arguments);
+                } else if catch_unwind(AssertUnwindSafe(|| {
+                    implementation.invoke_command(command, arguments)
+                }))
+                .is_err()
+                {
+                    eprintln!(
+                        "[whisker] disabled Desktop element at node {} after command {} panicked; common presentation remains active",
+                        node.get(),
+                        command.get()
+                    );
+                    *self = Self::Failed;
+                }
                 Ok(())
             }
+            Self::Failed => Ok(()),
             Self::Empty | Self::Text(_) | Self::ScrollContainer => {
                 Err(DesktopElementError::UnsupportedCommand { node, command })
             }

--- a/platforms/desktop/src/gpu/shaders.rs
+++ b/platforms/desktop/src/gpu/shaders.rs
@@ -109,7 +109,7 @@ fn vs_main(input: VertexInput, @builtin(instance_index) draw_index: u32) -> Vert
     output.position = vec4<f32>(
         transformed.x / viewport.logical_size.x * 2.0 - transformed.w,
         transformed.w - transformed.y / viewport.logical_size.y * 2.0,
-        transformed.z,
+        0.0,
         transformed.w,
     );
     output.color = input.color;

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -220,6 +220,12 @@ impl DesktopRuntime {
         self.modules.with_host(work)
     }
 
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.surface.take_presentation_updates()
+    }
+
     /// Reconfigures the GPU surface after an OS resize notification.
     pub fn resize(&mut self, physical_size: [u32; 2]) {
         self.surface.resize(physical_size);
@@ -229,17 +235,6 @@ impl DesktopRuntime {
     /// logical window position.
     pub fn cursor_at(&self, logical_position: [f32; 2]) -> Option<whisker_protocol::CursorKeyword> {
         self.surface.cursor_at(logical_position)
-    }
-
-    /// Resolves the Host-visible target after applying transient scroll state.
-    pub fn target_input(&self, event: &mut InputEvent) {
-        if event.target.is_none()
-            && let Some(pointer) = event.pointer
-        {
-            event.target = self
-                .surface
-                .hit_test([pointer.position.x, pointer.position.y]);
-        }
     }
 
     pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -238,7 +238,7 @@ impl DesktopRuntime {
     }
 
     /// Resolves the cursor for the target selected by Rust-authoritative hit testing.
-    pub fn cursor_for_target(
+    pub(crate) fn cursor_for_target(
         &self,
         target: Option<whisker_protocol::NodeId>,
     ) -> Option<whisker_protocol::CursorKeyword> {
@@ -255,7 +255,7 @@ impl DesktopRuntime {
     }
 
     /// Applies scrolling from a target selected by Rust-authoritative hit testing.
-    pub fn scroll_target(
+    pub(crate) fn scroll_target(
         &mut self,
         target: Option<whisker_protocol::NodeId>,
         delta: [f32; 2],
@@ -269,7 +269,10 @@ impl DesktopRuntime {
     }
 
     /// Settles scrolling from a target selected by Rust-authoritative hit testing.
-    pub fn settle_scroll_target(&mut self, target: Option<whisker_protocol::NodeId>) -> bool {
+    pub(crate) fn settle_scroll_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> bool {
         self.surface.settle_scroll_target(target)
     }
 
@@ -280,7 +283,10 @@ impl DesktopRuntime {
     }
 
     /// Focuses the nearest editor at a target selected by Rust hit testing.
-    pub fn focus_text_input_target(&mut self, target: Option<whisker_protocol::NodeId>) -> bool {
+    pub(crate) fn focus_text_input_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> bool {
         self.surface.focus_text_input_target(target)
     }
 

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -237,6 +237,14 @@ impl DesktopRuntime {
         self.surface.cursor_at(logical_position)
     }
 
+    /// Resolves the cursor for the target selected by Rust-authoritative hit testing.
+    pub fn cursor_for_target(
+        &self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> Option<whisker_protocol::CursorKeyword> {
+        self.surface.cursor_for_target(target)
+    }
+
     pub(crate) fn accessibility_snapshot(&self) -> DesktopAccessibilitySnapshot {
         self.surface.accessibility_snapshot()
     }
@@ -246,15 +254,34 @@ impl DesktopRuntime {
         self.surface.scroll_at(logical_position, delta)
     }
 
+    /// Applies scrolling from a target selected by Rust-authoritative hit testing.
+    pub fn scroll_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+        delta: [f32; 2],
+    ) -> bool {
+        self.surface.scroll_target(target, delta)
+    }
+
     /// Settles the nearest snapping ScrollView after wheel/trackpad input ends.
     pub fn settle_scroll_at(&mut self, logical_position: [f32; 2]) -> bool {
         self.surface.settle_scroll_at(logical_position)
+    }
+
+    /// Settles scrolling from a target selected by Rust-authoritative hit testing.
+    pub fn settle_scroll_target(&mut self, target: Option<whisker_protocol::NodeId>) -> bool {
+        self.surface.settle_scroll_target(target)
     }
 
     /// Focuses the editable native element under a pointer, blurring any
     /// previous editor. Clicking outside an editor clears text focus.
     pub fn focus_text_input_at(&mut self, logical_position: [f32; 2]) -> bool {
         self.surface.focus_text_input_at(logical_position)
+    }
+
+    /// Focuses the nearest editor at a target selected by Rust hit testing.
+    pub fn focus_text_input_target(&mut self, target: Option<whisker_protocol::NodeId>) -> bool {
+        self.surface.focus_text_input_target(target)
     }
 
     /// Routes one normalized OS edit to the focused native element.

--- a/platforms/desktop/src/lib.rs
+++ b/platforms/desktop/src/lib.rs
@@ -11,6 +11,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::path::{Path, PathBuf};
 
 use whisker::RuntimeInstance;
 use whisker::runtime::RuntimeWakeHandle;
@@ -66,6 +67,25 @@ use gpu::RasterResource;
 use resource::{DesktopResourceService, DesktopResourceUpdate};
 use surface::DesktopSurface;
 use text::NativeTextHost;
+
+fn asset_root_for_executable(executable: &Path) -> PathBuf {
+    let Some(directory) = executable.parent() else {
+        return PathBuf::new();
+    };
+    if directory.file_name().is_some_and(|name| name == "MacOS")
+        && let Some(contents) = directory.parent()
+        && contents.file_name().is_some_and(|name| name == "Contents")
+    {
+        return contents.join("Resources");
+    }
+    directory.to_owned()
+}
+
+fn bundled_asset_root() -> PathBuf {
+    std::env::current_exe()
+        .map(|executable| asset_root_for_executable(&executable))
+        .unwrap_or_default()
+}
 
 /// Logical and physical metrics sampled by an OS adapter for one frame.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -186,7 +206,7 @@ impl DesktopRuntime {
         Ok(Self {
             measurements: NativeTextHost::new(elements),
             surface,
-            resources: DesktopResourceService::new(std::path::PathBuf::new(), move || {
+            resources: DesktopResourceService::new(bundled_asset_root(), move || {
                 resource_wake.wake();
             }),
             resource_events: Vec::new(),
@@ -493,6 +513,24 @@ mod tests {
                 ..valid
             })
             .is_err()
+        );
+    }
+
+    #[test]
+    fn bundled_assets_resolve_beside_plain_desktop_executables() {
+        assert_eq!(
+            asset_root_for_executable(Path::new("/opt/example/bin/whisker-app")),
+            PathBuf::from("/opt/example/bin")
+        );
+    }
+
+    #[test]
+    fn bundled_assets_resolve_from_the_macos_bundle_resources_directory() {
+        assert_eq!(
+            asset_root_for_executable(Path::new(
+                "/Applications/Example.app/Contents/MacOS/example"
+            )),
+            PathBuf::from("/Applications/Example.app/Contents/Resources")
         );
     }
 

--- a/platforms/desktop/src/resource.rs
+++ b/platforms/desktop/src/resource.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
 
 use base64::Engine;
 use whisker_protocol::{
@@ -13,6 +14,10 @@ use whisker_protocol::{
 };
 
 use crate::gpu::RasterResource;
+
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum DesktopResourceState {
@@ -67,6 +72,7 @@ pub(crate) struct DesktopResourceService {
     sender: mpsc::Sender<Completion>,
     receiver: Receiver<Completion>,
     wake: Arc<dyn Fn() + Send + Sync>,
+    http: ureq::Agent,
 }
 
 impl DesktopResourceService {
@@ -79,6 +85,10 @@ impl DesktopResourceService {
             sender,
             receiver,
             wake: Arc::new(wake),
+            http: ureq::AgentBuilder::new()
+                .timeout_connect(HTTP_CONNECT_TIMEOUT)
+                .timeout_read(HTTP_READ_TIMEOUT)
+                .build(),
         }
     }
 
@@ -122,13 +132,14 @@ impl DesktopResourceService {
         let sender = self.sender.clone();
         let wake = Arc::clone(&self.wake);
         let asset_root = self.asset_root.clone();
+        let http = self.http.clone();
         std::thread::Builder::new()
             .name("whisker-desktop-resource".into())
             .spawn(move || {
                 let completion = Completion {
                     resource: request.resource,
                     generation: request.generation,
-                    result: acquire_raster(request.source, asset_root),
+                    result: acquire_raster(request.source, asset_root, &http),
                 };
                 let _ = sender.send(completion);
                 wake();
@@ -211,6 +222,7 @@ impl DesktopResourceService {
 fn acquire_raster(
     source: ResourceSource,
     asset_root: PathBuf,
+    http: &ureq::Agent,
 ) -> Result<RasterResource, (ResourceFailureCode, String)> {
     let bytes = match source {
         ResourceSource::Bytes { data, .. } => data,
@@ -218,7 +230,9 @@ fn acquire_raster(
             .map_err(|error| (ResourceFailureCode::NotFound, error.to_string()))?,
         ResourceSource::Url(url) if url.starts_with("data:") => decode_data_url(&url)?,
         ResourceSource::Url(url) if url.starts_with("https://") || url.starts_with("http://") => {
-            let response = ureq::get(&url)
+            let response = http
+                .get(&url)
+                .timeout(HTTP_REQUEST_TIMEOUT)
                 .call()
                 .map_err(|error| (ResourceFailureCode::Network, error.to_string()))?;
             let mut bytes = Vec::new();

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -338,6 +338,7 @@ pub(crate) struct DesktopScene {
     elements: DesktopElementRegistry,
     nodes: HashMap<NodeId, RenderNode>,
     smooth_scrolls: HashMap<NodeId, SmoothScroll>,
+    dirty_scroll_offsets: HashSet<NodeId>,
     presentation_pool: HashMap<ElementTypeId, Vec<DesktopElementContent>>,
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -10,8 +10,8 @@ use whisker_protocol::{
     BoxClip, BoxPaint, ClipShape, Cursor, ElementTypeId, FillRule, FrameMode, FramePacket,
     HitTestBehavior, ImageRepeat, LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip,
     PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand, PointerId,
-    RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent, Transform,
-    ValidationError, Visibility, VisualEffects, WhiskerValue,
+    PreparedContentId, RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent,
+    Transform, ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
 
 use crate::DesktopTextInputEvent;
@@ -343,6 +343,8 @@ pub(crate) struct DesktopScene {
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,
     raster_resources: HashSet<ResourceId>,
+    prepared_content_references: HashMap<PreparedContentId, usize>,
+    prepared_content_revision: u64,
 }
 
 impl fmt::Display for DesktopPresentError {

--- a/platforms/desktop/src/scene.rs
+++ b/platforms/desktop/src/scene.rs
@@ -9,7 +9,7 @@ use whisker_protocol::{
     Accessibility, ApplyResult, BackgroundAttachment, BackgroundLayer, BackgroundSize, BlendMode,
     BoxClip, BoxPaint, ClipShape, Cursor, ElementTypeId, FillRule, FrameMode, FramePacket,
     HitTestBehavior, ImageRepeat, LayoutGeometry, LayoutRect, NodeId, Operation, OverflowClip,
-    PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand, PointerId,
+    PaintBox, PaintColor, PaintCoordinate, PaintImage, PaintPosition, PathCommand,
     PreparedContentId, RadialGradientExtent, ResourceId, SceneProjection, SurfaceId, TextContent,
     Transform, ValidationError, Visibility, VisualEffects, WhiskerValue,
 };
@@ -338,7 +338,6 @@ pub(crate) struct DesktopScene {
     elements: DesktopElementRegistry,
     nodes: HashMap<NodeId, RenderNode>,
     smooth_scrolls: HashMap<NodeId, SmoothScroll>,
-    pointer_captures: HashMap<PointerId, NodeId>,
     presentation_pool: HashMap<ElementTypeId, Vec<DesktopElementContent>>,
     pending_events: Arc<Mutex<Vec<DesktopProviderEvent>>>,
     event_wake: RuntimeWakeHandle,

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -10,7 +10,8 @@ use whisker_protocol::{
     ElementMeasurement, ElementPropertySchema, ElementRegistration, ElementValueKind, EventId,
     FrameHeader, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight, MeasureTextDirection,
     MeasureTextOverflow, MeasureTextWrap, PaintCorners, PaintEdges, PaintLengthPercentage,
-    PropertyId, ProtocolVersion, TextMeasurePayload, TextMeasureStyle, TextPaint,
+    PreparedContentId, PropertyId, ProtocolVersion, TextMeasurePayload, TextMeasureStyle,
+    TextPaint,
 };
 
 fn element_type(name: &str) -> ElementTypeId {
@@ -108,6 +109,13 @@ fn text() -> TextContent {
         },
         paint: TextPaint::default(),
         prepared_content: None,
+    }
+}
+
+fn prepared_text(id: u64) -> TextContent {
+    TextContent {
+        prepared_content: PreparedContentId::new(id),
+        ..text()
     }
 }
 
@@ -1246,6 +1254,82 @@ fn text_content_operation_is_dispatched_by_registered_element_type() {
         scene.paint_commands().as_slice(),
         [PaintCommand::Box { .. }, PaintCommand::Text { node, .. }] if *node == root
     ));
+}
+
+#[test]
+fn prepared_text_references_follow_committed_scene_content() {
+    let node = id(1);
+    let first = PreparedContentId::new(11).unwrap();
+    let second = PreparedContentId::new(12).unwrap();
+    let rejected = PreparedContentId::new(13).unwrap();
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node,
+                    element_type: element_type(whisker::TEXT_ELEMENT_NAME),
+                },
+                Operation::SetText {
+                    node,
+                    content: prepared_text(first.get()),
+                },
+            ],
+        ))
+        .unwrap();
+    let first_revision = scene.prepared_content_revision();
+    assert!(scene.references_prepared_content(first));
+
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::SetText {
+                node,
+                content: prepared_text(second.get()),
+            }],
+        ))
+        .unwrap();
+    assert!(scene.prepared_content_revision() > first_revision);
+    assert!(!scene.references_prepared_content(first));
+    assert!(scene.references_prepared_content(second));
+
+    assert!(
+        scene
+            .present(&packet(
+                FrameMode::Delta,
+                2,
+                3,
+                vec![
+                    Operation::SetText {
+                        node,
+                        content: prepared_text(rejected.get()),
+                    },
+                    Operation::SetOpacity {
+                        node,
+                        opacity: f32::NAN,
+                    },
+                ],
+            ))
+            .is_err()
+    );
+    assert!(!scene.references_prepared_content(rejected));
+    assert!(scene.references_prepared_content(second));
+
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            2,
+            3,
+            vec![Operation::DeleteNode { node }],
+        ))
+        .unwrap();
+    assert!(!scene.references_prepared_content(second));
 }
 
 #[test]

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -494,6 +494,51 @@ fn native_toggle_applies_properties_invokes_command_and_routes_change() {
 }
 
 #[test]
+fn module_content_named_like_a_builtin_is_not_added_to_the_presentation_pool() {
+    let element_type = ElementTypeId::new(20).unwrap();
+    let node = id(1);
+    let registration = ElementRegistration {
+        element_type,
+        name: whisker::VIEW_ELEMENT_NAME.into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![],
+        events: vec![],
+        commands: vec![],
+    };
+    let factory = DesktopElementFactory::native(whisker::VIEW_ELEMENT_NAME, |events| {
+        Box::new(ToggleNative {
+            checked: false,
+            disabled: false,
+            events,
+        })
+    });
+    let mut scene = DesktopScene::new(
+        SurfaceId::new(1).unwrap(),
+        DesktopElementRegistry::bind(&[registration], &[factory]).unwrap(),
+    );
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![Operation::CreateNode { node, element_type }],
+        ))
+        .unwrap();
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::DeleteNode { node }],
+        ))
+        .unwrap();
+
+    assert!(scene.presentation_pool.is_empty());
+}
+
+#[test]
 fn native_toggle_rejects_wrong_property_shape_before_commit() {
     let node = id(1);
     let (mut scene, element_type) = toggle_scene();

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -269,6 +269,124 @@ fn toggle_scene() -> (DesktopScene, ElementTypeId) {
     toggle_scene_with_wake(RuntimeWakeHandle::new(|| {}))
 }
 
+#[derive(Debug)]
+struct FailingNative;
+
+impl DesktopNativeElement for FailingNative {
+    fn set_property(&mut self, _property: PropertyId, _value: &WhiskerValue) {
+        panic!("module property failure")
+    }
+
+    fn clear_property(&mut self, _property: PropertyId) {
+        panic!("module property clear failure")
+    }
+
+    fn invoke_command(&mut self, _command: CommandId, _arguments: &WhiskerValue) {
+        panic!("module command failure")
+    }
+}
+
+fn failing_scene(factory_panics: bool) -> (DesktopScene, ElementTypeId) {
+    let element_type = ElementTypeId::new(22).unwrap();
+    let mut registrations = standard_element_registrations();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/Failing".into(),
+        child_policy: whisker_protocol::ChildPolicy::None,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![ElementPropertySchema {
+            property: CHECKED,
+            name: "checked".into(),
+            value: ElementValueKind::Bool,
+        }],
+        events: vec![],
+        commands: vec![ElementCommandSchema {
+            command: TOGGLE,
+            name: "fail".into(),
+            arguments: ElementValueKind::Null,
+        }],
+    });
+    let mut factories = built_in_element_factories();
+    factories.push(DesktopElementFactory::native(
+        "whisker.test/Failing",
+        move |_| {
+            assert!(!factory_panics, "module factory failure");
+            Box::new(FailingNative)
+        },
+    ));
+    (
+        DesktopScene::new(
+            SurfaceId::new(1).unwrap(),
+            DesktopElementRegistry::bind(&registrations, &factories).unwrap(),
+        ),
+        element_type,
+    )
+}
+
+#[test]
+fn native_element_failure_is_isolated_from_common_presentation() {
+    let node = id(1);
+    let (mut scene, element_type) = failing_scene(false);
+    let result = scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetProperty {
+                    node,
+                    property: CHECKED,
+                    value: WhiskerValue::Bool(true),
+                },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(4.0, 5.0, 80.0, 30.0),
+                },
+                Operation::InvokeCommand {
+                    node,
+                    command: TOGGLE,
+                    arguments: WhiskerValue::Null,
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert!(matches!(result, ApplyResult::Accepted { revision: 1 }));
+    let state = &scene.nodes[&node];
+    assert!(matches!(state.content, DesktopElementContent::Failed));
+    assert_eq!(state.presentation.layout.border_box.x, 4.0);
+    assert_eq!(state.presentation.layout.border_box.y, 5.0);
+}
+
+#[test]
+fn native_factory_failure_keeps_an_inert_common_node() {
+    let node = id(1);
+    let (mut scene, element_type) = failing_scene(true);
+    let result = scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetLayout {
+                    node,
+                    geometry: geometry(7.0, 9.0, 40.0, 20.0),
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert!(matches!(result, ApplyResult::Accepted { revision: 1 }));
+    assert!(matches!(
+        scene.nodes[&node].content,
+        DesktopElementContent::Failed
+    ));
+    assert_eq!(scene.nodes[&node].presentation.layout.border_box.x, 7.0);
+}
+
 #[derive(Debug, Default)]
 struct TextInputProbe {
     focused: bool,
@@ -690,6 +808,14 @@ fn scroll_container_offsets_paint_and_hit_testing_inside_its_viewport() {
     assert!(scene.scroll_at([10.0, 60.0], [0.0, 120.0]));
     assert_eq!(scene.nodes[&scroll].scroll_offset, [0.0, 120.0]);
     assert_eq!(
+        scene.take_presentation_updates(),
+        vec![whisker_protocol::HostPresentationUpdate::ScrollOffset {
+            node: scroll,
+            offset: whisker_protocol::InputPoint { x: 0.0, y: 120.0 },
+        }]
+    );
+    assert!(scene.take_presentation_updates().is_empty());
+    assert_eq!(
         scene.take_events(),
         vec![DesktopProviderEvent {
             target: scroll,
@@ -1110,6 +1236,73 @@ fn cursor_hit_testing_respects_pointer_events_and_child_z_order() {
         Some(whisker_protocol::CursorKeyword::Grab)
     );
     assert_eq!(scene.cursor_at([200.0, 20.0]), None);
+}
+
+#[test]
+fn cursor_and_native_scroll_hit_testing_follow_transforms() {
+    let root = id(1);
+    let child = id(2);
+    let element_type = element_type(whisker::VIEW_ELEMENT_NAME);
+    let mut transform = Transform::IDENTITY;
+    transform.0[12] = 100.0;
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node: root,
+                    element_type,
+                },
+                Operation::CreateNode {
+                    node: child,
+                    element_type,
+                },
+                Operation::InsertChild {
+                    parent: root,
+                    child,
+                    index: 0,
+                },
+                Operation::SetLayout {
+                    node: root,
+                    geometry: geometry(0.0, 0.0, 300.0, 100.0),
+                },
+                Operation::SetLayout {
+                    node: child,
+                    geometry: geometry(0.0, 0.0, 50.0, 50.0),
+                },
+                Operation::SetTransform {
+                    node: child,
+                    transform,
+                },
+                Operation::SetCursor {
+                    node: root,
+                    cursor: Cursor {
+                        resources: Vec::new(),
+                        fallback: whisker_protocol::CursorKeyword::Pointer,
+                    },
+                },
+                Operation::SetCursor {
+                    node: child,
+                    cursor: Cursor {
+                        resources: Vec::new(),
+                        fallback: whisker_protocol::CursorKeyword::Grab,
+                    },
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert_eq!(
+        scene.cursor_at([110.0, 10.0]),
+        Some(whisker_protocol::CursorKeyword::Grab)
+    );
+    assert_eq!(
+        scene.cursor_at([10.0, 10.0]),
+        Some(whisker_protocol::CursorKeyword::Pointer)
+    );
 }
 
 #[test]

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -136,7 +136,7 @@ fn packet(mode: FrameMode, base: u64, target: u64, operations: Vec<Operation>) -
 }
 
 #[test]
-fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
+fn runtime_owned_pointer_capture_operations_are_accepted_by_the_desktop_surface() {
     let node = id(1);
     let pointer = whisker_protocol::PointerId::new(7).unwrap();
     let mut scene = scene(SurfaceId::new(1).unwrap());
@@ -155,7 +155,6 @@ fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
             ],
         ))
         .unwrap();
-    assert_eq!(scene.pointer_captures.get(&pointer), Some(&node));
 
     scene
         .present(&packet(
@@ -165,7 +164,6 @@ fn pointer_capture_is_retained_and_released_by_the_desktop_surface() {
             vec![Operation::ReleasePointerCapture { node, pointer }],
         ))
         .unwrap();
-    assert!(!scene.pointer_captures.contains_key(&pointer));
 }
 
 const CHECKED: PropertyId = PropertyId::new(1).unwrap();

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -2,7 +2,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::*;
 use crate::element::{
-    DesktopElementFactory, DesktopNativeElement, DesktopNativeEvent, built_in_element_factories,
+    DesktopElementFactory, DesktopNativeElement, DesktopNativeEvent, DesktopViewDefinition,
+    DesktopViewImplementation, built_in_element_factories,
 };
 use whisker::standard_element_registrations;
 use whisker_protocol::{
@@ -1397,6 +1398,54 @@ fn prepared_text_references_follow_committed_scene_content() {
         ))
         .unwrap();
     assert!(!scene.references_prepared_content(second));
+}
+
+#[test]
+fn validation_does_not_instantiate_module_elements() {
+    let element_type = ElementTypeId::new(22).unwrap();
+    let node = id(1);
+    let constructions = Arc::new(AtomicUsize::new(0));
+    let observed_constructions = Arc::clone(&constructions);
+    let mut registrations = standard_element_registrations();
+    registrations.push(ElementRegistration {
+        element_type,
+        name: "whisker.test/PlainText".into(),
+        child_policy: whisker_protocol::ChildPolicy::PlainText,
+        measurement: ElementMeasurement::None,
+        text_style: false,
+        properties: vec![],
+        events: vec![],
+        commands: vec![],
+    });
+    let mut factories = built_in_element_factories();
+    factories.push(
+        DesktopViewDefinition::new("whisker.test/PlainText", move |_| {
+            observed_constructions.fetch_add(1, Ordering::Relaxed);
+        })
+        .plain_text()
+        .into_desktop_factory(),
+    );
+    let mut scene = DesktopScene::new(
+        SurfaceId::new(1).unwrap(),
+        DesktopElementRegistry::bind(&registrations, &factories).unwrap(),
+    );
+
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode { node, element_type },
+                Operation::SetText {
+                    node,
+                    content: text(),
+                },
+            ],
+        ))
+        .unwrap();
+
+    assert_eq!(constructions.load(Ordering::Relaxed), 1);
 }
 
 #[test]

--- a/platforms/desktop/src/scene/tests.rs
+++ b/platforms/desktop/src/scene/tests.rs
@@ -732,6 +732,75 @@ fn smooth_scroll_command_advances_on_host_frames() {
 }
 
 #[test]
+fn snapshot_discards_scroll_animation_from_the_previous_scene_epoch() {
+    let scroll = id(1);
+    let content = id(2);
+    let mut scene = scene(SurfaceId::new(1).unwrap());
+    scene
+        .present(&packet(
+            FrameMode::Snapshot,
+            0,
+            1,
+            vec![
+                Operation::CreateNode {
+                    node: scroll,
+                    element_type: element_type(whisker::SCROLL_VIEW_ELEMENT_NAME),
+                },
+                Operation::CreateNode {
+                    node: content,
+                    element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+                },
+                Operation::InsertChild {
+                    parent: scroll,
+                    child: content,
+                    index: 0,
+                },
+                Operation::SetLayout {
+                    node: scroll,
+                    geometry: geometry(0.0, 0.0, 100.0, 100.0),
+                },
+                Operation::SetLayout {
+                    node: content,
+                    geometry: geometry(0.0, 0.0, 100.0, 500.0),
+                },
+            ],
+        ))
+        .unwrap();
+    scene
+        .present(&packet(
+            FrameMode::Delta,
+            1,
+            2,
+            vec![Operation::InvokeCommand {
+                node: scroll,
+                command: whisker::SCROLL_TO_COMMAND,
+                arguments: WhiskerValue::map([
+                    ("offset", WhiskerValue::Float(240.0)),
+                    ("smooth", WhiskerValue::Bool(true)),
+                ]),
+            }],
+        ))
+        .unwrap();
+    assert!(scene.has_active_scroll_animations());
+
+    let mut replacement = packet(
+        FrameMode::Snapshot,
+        0,
+        1,
+        vec![Operation::CreateNode {
+            node: scroll,
+            element_type: element_type(whisker::VIEW_ELEMENT_NAME),
+        }],
+    );
+    replacement.header.scene_epoch = 2;
+    scene.present(&replacement).unwrap();
+
+    assert!(!scene.has_active_scroll_animations());
+    assert!(!scene.advance_scroll_animations(16.0));
+    assert_eq!(scene.nodes[&scroll].scroll_offset, [0.0, 0.0]);
+}
+
+#[test]
 fn snap_stop_always_limits_one_wheel_sequence_to_the_adjacent_child() {
     let scroll = id(1);
     let first = id(2);

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -931,6 +931,7 @@ impl DesktopScene {
             }
             self.pending_events.lock().unwrap().clear();
             self.pointer_captures.clear();
+            self.smooth_scrolls.clear();
         }
         for operation in &packet.operations {
             match operation {

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -1,5 +1,31 @@
 use super::*;
 
+fn inverse_map_around(transform: Transform, point: [f32; 2], origin: [f32; 2]) -> Option<[f32; 2]> {
+    if transform == Transform::IDENTITY {
+        return Some(point);
+    }
+    let [x, y] = [point[0] - origin[0], point[1] - origin[1]];
+    let matrix = transform.0;
+    let [a, c, tx] = [matrix[0], matrix[4], matrix[12]];
+    let [b, d, ty] = [matrix[1], matrix[5], matrix[13]];
+    let [p, q, r] = [matrix[3], matrix[7], matrix[15]];
+    let determinant = a * (d * r - ty * q) - c * (b * r - ty * p) + tx * (b * q - d * p);
+    if determinant.abs() <= f32::EPSILON {
+        return None;
+    }
+    let inverse_x = (d * r - ty * q) * x + (tx * q - c * r) * y + (c * ty - tx * d);
+    let inverse_y = (ty * p - b * r) * x + (a * r - tx * p) * y + (tx * b - a * ty);
+    let inverse_w = (b * q - d * p) * x + (c * p - a * q) * y + (a * d - c * b);
+    if inverse_w.abs() <= f32::EPSILON {
+        return None;
+    }
+    let mapped = [
+        origin[0] + inverse_x / inverse_w,
+        origin[1] + inverse_y / inverse_w,
+    ];
+    mapped.into_iter().all(f32::is_finite).then_some(mapped)
+}
+
 impl DesktopScene {
     #[cfg(test)]
     pub(crate) fn new(surface: SurfaceId, elements: DesktopElementRegistry) -> Self {
@@ -16,6 +42,7 @@ impl DesktopScene {
             elements,
             nodes: HashMap::new(),
             smooth_scrolls: HashMap::new(),
+            dirty_scroll_offsets: HashSet::new(),
             presentation_pool: HashMap::new(),
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
@@ -59,6 +86,24 @@ impl DesktopScene {
                     target: event.target,
                     name,
                     detail: event.detail,
+                })
+            })
+            .collect()
+    }
+
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.dirty_scroll_offsets
+            .drain()
+            .filter_map(|node| {
+                let offset = self.nodes.get(&node)?.scroll_offset;
+                Some(whisker_protocol::HostPresentationUpdate::ScrollOffset {
+                    node,
+                    offset: whisker_protocol::InputPoint {
+                        x: offset[0],
+                        y: offset[1],
+                    },
                 })
             })
             .collect()
@@ -222,6 +267,7 @@ impl DesktopScene {
         let visible = presentation.visibility == Visibility::Visible;
         let rect = presentation.layout.border_box;
         let origin = [parent_origin[0] + rect.x, parent_origin[1] + rect.y];
+        let point = inverse_map_around(presentation.transform, point, origin)?;
         let contains_x = point[0] >= origin[0] && point[0] <= origin[0] + rect.width;
         let contains_y = point[1] >= origin[1] && point[1] <= origin[1] + rect.height;
         let clipped = (presentation.clip.horizontal == OverflowClip::Hidden && !contains_x)
@@ -235,23 +281,43 @@ impl DesktopScene {
             } else {
                 origin
             };
-            let mut children = presentation
-                .children
-                .iter()
-                .enumerate()
-                .map(|(index, child)| {
-                    (
-                        *child,
-                        self.nodes
-                            .get(child)
-                            .map_or(0, |child| child.presentation.z_order),
-                        index,
-                    )
-                })
-                .collect::<Vec<_>>();
-            children.sort_by_key(|(_, z_order, index)| (*z_order, *index));
-            for (child, _, _) in children.into_iter().rev() {
-                if let Some(target) = self.hit_test_node(child, point, child_origin) {
+            let first_z = presentation.children.first().map_or(0, |child| {
+                self.nodes
+                    .get(child)
+                    .map_or(0, |child| child.presentation.z_order)
+            });
+            let uniform_z = presentation.children.iter().all(|child| {
+                self.nodes
+                    .get(child)
+                    .map_or(0, |child| child.presentation.z_order)
+                    == first_z
+            });
+            if uniform_z {
+                if let Some(target) = presentation
+                    .children
+                    .iter()
+                    .rev()
+                    .find_map(|child| self.hit_test_node(*child, point, child_origin))
+                {
+                    return Some(target);
+                }
+            } else {
+                let mut best = None;
+                for (index, child) in presentation.children.iter().copied().enumerate() {
+                    let Some(target) = self.hit_test_node(child, point, child_origin) else {
+                        continue;
+                    };
+                    let z = self
+                        .nodes
+                        .get(&child)
+                        .map_or(0, |child| child.presentation.z_order);
+                    if best
+                        .is_none_or(|((best_z, best_index), _)| (z, index) > (best_z, best_index))
+                    {
+                        best = Some(((z, index), target));
+                    }
+                }
+                if let Some((_, target)) = best {
                     return Some(target);
                 }
             }
@@ -508,7 +574,8 @@ impl DesktopScene {
         None
     }
 
-    fn emit_scroll(&self, node: NodeId, offset: [f32; 2], max: [f32; 2]) {
+    fn emit_scroll(&mut self, node: NodeId, offset: [f32; 2], max: [f32; 2]) {
+        self.dirty_scroll_offsets.insert(node);
         let viewport = self.nodes[&node].presentation.layout.content_box;
         self.pending_events
             .lock()
@@ -929,6 +996,7 @@ impl DesktopScene {
                 self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
             }
             self.pending_events.lock().unwrap().clear();
+            self.dirty_scroll_offsets.clear();
             self.smooth_scrolls.clear();
         }
         for operation in &packet.operations {
@@ -1187,6 +1255,7 @@ impl DesktopScene {
 
     fn delete_subtree(&mut self, node: NodeId) {
         self.smooth_scrolls.remove(&node);
+        self.dirty_scroll_offsets.remove(&node);
         let Some(removed) = self.nodes.remove(&node) else {
             return;
         };

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -110,7 +110,14 @@ impl DesktopScene {
     }
 
     pub(crate) fn cursor_at(&self, point: [f32; 2]) -> Option<whisker_protocol::CursorKeyword> {
-        let node = self.hit_test(point)?;
+        self.cursor_for_target(self.hit_test(point))
+    }
+
+    pub(crate) fn cursor_for_target(
+        &self,
+        target: Option<NodeId>,
+    ) -> Option<whisker_protocol::CursorKeyword> {
+        let node = target?;
         Some(
             self.nodes
                 .get(&node)
@@ -141,7 +148,10 @@ impl DesktopScene {
     }
 
     pub(crate) fn focus_text_input_at(&mut self, point: [f32; 2]) -> bool {
-        let mut target = self.hit_test(point);
+        self.focus_text_input_target(self.hit_test(point))
+    }
+
+    pub(crate) fn focus_text_input_target(&mut self, mut target: Option<NodeId>) -> bool {
         while let Some(node) = target {
             let state = self
                 .nodes
@@ -330,7 +340,11 @@ impl DesktopScene {
     }
 
     pub(crate) fn scroll_at(&mut self, point: [f32; 2], delta: [f32; 2]) -> bool {
-        let Some(node) = self.scroll_node_at(point) else {
+        self.scroll_target(self.hit_test(point), delta)
+    }
+
+    pub(crate) fn scroll_target(&mut self, target: Option<NodeId>, delta: [f32; 2]) -> bool {
+        let Some(node) = self.scroll_node_from(target) else {
             return false;
         };
         if !self.nodes[&node].content.scroll_enabled() {
@@ -485,7 +499,11 @@ impl DesktopScene {
     }
 
     pub(crate) fn settle_scroll_at(&mut self, point: [f32; 2]) -> bool {
-        let Some(node) = self.scroll_node_at(point) else {
+        self.settle_scroll_target(self.hit_test(point))
+    }
+
+    pub(crate) fn settle_scroll_target(&mut self, target: Option<NodeId>) -> bool {
+        let Some(node) = self.scroll_node_from(target) else {
             return false;
         };
         self.smooth_scrolls.remove(&node);
@@ -562,8 +580,7 @@ impl DesktopScene {
         true
     }
 
-    fn scroll_node_at(&self, point: [f32; 2]) -> Option<NodeId> {
-        let mut current = self.hit_test(point);
+    fn scroll_node_from(&self, mut current: Option<NodeId>) -> Option<NodeId> {
         while let Some(node) = current {
             let state = self.nodes.get(&node)?;
             if state.content.is_scroll_container() {

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -16,7 +16,6 @@ impl DesktopScene {
             elements,
             nodes: HashMap::new(),
             smooth_scrolls: HashMap::new(),
-            pointer_captures: HashMap::new(),
             presentation_pool: HashMap::new(),
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
@@ -930,7 +929,6 @@ impl DesktopScene {
                 self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
             }
             self.pending_events.lock().unwrap().clear();
-            self.pointer_captures.clear();
             self.smooth_scrolls.clear();
         }
         for operation in &packet.operations {
@@ -1179,14 +1177,9 @@ impl DesktopScene {
                         .presentation
                         .cursor = cursor.clone();
                 }
-                Operation::SetPointerCapture { node, pointer } => {
-                    self.pointer_captures.insert(*pointer, *node);
-                }
-                Operation::ReleasePointerCapture { node, pointer } => {
-                    if self.pointer_captures.get(pointer) == Some(node) {
-                        self.pointer_captures.remove(pointer);
-                    }
-                }
+                // Pointer capture routing is owned by SurfaceRuntime. Hosts accept
+                // these protocol operations but do not maintain a second target map.
+                Operation::SetPointerCapture { .. } | Operation::ReleasePointerCapture { .. } => {}
             }
         }
         self.clamp_scroll_offsets();
@@ -1197,7 +1190,6 @@ impl DesktopScene {
         let Some(removed) = self.nodes.remove(&node) else {
             return;
         };
-        self.pointer_captures.retain(|_, target| *target != node);
         if let Some(parent) = removed.presentation.parent
             && let Some(parent) = self.nodes.get_mut(&parent)
         {

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -21,7 +21,17 @@ impl DesktopScene {
             pending_events: Arc::new(Mutex::new(Vec::new())),
             event_wake,
             raster_resources: HashSet::new(),
+            prepared_content_references: HashMap::new(),
+            prepared_content_revision: 0,
         }
+    }
+
+    pub(crate) fn prepared_content_revision(&self) -> u64 {
+        self.prepared_content_revision
+    }
+
+    pub(crate) fn references_prepared_content(&self, id: PreparedContentId) -> bool {
+        self.prepared_content_references.contains_key(&id)
     }
 
     pub(crate) fn register_raster_resource(&mut self, resource: ResourceId) {
@@ -915,6 +925,10 @@ impl DesktopScene {
             for (_, node) in nodes {
                 self.recycle_presentation(node);
             }
+            if !self.prepared_content_references.is_empty() {
+                self.prepared_content_references.clear();
+                self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
+            }
             self.pending_events.lock().unwrap().clear();
             self.pointer_captures.clear();
         }
@@ -1066,12 +1080,19 @@ impl DesktopScene {
                         .z_order = *z_order;
                 }
                 Operation::SetText { node, content } => {
+                    let previous = self
+                        .nodes
+                        .get(node)
+                        .and_then(|state| state.content.text())
+                        .and_then(|content| content.prepared_content);
+                    let next = content.prepared_content;
                     self.nodes
                         .get_mut(node)
                         .expect("validated node")
                         .content
                         .set_text(*node, content.clone())
                         .expect("element content operation was validated before commit");
+                    self.replace_prepared_content_reference(previous, next);
                 }
                 Operation::SetTextStyle { node, style } => {
                     self.nodes
@@ -1188,7 +1209,39 @@ impl DesktopScene {
         for child in children {
             self.delete_subtree(child);
         }
+        self.replace_prepared_content_reference(
+            removed
+                .content
+                .text()
+                .and_then(|content| content.prepared_content),
+            None,
+        );
         self.recycle_presentation(removed);
+    }
+
+    fn replace_prepared_content_reference(
+        &mut self,
+        previous: Option<PreparedContentId>,
+        next: Option<PreparedContentId>,
+    ) {
+        if previous == next {
+            return;
+        }
+        if let Some(previous) = previous {
+            let remove = if let Some(count) = self.prepared_content_references.get_mut(&previous) {
+                *count -= 1;
+                *count == 0
+            } else {
+                false
+            };
+            if remove {
+                self.prepared_content_references.remove(&previous);
+            }
+        }
+        if let Some(next) = next {
+            *self.prepared_content_references.entry(next).or_default() += 1;
+        }
+        self.prepared_content_revision = self.prepared_content_revision.wrapping_add(1);
     }
 
     fn recycle_presentation(&mut self, mut node: RenderNode) {

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -1238,7 +1238,7 @@ impl DesktopScene {
     }
 
     fn recycle_presentation(&mut self, mut node: RenderNode) {
-        if !self.elements.is_builtin_presentation(node.element_type) {
+        if !node.content.is_reusable_presentation() {
             return;
         }
         node.content.reset_for_presentation_reuse();

--- a/platforms/desktop/src/scene/transaction.rs
+++ b/platforms/desktop/src/scene/transaction.rs
@@ -805,8 +805,7 @@ impl DesktopScene {
         for operation in &packet.operations {
             match operation {
                 Operation::CreateNode { node, element_type } => {
-                    self.elements
-                        .create(*element_type, DesktopEventEmitter::default())?;
+                    self.elements.validate_element_type(*element_type)?;
                     types.insert(*node, *element_type);
                 }
                 Operation::InsertChild { parent, .. } => {
@@ -830,19 +829,20 @@ impl DesktopScene {
                         return Err(DesktopPresentError::Unsupported("text-decoration"));
                     }
                     if let Some(element_type) = types.get(node).copied() {
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text(*node, content.clone())?;
+                        if !self
+                            .elements
+                            .child_policy(element_type)?
+                            .accepts_plain_text()
+                        {
+                            return Err(DesktopElementError::UnexpectedText { node: *node }.into());
+                        }
                     }
                 }
-                Operation::SetTextStyle { node, style } => {
+                Operation::SetTextStyle { node, .. } => {
                     if let Some(element_type) = types.get(node).copied() {
                         if !self.elements.receives_text_style(element_type)? {
                             return Err(DesktopPresentError::Unsupported("text-style"));
                         }
-                        self.elements
-                            .create(element_type, DesktopEventEmitter::default())?
-                            .set_text_style(*node, style)?;
                     }
                 }
                 Operation::SetProperty {

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -89,16 +89,45 @@ impl DesktopSurface {
         self.scene.cursor_at(logical_position)
     }
 
+    pub(crate) fn cursor_for_target(
+        &self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> Option<whisker_protocol::CursorKeyword> {
+        self.scene.cursor_for_target(target)
+    }
+
     pub(crate) fn scroll_at(&mut self, logical_position: [f32; 2], delta: [f32; 2]) -> bool {
         self.scene.scroll_at(logical_position, delta)
+    }
+
+    pub(crate) fn scroll_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+        delta: [f32; 2],
+    ) -> bool {
+        self.scene.scroll_target(target, delta)
     }
 
     pub(crate) fn settle_scroll_at(&mut self, logical_position: [f32; 2]) -> bool {
         self.scene.settle_scroll_at(logical_position)
     }
 
+    pub(crate) fn settle_scroll_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> bool {
+        self.scene.settle_scroll_target(target)
+    }
+
     pub(crate) fn focus_text_input_at(&mut self, logical_position: [f32; 2]) -> bool {
         self.scene.focus_text_input_at(logical_position)
+    }
+
+    pub(crate) fn focus_text_input_target(
+        &mut self,
+        target: Option<whisker_protocol::NodeId>,
+    ) -> bool {
+        self.scene.focus_text_input_target(target)
     }
 
     pub(crate) fn dispatch_text_input(&mut self, event: &crate::DesktopTextInputEvent) -> bool {

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -14,6 +14,8 @@ use crate::text::NativeTextHost;
 pub(crate) struct DesktopSurface {
     scene: DesktopScene,
     gpu: GpuRenderer,
+    last_preparation_generation: u64,
+    last_prepared_content_revision: u64,
 }
 
 impl DesktopSurface {
@@ -28,6 +30,8 @@ impl DesktopSurface {
         Ok(Self {
             scene: DesktopScene::new_with_wake(surface, elements, event_wake),
             gpu: GpuRenderer::new(target, physical_size, background_rgb).await?,
+            last_preparation_generation: 0,
+            last_prepared_content_revision: 0,
         })
     }
 
@@ -55,6 +59,15 @@ impl DesktopSurface {
         logical_size: [f32; 2],
         scale: f32,
     ) -> Result<(), GpuError> {
+        let preparation_generation = text.preparation_generation();
+        let prepared_content_revision = self.scene.prepared_content_revision();
+        if preparation_generation != self.last_preparation_generation
+            || prepared_content_revision != self.last_prepared_content_revision
+        {
+            text.retain_prepared(|id| self.scene.references_prepared_content(id));
+            self.last_preparation_generation = preparation_generation;
+            self.last_prepared_content_revision = prepared_content_revision;
+        }
         self.gpu
             .render(&self.scene.paint_commands(), text, logical_size, scale)
     }

--- a/platforms/desktop/src/surface.rs
+++ b/platforms/desktop/src/surface.rs
@@ -76,15 +76,17 @@ impl DesktopSurface {
         self.scene.take_events()
     }
 
+    pub(crate) fn take_presentation_updates(
+        &mut self,
+    ) -> Vec<whisker_protocol::HostPresentationUpdate> {
+        self.scene.take_presentation_updates()
+    }
+
     pub(crate) fn cursor_at(
         &self,
         logical_position: [f32; 2],
     ) -> Option<whisker_protocol::CursorKeyword> {
         self.scene.cursor_at(logical_position)
-    }
-
-    pub(crate) fn hit_test(&self, logical_position: [f32; 2]) -> Option<whisker_protocol::NodeId> {
-        self.scene.hit_test(logical_position)
     }
 
     pub(crate) fn scroll_at(&mut self, logical_position: [f32; 2], delta: [f32; 2]) -> bool {

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -181,6 +181,7 @@ impl NativeTextHost {
         };
         let available_width = match request.constraints.available_space[0] {
             AvailableSpace::Definite(value) => Some(value.max(0.0)),
+            AvailableSpace::MinContent if payload.wrap == MeasureTextWrap::Wrap => Some(0.0),
             AvailableSpace::MinContent | AvailableSpace::MaxContent => None,
         };
         let width = request.constraints.known_dimensions[0].or(available_width);

--- a/platforms/desktop/src/text.rs
+++ b/platforms/desktop/src/text.rs
@@ -25,6 +25,7 @@ pub(crate) struct NativeTextHost {
     pub(crate) font_system: FontSystem,
     pub(crate) swash_cache: SwashCache,
     pub(crate) prepared: HashMap<PreparedContentId, PreparedText>,
+    preparation_generation: u64,
 }
 
 fn cosmic_alignment(value: whisker_protocol::MeasureTextAlignment) -> Option<Align> {
@@ -59,7 +60,19 @@ impl NativeTextHost {
             font_system: FontSystem::new(),
             swash_cache: SwashCache::new(),
             prepared: HashMap::new(),
+            preparation_generation: 0,
         }
+    }
+
+    pub(crate) fn preparation_generation(&self) -> u64 {
+        self.preparation_generation
+    }
+
+    pub(crate) fn retain_prepared(
+        &mut self,
+        mut referenced: impl FnMut(PreparedContentId) -> bool,
+    ) {
+        self.prepared.retain(|id, _| referenced(*id));
     }
 
     fn shape_text(
@@ -306,6 +319,7 @@ impl MeasurementProvider for NativeTextHost {
                     let id = PreparedContentId::new(request.key.get())
                         .expect("measurement keys are always non-zero");
                     self.prepared.insert(id, prepared);
+                    self.preparation_generation = self.preparation_generation.wrapping_add(1);
                     metrics.prepared_content = Some(id);
                     MeasurementResponse::Ready {
                         key: request.key,
@@ -437,6 +451,40 @@ mod tests {
         assert!(metrics.last_baseline.is_some());
         let prepared = metrics.prepared_content.unwrap();
         assert!(host.prepared.contains_key(&prepared));
+    }
+
+    #[test]
+    fn prepared_text_cache_discards_content_not_referenced_by_the_scene() {
+        let payload = MeasurementPayload::Text(TextMeasurePayload {
+            text: "Whisker".into(),
+            style: whisker_protocol::TextMeasureStyle::default(),
+            locale: None,
+            direction: whisker_protocol::MeasureTextDirection::Auto,
+            alignment: whisker_protocol::MeasureTextAlignment::Start,
+            indent: Default::default(),
+            wrap: MeasureTextWrap::Wrap,
+            word_break: Default::default(),
+            max_lines: None,
+            overflow: whisker_protocol::MeasureTextOverflow::Clip,
+        });
+        let mut host = NativeTextHost::new(registry());
+        let mut responses = Vec::new();
+        host.measure_batch(
+            SurfaceId::new(1).unwrap(),
+            &[request(7, payload.clone()), request(8, payload)],
+            &mut responses,
+        )
+        .unwrap();
+        let generation = host.preparation_generation();
+
+        host.retain_prepared(|id| id == PreparedContentId::new(8).unwrap());
+
+        assert_eq!(host.prepared.len(), 1);
+        assert!(
+            host.prepared
+                .contains_key(&PreparedContentId::new(8).unwrap())
+        );
+        assert_eq!(host.preparation_generation(), generation);
     }
 
     #[test]

--- a/platforms/desktop/tests/host_conformance/mod.rs
+++ b/platforms/desktop/tests/host_conformance/mod.rs
@@ -1469,6 +1469,7 @@ impl Driver {
             alignment,
             indent,
             available_width,
+            available_width_kind,
         } = command
         else {
             unreachable!("measure_text is only called for MeasureText commands")
@@ -1482,7 +1483,17 @@ impl Driver {
             constraints: MeasureConstraints {
                 known_dimensions: [None, None],
                 available_space: [
-                    AvailableSpace::Definite(*available_width),
+                    match available_width_kind {
+                        whisker_host_conformance::AvailableWidthFixture::Definite => {
+                            AvailableSpace::Definite(*available_width)
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MinContent => {
+                            AvailableSpace::MinContent
+                        }
+                        whisker_host_conformance::AvailableWidthFixture::MaxContent => {
+                            AvailableSpace::MaxContent
+                        }
+                    },
                     AvailableSpace::MaxContent,
                 ],
             },

--- a/platforms/linux/Cargo.toml
+++ b/platforms/linux/Cargo.toml
@@ -11,5 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 description = "Native Linux application shell for Whisker."
 
+[features]
+hot-reload = ["whisker-desktop/hot-reload"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 whisker-desktop = { workspace = true }

--- a/platforms/linux/src/lib.rs
+++ b/platforms/linux/src/lib.rs
@@ -12,4 +12,4 @@
 pub type LinuxAppConfig = whisker_desktop::DesktopAppConfig;
 /// Failure while creating or running the native Linux Host.
 pub type LinuxError = whisker_desktop::DesktopAppError;
-pub use whisker_desktop::run;
+pub use whisker_desktop::{run, run_with_application_hash};

--- a/platforms/windows/Cargo.toml
+++ b/platforms/windows/Cargo.toml
@@ -11,5 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 description = "Native Windows application shell for Whisker."
 
+[features]
+hot-reload = ["whisker-desktop/hot-reload"]
+
 [target.'cfg(target_os = "windows")'.dependencies]
 whisker-desktop = { workspace = true }

--- a/platforms/windows/src/lib.rs
+++ b/platforms/windows/src/lib.rs
@@ -12,4 +12,4 @@
 pub type WindowsAppConfig = whisker_desktop::DesktopAppConfig;
 /// Failure while creating or running the native Windows Host.
 pub type WindowsError = whisker_desktop::DesktopAppError;
-pub use whisker_desktop::run;
+pub use whisker_desktop::{run, run_with_application_hash};


### PR DESCRIPTION
Post "https://api.github.com/graphql": net/http: TLS handshake timeout

## Stack and re-audit update

Base: `codex/review-rollup-runtime-abi`. After #651 merges, retarget this PR to `next-architecture`.

Desktop now reuses Rust's existing `InputDispatch.target` for cursor, native text focus, wheel routing, and snap settling. This removes the second Host hit test from pointer movement and prevents clip-path/rounded-overflow disagreement without adding FFI or public API.

Latest local validation: `cargo test -p whisker-desktop` — 71 passed; `cargo check -p whisker-desktop` passed.