### PR TITLE
Fix clean iOS host builds and advance SwiftPM SDK

### DIFF
--- a/crates/whisker-build/src/ios.rs
+++ b/crates/whisker-build/src/ios.rs
@@ -457,6 +457,10 @@ pub fn run_xcodebuild_app(args: &XcodebuildArgs<'_>) -> Result<PathBuf> {
         // headless build can't answer, so skip validation (the plugin
         // ships from Whisker's own `whisker` SPM package).
         .arg("-skipPackagePluginValidation")
+        // `@WhiskerModule` is implemented by a Swift compiler macro.
+        // Xcode has a separate trust gate for compiler macros, so the
+        // package-plugin flag above is not sufficient on a clean host.
+        .arg("-skipMacroValidation")
         .args(["-quiet", "build"]);
     if let Some(p) = args.whisker_runtime_path {
         cmd.env("WHISKER_IOS_RUNTIME", p);
@@ -592,6 +596,7 @@ pub fn archive_and_export(inputs: &IosReleaseInputs<'_>) -> Result<PathBuf> {
         // SwiftPM build-tool plugins sit behind an interactive trust
         // prompt headless builds can't answer.
         .arg("-skipPackagePluginValidation")
+        .arg("-skipMacroValidation")
         .arg("-allowProvisioningUpdates")
         .arg("-authenticationKeyPath")
         .arg(signing.key_path)

--- a/crates/whisker-cng/src/ios_modules.rs
+++ b/crates/whisker-cng/src/ios_modules.rs
@@ -13,7 +13,7 @@ use crate::modules::{ModulePlatform, NativeManifestKind, ResolvedModule};
 /// Canonical remote Swift package containing Whisker's iOS Host SDK.
 pub const WHISKER_IOS_SPM_URL: &str = "https://github.com/whiskerrs/whisker.git";
 /// Exact Swift package version used by generated consumer projects.
-pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.12";
+pub const WHISKER_IOS_SPM_VERSION: &str = "0.1.13";
 
 /// Generate the iOS module-aggregator SwiftPM package under
 /// `gen/ios/whisker_modules/`. Module sources stay in their own

--- a/packages/whisker-asset/Package.swift
+++ b/packages/whisker-asset/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .library(name: "WhiskerAsset", targets: ["WhiskerAsset"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-audio/Package.swift
+++ b/packages/whisker-audio/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .library(name: "WhiskerAudio", targets: ["WhiskerAudio"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-haptics/Package.swift
+++ b/packages/whisker-haptics/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerHaptics", targets: ["WhiskerHaptics"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-image/Package.swift
+++ b/packages/whisker-image/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         .library(name: "WhiskerImage", targets: ["WhiskerImage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
         // Kingfisher 7.x — pure Swift image loader. PNG / JPEG / HEIC
         // via Core Image, animated GIF via `AnimatedImageView`, in-
         // memory `NSCache` + disk cache out of the box. WebP requires

--- a/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
+++ b/packages/whisker-image/ios/Sources/WhiskerImage/ImageModule.swift
@@ -9,6 +9,7 @@
 // `ImageView.swift`. Same split on Android (`ImageModule.kt` +
 // `WhiskerImageView.kt`).
 
+import Foundation
 import WhiskerModule
 
 @WhiskerModule

--- a/packages/whisker-input/Package.swift
+++ b/packages/whisker-input/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .library(name: "WhiskerInput", targets: ["WhiskerInput"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-keyboard/Package.swift
+++ b/packages/whisker-keyboard/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "WhiskerKeyboard", targets: ["WhiskerKeyboard"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-local-store/Package.swift
+++ b/packages/whisker-local-store/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "WhiskerLocalStore", targets: ["WhiskerLocalStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
         // PoC — an external SwiftPM dependency. swift-collections is
         // Apple-maintained, header-only Swift, small enough that
         // resolving it is fast even on a cold cache. Use is minimal

--- a/packages/whisker-paths/Package.swift
+++ b/packages/whisker-paths/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "WhiskerPaths", targets: ["WhiskerPaths"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-safe-area/Package.swift
+++ b/packages/whisker-safe-area/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "WhiskerSafeArea", targets: ["WhiskerSafeArea"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-secure-store/Package.swift
+++ b/packages/whisker-secure-store/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerSecureStore", targets: ["WhiskerSecureStore"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-splash-screen/src/plugin.rs
+++ b/packages/whisker-splash-screen/src/plugin.rs
@@ -134,7 +134,7 @@ const ANDROID_BG_COLOR: &str = "whisker_splash_background";
 const ANDROID_ICON: &str = "whisker_splash_icon";
 /// The app's normal theme, restored after the splash (`postSplashScreenTheme`).
 /// Must match the manifest template's default.
-const ANDROID_POST_THEME: &str = "@style/Theme.AppCompat.NoActionBar";
+const ANDROID_POST_THEME: &str = "@style/Theme.Whisker";
 const ANDROID_SPLASHSCREEN_DEP: &str = "implementation(\"androidx.core:core-splashscreen:1.0.1\")";
 
 impl Plugin for WhiskerSplashScreen {

--- a/packages/whisker-svg/Package.swift
+++ b/packages/whisker-svg/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .library(name: "WhiskerSvg", targets: ["WhiskerSvg"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-video/Package.swift
+++ b/packages/whisker-video/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         // it there, and the package identity (the crate's dir name)
         // is unique, so the app aggregator references it via
         // `.package(path: …)` without the `ios`-dir-name collision.
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-web-browser/Package.swift
+++ b/packages/whisker-web-browser/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "WhiskerWebBrowser", targets: ["WhiskerWebBrowser"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(

--- a/packages/whisker-webview/Package.swift
+++ b/packages/whisker-webview/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "WhiskerWebview", targets: ["WhiskerWebview"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.12"),
+        .package(url: "https://github.com/whiskerrs/whisker.git", exact: "0.1.13"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

- skip Swift compiler macro trust validation in generated-app build and archive flows
- import Foundation in the iOS image module so DispatchQueue resolves for external consumers
- restore the generated Android splash screen to Theme.Whisker
- advance the iOS SwiftPM SDK pin to 0.1.13 across generated consumers and module manifests

## Validation

- cargo fmt --all --check
- cargo test -p whisker-build -p whisker-splash-screen -p whisker-image
- Giga iOS simulator host build with external Swift packages