### PR TITLE
fix(runtime): retain touch sequence targets

### DIFF
--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -586,6 +586,26 @@ struct ActivationRecognizer {
 }
 
 impl ActivationRecognizer {
+    // Touch and pen contacts keep the node selected by pointer-down for their
+    // whole active sequence. This gives raw touch listeners the same stable
+    // target as implicit pointer capture without changing mouse hover routing.
+    fn implicit_capture_target(&self, event: &InputEvent) -> Option<NodeId> {
+        let pointer = event.pointer?;
+        if !matches!(pointer.kind, PointerKind::Touch | PointerKind::Pen)
+            || !matches!(
+                event.kind,
+                InputEventKind::PointerMove
+                    | InputEventKind::PointerUp
+                    | InputEventKind::PointerCancel
+            )
+        {
+            return None;
+        }
+        self.pointers
+            .get(&pointer.id)
+            .map(|candidate| candidate.target)
+    }
+
     fn observe(
         &mut self,
         event: &InputEvent,
@@ -624,7 +644,10 @@ impl ActivationRecognizer {
             InputEventKind::PointerUp => {
                 let candidate = self.pointers.remove(&pointer.id)?;
                 let elapsed = event.timestamp_ms - candidate.started_at_ms;
+                let dx = pointer.position.x - candidate.origin.x;
+                let dy = pointer.position.y - candidate.origin.y;
                 if candidate.cancelled
+                    || dx * dx + dy * dy > TAP_SLOP * TAP_SLOP
                     || !(0.0..=TAP_TIMEOUT_MS).contains(&elapsed)
                     || hit_target != Some(candidate.target)
                 {
@@ -1110,9 +1133,21 @@ impl RuntimeInstance {
         // is committed once after the queue settles.
         self.surface.begin_mutation_batch();
         let dispatch = (|| {
+            let routed_event = if event.target.is_none() {
+                self.activations
+                    .borrow()
+                    .implicit_capture_target(event)
+                    .map(|target| InputEvent {
+                        target: Some(target),
+                        ..event.clone()
+                    })
+            } else {
+                None
+            };
+            let routed_event = routed_event.as_ref().unwrap_or(event);
             let mut dispatch = self
                 .surface
-                .dispatch_input_with_presentation(event, presentation)?;
+                .dispatch_input_with_presentation(routed_event, presentation)?;
             let activation = self
                 .activations
                 .borrow_mut()

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -1678,6 +1678,104 @@ fn raw_touch_stream_synthesizes_tap_but_drag_does_not() {
 }
 
 #[test]
+fn touch_stream_stays_routed_to_its_pointer_down_target() {
+    let surface = surface(38);
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    let log = Rc::new(RefCell::new(Vec::new()));
+    let first_start = Rc::clone(&log);
+    let first_move = Rc::clone(&log);
+    let first_end = Rc::clone(&log);
+    let first_cancel = Rc::clone(&log);
+    let second_move = Rc::clone(&log);
+    let second_end = Rc::clone(&log);
+    let second_cancel = Rc::clone(&log);
+
+    runtime
+        .mount(move || {
+            render! {
+                View(
+                    style: css!(
+                        width: px(100),
+                        height: px(50),
+                        flex_direction: FlexDirection::Row,
+                    ),
+                ) {
+                    View(
+                        style: css!(width: px(50), height: px(50)),
+                        on_touchstart: move |_| first_start.borrow_mut().push("first-start"),
+                        on_touchmove: move |_| first_move.borrow_mut().push("first-move"),
+                        on_touchend: move |_| first_end.borrow_mut().push("first-end"),
+                        on_touchcancel: move |_| first_cancel.borrow_mut().push("first-cancel"),
+                    )
+                    View(
+                        style: css!(width: px(50), height: px(50)),
+                        on_touchmove: move |_| second_move.borrow_mut().push("second-move"),
+                        on_touchend: move |_| second_end.borrow_mut().push("second-end"),
+                        on_touchcancel: move |_| second_cancel.borrow_mut().push("second-cancel"),
+                    )
+                }
+            }
+        })
+        .unwrap();
+
+    let mut measurements = NoMeasurement;
+    let mut sink = RecordingRenderer::new(surface.surface());
+    runtime
+        .drive_frame(
+            1.0,
+            StyleEnvironment::new(100.0, 50.0, 1.0, 14.0),
+            1,
+            1,
+            &mut measurements,
+            &mut sink,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    let pointer = |timestamp_ms, kind, x, buttons| InputEvent {
+        surface: surface.surface(),
+        timestamp_ms,
+        kind,
+        pointer: Some(PointerInput {
+            id: PointerId::new(1).unwrap(),
+            kind: PointerKind::Touch,
+            position: InputPoint { x, y: 25.0 },
+            buttons,
+            changed_button: -1,
+        }),
+        target: None,
+        detail: WhiskerValue::Null,
+    };
+
+    runtime
+        .dispatch_input(&pointer(2.0, InputEventKind::PointerDown, 25.0, 1))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(3.0, InputEventKind::PointerMove, 75.0, 1))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(4.0, InputEventKind::PointerUp, 75.0, 0))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(5.0, InputEventKind::PointerDown, 25.0, 1))
+        .unwrap();
+    runtime
+        .dispatch_input(&pointer(6.0, InputEventKind::PointerCancel, 75.0, 0))
+        .unwrap();
+
+    assert_eq!(
+        log.borrow().as_slice(),
+        [
+            "first-start",
+            "first-move",
+            "first-end",
+            "first-start",
+            "first-cancel",
+        ]
+    );
+}
+
+#[test]
 fn raw_mouse_stream_synthesizes_cross_host_tap_and_mouse_click() {
     let surface = surface(37);
     let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));


### PR DESCRIPTION
## Summary

- keep touch and pen move/up/cancel events routed to the node selected on pointer-down
- preserve coordinate-based mouse routing
- include pointer-up displacement in tap cancellation so a stream without an intermediate move cannot synthesize a distant tap
- add a regression test covering move, end, and cancel after crossing into a sibling element

## Root cause

The Rust-authoritative input path hit-tested every touch sample independently. A press could start on one item and end on another after a scroll gesture, so the original item never received `touchend` or `touchcancel` and retained its pressed animation state.

## Validation

- `cargo test -p whisker --test runtime_instance`
- `cargo test -p whisker-runtime`
- `cargo clippy -p whisker-runtime -p whisker --tests --all-targets -- -D warnings`
- `cargo fmt --all -- --check`