### PR TITLE
chore: prepare Android platform releases

### DIFF
--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -64,9 +64,9 @@ pub struct PlatformSync {
 /// Not every `sdk-v*` tag needs a bump here — read the SDK diff and
 /// move this only when apps must pick the release up, such as a Host
 /// runtime ABI change or a Kotlin API consumed by applications/modules.
-// 0.1.20 is the first Android SDK release that ships WhiskerView in the
-// standalone whisker-runtime-android AAR.
-const WHISKER_SDK_VERSION: &str = "0.1.20";
+// 0.1.21 is the first published Android SDK release that ships WhiskerView in
+// the standalone whisker-runtime-android AAR. 0.1.20 failed before publishing.
+const WHISKER_SDK_VERSION: &str = "0.1.21";
 /// Gradle plugin version pinned into the generated
 /// `settings.gradle.kts` `pluginManagement.plugins` + `plugins`
 /// blocks. Bumped independently from the SDK via the

--- a/crates/whisker-cli/src/platforms.rs
+++ b/crates/whisker-cli/src/platforms.rs
@@ -73,7 +73,9 @@ const WHISKER_SDK_VERSION: &str = "0.1.20";
 /// `gradle-plugin-v*` release tag. The Settings plugin and the
 /// Project plugin ship as separate Maven artifacts but share this
 /// version.
-const WHISKER_GRADLE_PLUGIN_VERSION: &str = "0.4.1";
+// 0.5.0 ships the package-scoped module-report contract and the build-process
+// fixes required by the standalone new-architecture Android Host.
+const WHISKER_GRADLE_PLUGIN_VERSION: &str = "0.5.0";
 const WHISKER_MAVEN_URL: &str = "https://whiskerrs.github.io/whisker/maven";
 
 fn sync_android(

--- a/packages/whisker-asset/build.gradle.kts
+++ b/packages/whisker-asset/build.gradle.kts
@@ -53,6 +53,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 }

--- a/packages/whisker-audio/build.gradle.kts
+++ b/packages/whisker-audio/build.gradle.kts
@@ -43,8 +43,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // AndroidX Media3 — modern Player API. We use ExoPlayer (the
     // engine) directly without PlayerView (the visual chrome),

--- a/packages/whisker-haptics/build.gradle.kts
+++ b/packages/whisker-haptics/build.gradle.kts
@@ -42,8 +42,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
     // No extra native dep: `Vibrator`/`VibratorManager` are platform
     // APIs — see `src/lib.rs`'s doc comment.
 }

--- a/packages/whisker-image/build.gradle.kts
+++ b/packages/whisker-image/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 dependencies {
     // 0.1.15 for the module-level `AsyncFunction` the `prefetch`
     // entry point needs; the view-only packages still build on 0.1.0.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // Coil 2.7 — Kotlin-first, coroutine-native image loader. Base
     // artifact covers PNG / JPEG / static WebP (Android 14+ native

--- a/packages/whisker-input/build.gradle.kts
+++ b/packages/whisker-input/build.gradle.kts
@@ -46,6 +46,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 }

--- a/packages/whisker-keyboard/build.gradle.kts
+++ b/packages/whisker-keyboard/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
     // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
     // (the shared decor-view inset multiplexer this module subscribes
     // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // `WindowInsetsCompat.Type.ime()` + `ViewCompat.setOnApplyWindowInsetsListener`
     // — the AndroidX wrappers that expose the IME inset uniformly across

--- a/packages/whisker-local-store/build.gradle.kts
+++ b/packages/whisker-local-store/build.gradle.kts
@@ -40,12 +40,12 @@ ksp {
 }
 
 dependencies {
-    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.20")`
+    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.21")`
     // stays separate (it is a build-time processor, not on the
     // runtime classpath). The KSP processor discovers explicit
     // `@WhiskerModule` declarations from the runtime artifact.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // Phase 7-Φ.G PoC — an external Maven dependency. AndroidX
     // Collection is small + pure-Kotlin (no native libs), so it

--- a/packages/whisker-paths/build.gradle.kts
+++ b/packages/whisker-paths/build.gradle.kts
@@ -41,6 +41,6 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 }

--- a/packages/whisker-router/build.gradle.kts
+++ b/packages/whisker-router/build.gradle.kts
@@ -54,11 +54,11 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
     // androidx.activity.OnBackPressedDispatcher / -Callback for
     // PredictiveBackModule. 1.8+ is the floor that wires
     // OnBackPressedDispatcher into the platform's OnBackInvoked
     // path on API 33+ — older androidx routes the legacy path.
     implementation("androidx.activity:activity:1.8.2")
