### PR TITLE
fix(modules): align Host registration names

### DIFF
--- a/crates/whisker-cli/src/new_module.rs
+++ b/crates/whisker-cli/src/new_module.rs
@@ -87,7 +87,7 @@ pub fn run(args: NewModuleArgs) -> Result<()> {
         .to_string();
     let module_class = format!("{tag}Module");
     let view_class = format!("{tag}View");
-    let element_name = format!("{}/{}", args.name.replace('-', "."), tag);
+    let element_name = format!("{}:{tag}", args.name);
 
     let v = Vars {
         crate_name: &args.name,
@@ -493,7 +493,9 @@ impl WhiskerModule for {tag}Module {{
     type Definition = ModuleDefinition;
 
     fn definition() -> Self::Definition {{
-        ModuleDefinition::new().view(DesktopViewDefinition::new("{element_name}", || ()))
+        ModuleDefinition::new()
+            .name("{element_name}")
+            .view(DesktopViewDefinition::new("{element_name}", || ()))
     }}
 }}
 "#,
@@ -533,11 +535,13 @@ impl WhiskerModule for {tag}Module {{
     type Definition = ModuleDefinition;
 
     fn definition() -> Self::Definition {{
-        ModuleDefinition::new().view(WebViewDefinition::new(
-            "{element_name}",
-            |document, _| document.create_element("div"),
-            Clone::clone,
-        ))
+        ModuleDefinition::new()
+            .name("{element_name}")
+            .view(WebViewDefinition::new(
+                "{element_name}",
+                |document, _| document.create_element("div"),
+                Clone::clone,
+            ))
     }}
 }}
 "#,
@@ -596,6 +600,7 @@ import WhiskerModule    // Module, ModuleDefinition, DSL
 public final class {module_class}: Module {{
     public override func definition() -> ModuleDefinition {{
         ModuleDefinition {{
+            Name("{tag}")
             View("{element_name}", {view_class}.self) {{
                 // Declare Prop / Command entries here, e.g.:
                 //   Prop("title") {{ (view: {view_class}, value: WhiskerValue) in
@@ -610,6 +615,7 @@ public final class {module_class}: Module {{
 }}
 "#,
         element_name = v.element_name,
+        tag = v.tag,
         module_class = v.module_class,
         view_class = v.view_class,
     )
@@ -662,6 +668,7 @@ import rs.whisker.runtime.WhiskerValue
 @WhiskerModule
 class {module_class} : Module() {{
     override fun definition() = ModuleDefinition {{
+        Name("{tag}")
         View("{element_name}", {view_class}::class.java) {{
             // Declare Prop / Command entries here, e.g.:
             //   Prop("title") {{ view: {view_class}, value: WhiskerValue ->
@@ -675,6 +682,7 @@ class {module_class} : Module() {{
 }}
 "#,
         element_name = v.element_name,
+        tag = v.tag,
         ns = v.ns,
         module_class = v.module_class,
         view_class = v.view_class,
@@ -908,7 +916,7 @@ mod tests {
             assert!(module.join(path).is_file(), "missing {path}");
         }
         let common = std::fs::read_to_string(module.join("src/lib.rs")).unwrap();
-        assert!(common.contains("whisker.switch/Switch"));
+        assert!(common.contains("whisker-switch:Switch"));
         assert!(!common.contains("whisker_desktop"));
         assert!(!common.contains("whisker_web"));
         let manifest = std::fs::read_to_string(module.join("Cargo.toml")).unwrap();
@@ -917,8 +925,26 @@ mod tests {
         assert!(manifest.contains("desktop = { manifest = \"desktop/Cargo.toml\" }"));
         let desktop = std::fs::read_to_string(module.join("desktop/Cargo.toml")).unwrap();
         assert!(desktop.contains("name = \"whisker-switch-desktop\""));
+        let desktop_source = std::fs::read_to_string(module.join("desktop/src/lib.rs")).unwrap();
+        assert!(desktop_source.contains("whisker-switch:Switch"));
+        assert!(desktop_source.contains(".name(\"whisker-switch:Switch\")"));
         let web = std::fs::read_to_string(module.join("web/Cargo.toml")).unwrap();
         assert!(web.contains("name = \"whisker-switch-web\""));
+        let web_source = std::fs::read_to_string(module.join("web/src/lib.rs")).unwrap();
+        assert!(web_source.contains("whisker-switch:Switch"));
+        assert!(web_source.contains(".name(\"whisker-switch:Switch\")"));
+        let android = std::fs::read_to_string(
+            module
+                .join("android/src/main/kotlin/rs/whisker/modules/whisker_switch/SwitchModule.kt"),
+        )
+        .unwrap();
+        assert!(android.contains("Name(\"Switch\")"));
+        assert!(android.contains("View(\"whisker-switch:Switch\""));
+        let ios =
+            std::fs::read_to_string(module.join("ios/Sources/WhiskerSwitch/SwitchModule.swift"))
+                .unwrap();
+        assert!(ios.contains("Name(\"Switch\")"));
+        assert!(ios.contains("View(\"whisker-switch:Switch\""));
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -510,7 +510,7 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[whisker::module_element(
-///     name = "example.ui/Hello",
+///     name = "example-ui:Hello",
 ///     measurement = None,
 /// )]
 /// pub fn hello(style: whisker::Style) {}

--- a/crates/whisker-macros/src/module_element.rs
+++ b/crates/whisker-macros/src/module_element.rs
@@ -16,7 +16,7 @@
 //!
 //! ```ignore
 //! #[whisker::module_element(
-//!     name = "example.forms/Input",
+//!     name = "example-forms:Input",
 //!     measurement = None,
 //! )]
 //! pub fn input(

--- a/docs/module-api-design.md
+++ b/docs/module-api-design.md
@@ -92,7 +92,7 @@ In words:
 
 Every shape below uses one of two Rust-side macros:
 
-- `#[whisker::module_element(name = "package/Name", ...)]` — declares a
+- `#[whisker::module_element(name = "package:Name", ...)]` — declares a
   **Host view** element and its portable schema for `render!`. The element
   name is explicit, stable, and versionless. Shapes 1 and 2 use it.
 - `whisker::module!("Name")` — resolves a **function module** handle
@@ -139,7 +139,7 @@ public final class LocalStoreModule: Module {
 
 ```rust
 #[whisker::module_element(
-    name = "whisker.image/Image",
+    name = "whisker-image:Image",
     measurement = ReplacedContent,
 )]
 pub fn image(src: Signal<String>, mode: Signal<ImageMode>, style: whisker::Style) {}
@@ -177,7 +177,7 @@ there's nothing to observe.
 
 ```rust
 #[whisker::module_element(
-    name = "whisker.video/Video",
+    name = "whisker-video:Video",
     measurement = None,
     commands = [("play", Null), ("pause", Null), ("seek", Float)],
 )]

--- a/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
+++ b/docs/rfcs/0002-renderer-interface-and-frame-protocol.md
@@ -929,7 +929,7 @@ property/event/command members:
 
 ```rust,ignore
 #[whisker::module_element(
-    name = "example.controls/Toggle",
+    name = "example-controls:Toggle",
     measurement = None,
 )]
 pub fn toggle(checked: Signal<bool>, on_change: ChangeEvent) {}
@@ -1018,7 +1018,7 @@ whisker-video package
 |- Rust declarative component API
 |- Rust typed ElementHandle, props, events, and commands
 |- runtime module providing an ElementProvider
-|- canonical whisker.video/Video element schema
+|- canonical whisker-video:Video element schema
 |- Android Host element factory
 |- iOS Host element factory
 |- JavaScript Host element factory
@@ -1097,7 +1097,7 @@ An illustrative generated schema is:
 
 ```rust,ignore
 ElementSchema {
-    key: "whisker.video/Video",
+    key: "whisker-video:Video",
     presentation: Presentation::Box,
     children: ChildrenPolicy::None,
     content: Content::Native,
@@ -1188,7 +1188,7 @@ later factory through `PreparedContentId`.
 The same element key can map to different concrete objects:
 
 ```text
-whisker.video/Video
+whisker-video:Video
   Android -> PlayerView / Media3 player
   iOS     -> AVPlayerLayer-backed UIView
   Web     -> HTMLVideoElement
@@ -1205,7 +1205,7 @@ and generated registration to be included in Project IR. At runtime:
 
 ```text
 Video module
-  -> provides ElementSchema("whisker.video/Video")
+  -> provides ElementSchema("whisker-video:Video")
 
 Whisker Core
   -> collects and normalizes the schema
@@ -1272,7 +1272,7 @@ composition fails. It must not silently emit an empty view or ignore commands:
 
 ```text
 cannot compose target `web`:
-  whisker.video/Video is selected
+  whisker-video:Video is selected
   available Host providers: android, ios
   missing Host provider: web
 ```

--- a/docs/rfcs/0004-native-modules-and-host-elements.md
+++ b/docs/rfcs/0004-native-modules-and-host-elements.md
@@ -161,9 +161,10 @@ per target, but it is not decomposed into one renderer per element.
 
 ### Registration and identity
 
-An element has one versionless name, for example `whisker.ui/Text`
-or `whisker.google-maps/GoogleMap`. Build composition embeds a matching Host
-factory. During surface bootstrap, core:
+An element has one versionless name, for example the built-in
+`whisker.ui/Text` or the module element `whisker-google-maps:GoogleMap`.
+Build composition embeds a matching Host factory. During surface bootstrap,
+core:
 
 1. collects element schemas from selected modules;
 2. rejects duplicate names;
@@ -187,7 +188,7 @@ The author-facing definition states only the cross-platform contract:
 
 ```rust,ignore
 #[whisker::module_element(
-    name = "example.controls/Toggle",
+    name = "example-controls:Toggle",
     measurement = None,
 )]
 pub fn toggle(
@@ -539,7 +540,7 @@ language-idiomatic, but every Host definition uses stable strings:
 public func definition() -> ModuleDefinition {
   Name("WhiskerTextInput")
 
-  View("whisker.input/TextInput", TextInputView.self) {
+  View("whisker-input:TextInput", TextInputView.self) {
     Prop("value") { view, value in view.reconcileValue(value) }
     Events("change", "selectionChange")
     Command("focus") { view, _ in view.focus() }
@@ -590,7 +591,7 @@ qualified as `<cargo-crate>:<Name>` by mobile build composition. Ordinary Rust
 Desktop/Web Host crates declare that resulting qualified name directly because
 they use Cargo dependency resolution rather than mobile discovery codegen.
 Every `View` uses an explicit, versionless, package-qualified element name such
-as `whisker.video/Video`; element and service identities are separate.
+as `whisker-video:Video`; element and service identities are separate.
 
 All application data crossing this boundary is composed from `WhiskerValue`.
 Properties and events carry one value, service functions carry a positional

--- a/packages/whisker-keyboard/web/src/lib.rs
+++ b/packages/whisker-keyboard/web/src/lib.rs
@@ -3,7 +3,7 @@
 use whisker_web::wasm_bindgen::JsCast;
 use whisker_web::{ModuleDefinition, WhiskerModule, WhiskerValue};
 
-const MODULE_NAME: &str = "Keyboard";
+const MODULE_NAME: &str = "whisker-keyboard:Keyboard";
 const CHANGED_EVENT: &str = "keyboardChanged";
 
 struct KeyboardModule;

--- a/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/SvgModule.kt
+++ b/packages/whisker-svg/android/src/main/kotlin/rs/whisker/modules/svg/SvgModule.kt
@@ -19,7 +19,7 @@ import rs.whisker.runtime.ModuleDefinition
 class SvgModule : Module() {
     override fun definition() = ModuleDefinition {
         Name("Svg")
-        View("whisker.svg/Svg", WhiskerSvgView::class.java) {
+        View("whisker-svg:Svg", WhiskerSvgView::class.java) {
             Prop("display-list") { view: WhiskerSvgView, value ->
                 view.setDisplayList(value.asString() ?: "")
             }

--- a/packages/whisker-svg/ios/Sources/WhiskerSvg/SvgModule.swift
+++ b/packages/whisker-svg/ios/Sources/WhiskerSvg/SvgModule.swift
@@ -20,7 +20,7 @@ public final class SvgModule: Module {
     public override func definition() -> ModuleDefinition {
         ModuleDefinition {
             Name("Svg")
-            View("whisker.svg/Svg", WhiskerSvgView.self) {
+            View("whisker-svg:Svg", WhiskerSvgView.self) {
                 Prop("display-list") { (view: WhiskerSvgView, value: WhiskerValue) in
                     view.setDisplayList(value.asString ?? "")
                 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinition.kt
@@ -66,7 +66,7 @@ public data class WhiskerNameComponent(public val value: String) :
     WhiskerDefinitionComponent
 
 /**
- * `View("package/Element", Foo::class.java) { ... }` — registers a native View class
+ * `View("<crate>:Element", Foo::class.java) { ... }` — registers a native View class
  * + its explicit Rust element identity and inner DSL block (Prop / Command / Events). The class is
  * type-erased to `Class<*>` so the parent struct isn't generic;
  * the concrete class is typically a [WhiskerUI] subclass.

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinitionSamples.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/ModuleDefinitionSamples.kt
@@ -23,7 +23,7 @@ internal object ModuleDefinitionSamples {
     internal fun videoModuleDefinition(): ModuleDefinition = ModuleDefinition {
         Name("Video")
 
-        View("sample/Video", FakeVideoView::class.java) {
+        View("sample-module:Video", FakeVideoView::class.java) {
             Prop("src") { view: FakeVideoView, value ->
                 view.setSrc(value.asString() ?: "")
             }

--- a/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
+++ b/platforms/ios/Sources/WhiskerModule/ModuleDefinition.swift
@@ -10,7 +10,7 @@
 // @WhiskerModule
 // public final class VideoModule: Module {
 //     public override func definition() -> ModuleDefinition {
-//         Name("whisker-video:Video")
+//         Name("Video")
 //
 //         View("whisker-video:Video", WhiskerVideoView.self) {
 //             Prop("src") { (view: WhiskerVideoView, value: String) in

--- a/platforms/ios/Sources/WhiskerModule/ModuleDefinitionSamples.swift
+++ b/platforms/ios/Sources/WhiskerModule/ModuleDefinitionSamples.swift
@@ -22,7 +22,7 @@ internal enum ModuleDefinitionSamples {
         ModuleDefinition {
             Name("Video")
 
-            View("sample/Video", FakeVideoView.self) {
+            View("sample-module:Video", FakeVideoView.self) {
                 Prop("src") { (view: FakeVideoView, value: WhiskerValue) in
                     view.setSrc(value.asString ?? "")
                 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -12,6 +12,8 @@ mod rust_host_link_test;
 
 #[cfg(test)]
 mod host_sdk_surface;
+#[cfg(test)]
+mod module_contract;
 
 fn main() -> Result<()> {
     let mut arguments = std::env::args().skip(1);

--- a/xtask/src/module_contract.rs
+++ b/xtask/src/module_contract.rs
@@ -1,0 +1,251 @@
+//! Static contract checks for first-party Whisker modules.
+//!
+//! Host implementations are intentionally hand-written and loosely coupled
+//! from their Rust package. That keeps normal Xcode/Gradle/Cargo builds
+//! autonomous, but it also means an identifier typo otherwise survives until
+//! runtime bootstrap. These tests keep the checked-in first-party packages in
+//! sync without introducing generated Host bindings.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const HOSTS: [&str; 4] = ["android", "ios", "web", "desktop"];
+
+#[test]
+fn first_party_element_names_match_every_declared_host() {
+    let root = super::workspace_root().expect("resolve workspace root");
+    let mut failures = Vec::new();
+
+    for package_dir in module_package_dirs(&root) {
+        let manifest = read(&package_dir.join("Cargo.toml"));
+        let package_name = package_name(&manifest)
+            .unwrap_or_else(|| panic!("{} has no [package] name", package_dir.display()));
+        let rust_source = source_tree(&package_dir.join("src"), "rs");
+        let element_names = module_element_names(&rust_source);
+
+        for element_name in &element_names {
+            if !element_name.starts_with(&format!("{package_name}:")) {
+                failures.push(format!(
+                    "{package_name}: Rust element {element_name:?} must use `<crate>:<Element>`"
+                ));
+            }
+        }
+
+        for host in HOSTS {
+            let Some(host_manifest) = platform_manifest(&manifest, host) else {
+                continue;
+            };
+            let host_root = package_dir
+                .join(host_manifest)
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let source_root = match host {
+                "android" => host_root.join("android/src/main"),
+                "ios" => host_root.join("ios/Sources"),
+                "web" | "desktop" => host_root.join("src"),
+                _ => unreachable!(),
+            };
+            let extension = match host {
+                "android" => "kt",
+                "ios" => "swift",
+                "web" | "desktop" => "rs",
+                _ => unreachable!(),
+            };
+            let host_source = source_tree(&source_root, extension);
+            for element_name in &element_names {
+                let declared = match host {
+                    "android" | "ios" => string_values_after(&host_source, "View(\"")
+                        .any(|name| name == *element_name),
+                    "web" | "desktop" => rust_host_declares_element(&host_source, element_name),
+                    _ => unreachable!(),
+                };
+                if !declared {
+                    failures.push(format!(
+                        "{package_name}: {host} Host does not declare Rust element {element_name:?}"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "first-party element contracts are inconsistent:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn rust_host_module_names_are_package_qualified() {
+    let root = super::workspace_root().expect("resolve workspace root");
+    let mut failures = Vec::new();
+
+    for package_dir in module_package_dirs(&root) {
+        let manifest = read(&package_dir.join("Cargo.toml"));
+        let package_name = package_name(&manifest)
+            .unwrap_or_else(|| panic!("{} has no [package] name", package_dir.display()));
+        let expected_prefix = format!("{package_name}:");
+        let rust_source = source_tree(&package_dir.join("src"), "rs");
+        let mut expected_names = module_element_names(&rust_source)
+            .into_iter()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        expected_names.extend(
+            string_values_after(&rust_source, "module!(\"")
+                .map(|name| format!("{package_name}:{name}")),
+        );
+
+        for host in ["web", "desktop"] {
+            let Some(host_manifest) = platform_manifest(&manifest, host) else {
+                continue;
+            };
+            let host_root = package_dir
+                .join(host_manifest)
+                .parent()
+                .unwrap()
+                .to_path_buf();
+            let source = source_tree(&host_root.join("src"), "rs");
+            let compact = compact_source(&source);
+            let constant_names =
+                string_values_after(&source, "const MODULE_NAME: &str = \"").collect::<Vec<_>>();
+            let direct_names = string_values_after(&compact, "ModuleDefinition::new().name(\"")
+                .collect::<Vec<_>>();
+            let names_module = !direct_names.is_empty()
+                || !constant_names.is_empty()
+                    && compact.contains("ModuleDefinition::new().name(MODULE_NAME)");
+            if source.contains("impl WhiskerModule") && !names_module {
+                failures.push(format!(
+                    "{package_name}: {host} WhiskerModule has no ModuleDefinition name"
+                ));
+            }
+            for module_name in constant_names.into_iter().chain(direct_names) {
+                if !module_name.starts_with(&expected_prefix) {
+                    failures.push(format!(
+                        "{package_name}: {host} module name {module_name:?} must start with {expected_prefix:?}"
+                    ));
+                } else if !expected_names
+                    .iter()
+                    .any(|expected| expected == module_name)
+                {
+                    failures.push(format!(
+                        "{package_name}: {host} registers {module_name:?}, which has no matching Rust element or module handle"
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "first-party Rust Host module names are inconsistent:\n{}",
+        failures.join("\n")
+    );
+}
+
+fn module_package_dirs(root: &Path) -> Vec<PathBuf> {
+    let mut directories = fs::read_dir(root.join("packages"))
+        .expect("read packages directory")
+        .map(|entry| entry.expect("read package entry").path())
+        .filter(|path| {
+            path.join("Cargo.toml").is_file()
+                && read(&path.join("Cargo.toml"))
+                    .contains("[package.metadata.whisker.module.platforms]")
+        })
+        .collect::<Vec<_>>();
+    directories.sort();
+    directories
+}
+
+fn package_name(manifest: &str) -> Option<&str> {
+    let package = manifest.split_once("[package]")?.1;
+    let package = package.split("\n[").next().unwrap_or(package);
+    string_values_after(package, "name = \"").next()
+}
+
+fn platform_manifest(manifest: &str, host: &str) -> Option<String> {
+    let platforms = manifest
+        .split_once("[package.metadata.whisker.module.platforms]")?
+        .1
+        .split("\n[")
+        .next()
+        .unwrap_or_default();
+    let line = platforms
+        .lines()
+        .find(|line| line.trim_start().starts_with(&format!("{host} =")))?;
+    string_values_after(line, "manifest = \"")
+        .next()
+        .map(str::to_owned)
+}
+
+fn module_element_names(source: &str) -> Vec<&str> {
+    let mut names = Vec::new();
+    let mut rest = source;
+    const START: &str = "#[whisker::module_element(";
+    while let Some((_, after_start)) = rest.split_once(START) {
+        let Some((attribute, after_attribute)) = after_start.split_once(")]") else {
+            break;
+        };
+        if let Some(name) = string_values_after(attribute, "name = \"").next() {
+            names.push(name);
+        }
+        rest = after_attribute;
+    }
+    names
+}
+
+fn rust_host_declares_element(source: &str, element_name: &str) -> bool {
+    let compact = compact_source(source);
+    let direct_web = format!("WebViewDefinition::new(\"{element_name}\"");
+    let direct_desktop = format!("DesktopViewDefinition::new(\"{element_name}\"");
+    let constant = format!("constMODULE_NAME:&str=\"{element_name}\";");
+    let constant_view = compact.contains("WebViewDefinition::new(MODULE_NAME,")
+        || compact.contains("DesktopViewDefinition::new(MODULE_NAME,");
+
+    compact.contains(&direct_web)
+        || compact.contains(&direct_desktop)
+        || compact.contains(&constant) && constant_view
+}
+
+fn compact_source(source: &str) -> String {
+    source
+        .chars()
+        .filter(|character| !character.is_ascii_whitespace())
+        .collect()
+}
+
+fn string_values_after<'a>(source: &'a str, marker: &'a str) -> impl Iterator<Item = &'a str> {
+    source.match_indices(marker).filter_map(move |(offset, _)| {
+        let value = &source[offset + marker.len()..];
+        value.split_once('"').map(|(value, _)| value)
+    })
+}
+
+fn source_tree(root: &Path, extension: &str) -> String {
+    let mut files = Vec::new();
+    collect_sources(root, extension, &mut files);
+    files.sort();
+    files
+        .into_iter()
+        .map(|path| read(&path))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn collect_sources(root: &Path, extension: &str, files: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries {
+        let path = entry.expect("read source entry").path();
+        if path.is_dir() {
+            collect_sources(&path, extension, files);
+        } else if path.extension().and_then(|value| value.to_str()) == Some(extension) {
+            files.push(path);
+        }
+    }
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}


### PR DESCRIPTION
## Summary

- align the `whisker-svg:Svg` element identity across Rust, Android, and iOS
- register the Web keyboard service as `whisker-keyboard:Keyboard`
- make `whisker new-module` emit the current `<crate>:<Element>` identity and required module names on all four Hosts
- add first-party cross-Host contract checks and update author-facing examples

## Root cause

Host element and service implementations are intentionally matched to Rust declarations by strings at bootstrap. A stale slash-form SVG identifier and an unqualified Web keyboard identifier drifted from the Rust-side names. The module scaffolder still emitted the old form and omitted required `Name` declarations, so it could reproduce the same failure in newly generated modules.

## Verification

Per request, no further test suite was run after the final code changes. The added contract tests cover checked-in first-party element names on every declared Host and package qualification of Rust Host module names.