### PR TITLE
chore: release

### DIFF
--- a/crates/whisker-cng/CHANGELOG.md
+++ b/crates/whisker-cng/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(cng)* include Web and macOS Host templates in the published crate
 - *(router)* complete cross-platform navigation
 - *(router)* restore Android host navigation
 - *(ios)* keep Xcode builds on the active CLI


### PR DESCRIPTION
## Release recovery

Resumes the partially completed Rust 0.13.0 release after fixing the `whisker-cng` package archive.

Already published and therefore skipped by release-plz:
- `whisker-plugin 0.13.0`
- `whisker-config 0.13.0`

All other unpublished workspace packages remain at their prepared 0.13.0 versions. The `release-plz-` branch prefix intentionally marks this as a release PR.