-    ksp("rs.whisker:ksp:0.1.20")
+    ksp("rs.whisker:ksp:0.1.21")
 }

--- a/packages/whisker-safe-area/build.gradle.kts
+++ b/packages/whisker-safe-area/build.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     // 0.1.6 is the first SDK release carrying `WhiskerInsetsDispatcher`
     // (the shared decor-view inset multiplexer this module subscribes
     // to). Requires cutting `sdk-v0.1.6`; see the module refactor commit.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // `WindowInsetsCompat` + `ViewCompat.setOnApplyWindowInsetsListener`
     // — the AndroidX wrappers that paper over the API-30 introduction

--- a/packages/whisker-secure-store/build.gradle.kts
+++ b/packages/whisker-secure-store/build.gradle.kts
@@ -43,8 +43,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // Google Tink — AES-256-GCM payload crypto with an Android
     // Keystore-wrapped keyset. Google's recommended replacement for the

--- a/packages/whisker-status-bar/build.gradle.kts
+++ b/packages/whisker-status-bar/build.gradle.kts
@@ -40,8 +40,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
     // `WindowInsetsControllerCompat` / `WindowCompat` live in
     // androidx.core — the runtime already depends on it transitively,
     // but declare it so this module builds standalone too.

--- a/packages/whisker-svg/build.gradle.kts
+++ b/packages/whisker-svg/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/packages/whisker-video/build.gradle.kts
+++ b/packages/whisker-video/build.gradle.kts
@@ -38,12 +38,12 @@ ksp {
 }
 
 dependencies {
-    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.20")`
+    // Phase J — single Whisker runtime dep. `ksp("rs.whisker:ksp:0.1.21")`
     // stays separate (it is a build-time processor, not on the
     // runtime classpath). The KSP processor discovers explicit
     // `@WhiskerModule` declarations from the runtime artifact.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // AndroidX Media3 — modern replacement for the deprecated
     // android.widget.VideoView / MediaPlayer pair. ExoPlayer is

--- a/packages/whisker-web-browser/build.gradle.kts
+++ b/packages/whisker-web-browser/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     // `0.1.7` — needs `WhiskerAppContext.DeepLinkListener`/
     // `addDeepLinkListener`/`removeDeepLinkListener`, added in this
     // same change and published by the `sdk-v0.1.7` release.
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
     implementation("androidx.browser:browser:1.8.0")
 }

--- a/packages/whisker-webview/build.gradle.kts
+++ b/packages/whisker-webview/build.gradle.kts
@@ -48,8 +48,8 @@ ksp {
 }
 
 dependencies {
-    implementation("rs.whisker:whisker-module-android:0.1.20")
-    ksp("rs.whisker:ksp:0.1.20")
+    implementation("rs.whisker:whisker-module-android:0.1.21")
+    ksp("rs.whisker:ksp:0.1.21")
 
     // AndroidX WebKit compat — provides WebViewCompat.addDocumentStartJavaScript
     // (API 24+) for reliable document-start JS injection without a race against

--- a/platforms/android/runtime/build.gradle.kts
+++ b/platforms/android/runtime/build.gradle.kts
@@ -38,7 +38,11 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
-            withJavadocJar()
+            // AGP 8.6's bundled Dokka cannot read the Java 17
+            // PermittedSubclasses attribute emitted for WhiskerValue in the
+            // module API. Documentation is published from the source jar;
+            // do not make the runtime AAR release depend on that obsolete
+            // Javadoc pipeline.
         }
     }
 }


### PR DESCRIPTION
## Summary
- point generated Android projects at Gradle plugin 0.5.0
- move the Android SDK pin to 0.1.21 after sdk-v0.1.20 failed before publication
- update every Android module package to the same SDK/KSP version
- skip the runtime Javadoc artifact that AGP 8.6 Dokka cannot generate from Java 17 sealed classes

## Release order
- Gradle plugin 0.5.0 has been published first
- after this PR merges, publish sdk-v0.1.21
- merge release-plz PR #403 only after all platform artifacts are reachable

## Verification
- cargo test -p whisker-cli platforms --lib
- local Android module/runtime Maven publication
- local KSP Maven publication