### PR TITLE
fix Android text metrics and disabled motion rendering

### DIFF
--- a/crates/whisker-css/src/shorthand/animation.rs
+++ b/crates/whisker-css/src/shorthand/animation.rs
@@ -178,7 +178,10 @@ impl Css {
     /// Sets the `animation` shorthand for multiple comma-separated
     /// animations.
     pub fn animations(self, anims: impl IntoIterator<Item = Animation>) -> Self {
-        let anims = anims.into_iter().collect::<Vec<_>>();
+        let mut anims = anims.into_iter().collect::<Vec<_>>();
+        if anims.is_empty() {
+            anims.push(Animation::new("none"));
+        }
         let mut s = String::new();
         for (i, a) in anims.iter().enumerate() {
             if i > 0 {
@@ -250,6 +253,20 @@ mod tests {
             resolved.computed().motion().animations[1].delay.get(),
             100.0
         );
+    }
+
+    #[test]
+    fn empty_animations_disable_animations() {
+        let style = Css::new().animations([]);
+        let resolved = whisker_style::resolve_style(
+            &style.to_specified_style(),
+            None,
+            whisker_style::StyleEnvironment::default(),
+        )
+        .expect("an empty animation collection means animation: none");
+
+        assert_eq!(style.to_string(), "animation: none;");
+        assert!(resolved.computed().motion().animations.is_empty());
     }
 
     #[test]

--- a/crates/whisker-css/src/shorthand/transition.rs
+++ b/crates/whisker-css/src/shorthand/transition.rs
@@ -87,7 +87,10 @@ impl Css {
     /// Sets the `transition` shorthand for multiple comma-separated
     /// transitions.
     pub fn transitions(self, ts: impl IntoIterator<Item = Transition>) -> Self {
-        let ts = ts.into_iter().collect::<Vec<_>>();
+        let mut ts = ts.into_iter().collect::<Vec<_>>();
+        if ts.is_empty() {
+            ts.push(Transition::new(TransitionPropertyKind::None));
+        }
         let mut s = String::new();
         for (i, t) in ts.iter().enumerate() {
             if i > 0 {
@@ -162,5 +165,19 @@ mod tests {
             resolved.computed().motion().transitions[1].duration.get(),
             500.0
         );
+    }
+
+    #[test]
+    fn empty_transitions_disable_transitions() {
+        let style = Css::new().transitions([]);
+        let resolved = whisker_style::resolve_style(
+            &style.to_specified_style(),
+            None,
+            whisker_style::StyleEnvironment::default(),
+        )
+        .expect("an empty transition collection means transition: none");
+
+        assert_eq!(style.to_string(), "transition: none;");
+        assert!(resolved.computed().motion().transitions.is_empty());
     }
 }

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -489,7 +489,10 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
     fun applyTextStyle(style: WhiskerTextStyle) {
         val et = view()
         et.setTextColor(style.color)
-        et.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.fontSize)
+        et.setTextSize(
+            TypedValue.COMPLEX_UNIT_PX,
+            inputTextSizePixels(style.fontSize, et.resources.displayMetrics.density),
+        )
         val family = style.fontFamilies.firstOrNull()?.takeUnless { it == "system" }
         val base = Typeface.create(family, Typeface.NORMAL)
         et.typeface = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -566,3 +569,6 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
         }
     }
 }
+
+internal fun inputTextSizePixels(logicalPixels: Float, density: Float): Float =
+    logicalPixels * density

--- a/packages/whisker-input/android/src/test/kotlin/rs/whisker/elements/input/WhiskerInputTextStyleTest.kt
+++ b/packages/whisker-input/android/src/test/kotlin/rs/whisker/elements/input/WhiskerInputTextStyleTest.kt
@@ -1,0 +1,11 @@
+package rs.whisker.elements.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WhiskerInputTextStyleTest {
+    @Test
+    fun convertsLogicalFontSizeToPhysicalPixels() {
+        assertEquals(48f, inputTextSizePixels(logicalPixels = 16f, density = 3f), 0f)
+    }
+}

--- a/packages/whisker-input/build.gradle.kts
+++ b/packages/whisker-input/build.gradle.kts
@@ -37,6 +37,9 @@ android {
         getByName("main") {
             kotlin.srcDirs("android/src/main/kotlin")
         }
+        getByName("test") {
+            kotlin.srcDirs("android/src/test/kotlin")
+        }
     }
 }
 
@@ -48,4 +51,5 @@ ksp {
 dependencies {
     implementation("rs.whisker:whisker-module-android:0.1.21")
     ksp("rs.whisker:ksp:0.1.21")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerBuiltInElements.kt
@@ -71,7 +71,10 @@ public object WhiskerBuiltInElements {
             },
         ) { context ->
             WhiskerTextView(context).apply {
-                includeFontPadding = false
+                // API 28+ can size lines from fallback fonts directly. Older
+                // Android releases need font padding as the conservative
+                // fallback, otherwise CJK glyph descenders can be clipped.
+                includeFontPadding = Build.VERSION.SDK_INT < Build.VERSION_CODES.P
                 gravity = Gravity.TOP or Gravity.START
             }
         }

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerTextView.kt
@@ -17,6 +17,12 @@ import rs.whisker.runtime.internal.CenteredLineHeightSpan
 
 /** Native text element implementing Whisker's single-line decorations. */
 public class WhiskerTextView(context: Context) : TextView(context) {
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            setFallbackLineSpacing(true)
+        }
+    }
+
     private var whiskerTextValue: String = ""
     private var whiskerTextIndent: WhiskerTextIndent = WhiskerTextIndent()
     private var whiskerWordBreak: WhiskerTextWordBreak = WhiskerTextWordBreak.NORMAL

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/CenteredLineHeightSpanTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/CenteredLineHeightSpanTest.kt
@@ -5,14 +5,33 @@ import android.text.Spanned
 import android.text.StaticLayout
 import android.text.TextPaint
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import rs.whisker.runtime.internal.CenteredLineHeightSpan
 import rs.whisker.runtime.internal.centeredLineAscent
+import rs.whisker.runtime.measure.configureFallbackLineSpacing
 
 @RunWith(AndroidJUnit4::class)
 class CenteredLineHeightSpanTest {
+    @Test
+    @SdkSuppress(minSdkVersion = 28)
+    fun textRenderingAndMeasurementIncludeFallbackFontMetrics() {
+        val context = androidx.test.core.app.ApplicationProvider
+            .getApplicationContext<android.content.Context>()
+        val view = WhiskerTextView(context)
+        assertTrue(view.isFallbackLineSpacing)
+
+        val paint = TextPaint().apply { textSize = 32f }
+        val text = "日本語"
+        val layout = configureFallbackLineSpacing(
+            StaticLayout.Builder.obtain(text, 0, text.length, paint, 1024),
+        ).build()
+        assertTrue(layout.isFallbackLineSpacingEnabled)
+    }
+
     @Test
     fun staticLayoutUsesTheCenteredBaselineAndRequestedLineHeight() {
         val paint = TextPaint().apply { textSize = 32f }

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -165,12 +165,14 @@ internal class HostMeasurementProvider(
             availableWidthKind == MIN_CONTENT && wrap != 0 -> 1
             else -> ceil(paint.measureText(text) + semantics.indentPixels).toInt().coerceAtLeast(1)
         }
-        val builder = StaticLayout.Builder.obtain(
+        val builder = configureFallbackLineSpacing(StaticLayout.Builder.obtain(
             layoutText, 0, layoutText.length, paint, maxWidthPx,
-        )
+        ))
             .setAlignment(semantics.alignment)
             .setTextDirection(semantics.directionHeuristic)
-            .setIncludePad(false)
+            // Before API 28 there is no fallback-line-spacing switch, so
+            // retain font padding to keep fallback glyphs inside the measured box.
+            .setIncludePad(Build.VERSION.SDK_INT < Build.VERSION_CODES.P)
             .setMaxLines(if (maxLines == 0) Int.MAX_VALUE else maxLines)
             .setBreakStrategy(
                 if (wordBreak == WORD_BREAK_BREAK_ALL) Layout.BREAK_STRATEGY_SIMPLE
@@ -203,6 +205,15 @@ internal class HostMeasurementProvider(
 
     private fun ready(width: Float, height: Float): FloatArray =
         floatArrayOf(READY, 0f, width, height, 0f, 0f, 0f)
+}
+
+internal fun configureFallbackLineSpacing(
+    builder: StaticLayout.Builder,
+): StaticLayout.Builder {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        builder.setUseLineSpacingFromFallbacks(true)
+    }
+    return builder
 }
 
 internal fun measuredTextWidth(


### PR DESCRIPTION
## Summary
- treat empty animation and transition collections as CSS `none` instead of producing invalid declarations
- convert inherited input font sizes from Whisker logical pixels to Android physical pixels
- include fallback-font line metrics in Android text measurement and rendering, with a pre-API 28 font-padding fallback

## Verification
- `cargo test -p whisker-css`
- `platforms/android/gradle-plugin/gradlew -p platforms/android :module:testDebugUnitTest :runtime:testDebugUnitTest`
- `platforms/android/gradle-plugin/gradlew -p platforms/android :runtime:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=rs.whisker.runtime.CenteredLineHeightSpanTest`
- `:whisker-input:testDebugUnitTest --tests rs.whisker.elements.input.WhiskerInputTextStyleTest` in a generated Android Host
- verified the Giga Android app renders normal input text, unclipped Japanese text, and immediate state changes with animations disabled