### PR TITLE
fix: preserve initial position for virtualized lists

### DIFF
--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 
 use whisker_style::{
     GridPlacementValue, LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue,
-    SizeValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
+    PositionValue, SizeValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
 };
 use whisker_value::WhiskerValue;
 
@@ -417,8 +417,10 @@ pub fn virtualize<T, K>(
         footer,
         empty,
     } = options;
+    let scroll_extent = create_element(ElementTag::View);
     let leading_spacer = create_element(ElementTag::View);
     let trailing_spacer = create_element(ElementTag::View);
+    append_child(scroll_view, scroll_extent);
     append_child(scroll_view, content);
     if let Some(header) = header {
         append_child(content, header);
@@ -450,6 +452,9 @@ pub fn virtualize<T, K>(
         Rc::new(RefCell::new(HashMap::new()));
     let rendered_window = Rc::new(Cell::new(None::<LayoutWindow>));
     let pending_initial_scroll = Rc::new(RefCell::new(initial_scroll));
+    let viewport_ready = Rc::new(Cell::new(false));
+    let presented_scroll_extent = Rc::new(Cell::new(0.0));
+    let configured_scroll_extent = Rc::new(Cell::new(f32::NAN));
     let inside_start_threshold = Rc::new(Cell::new(false));
     let inside_end_threshold = Rc::new(Cell::new(false));
     if let Some(list_ref) = &list_ref {
@@ -462,12 +467,18 @@ pub fn virtualize<T, K>(
         let geometry = Rc::clone(&geometry);
         let reconcile_slot = Rc::clone(&reconcile_slot);
         let list_ref = list_ref.clone();
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
         Rc::new(move |key, handle| {
             let key = key.clone();
             let layout = Rc::clone(&layout);
             let geometry = Rc::clone(&geometry);
             let reconcile_slot = Rc::clone(&reconcile_slot);
             let list_ref = list_ref.clone();
+            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+            let viewport_ready = Rc::clone(&viewport_ready);
+            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
@@ -480,8 +491,20 @@ pub fn virtualize<T, K>(
                             ScrollAxis::Horizontal => layout_geometry.border_box.width,
                         };
                         let changed = layout.update_measurement(&key, measured_size.max(0.0));
-                        let corrected_offset = anchor.and_then(|(key, within_item)| {
-                            layout.anchored_offset(&key, within_item)
+                        let initial_offset = resolve_pending_initial_target(
+                            &mut pending_initial_scroll.borrow_mut(),
+                            &layout,
+                            current_geometry,
+                            initial_geometry_ready(
+                                viewport_ready.get(),
+                                presented_scroll_extent.get(),
+                                layout.total_extent(),
+                            ),
+                        );
+                        let corrected_offset = initial_offset.or_else(|| {
+                            anchor.and_then(|(key, within_item)| {
+                                layout.anchored_offset(&key, within_item)
+                            })
                         });
                         if changed && let Some(list_ref) = &list_ref {
                             let (starts, ends) = layout.item_offsets();
@@ -523,6 +546,9 @@ pub fn virtualize<T, K>(
         let geometry = Rc::clone(&geometry);
         let reconcile_slot = Rc::clone(&reconcile_slot);
         let list_ref = list_ref.clone();
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
         let main_gap = match &virtual_layout {
             VirtualListLayout::Linear => 0.0,
             VirtualListLayout::Grid(grid) => grid.main_gap,
@@ -532,6 +558,9 @@ pub fn virtualize<T, K>(
             let geometry = Rc::clone(&geometry);
             let reconcile_slot = Rc::clone(&reconcile_slot);
             let list_ref = list_ref.clone();
+            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+            let viewport_ready = Rc::clone(&viewport_ready);
+            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
@@ -556,8 +585,20 @@ pub fn virtualize<T, K>(
                         let extent = measured_size.max(0.0)
                             + if track_has_successor { main_gap } else { 0.0 };
                         let changed = layout.update_measurement(first_key, extent);
-                        let corrected_offset = anchor.and_then(|(key, within_item)| {
-                            layout.anchored_offset(&key, within_item)
+                        let initial_offset = resolve_pending_initial_target(
+                            &mut pending_initial_scroll.borrow_mut(),
+                            &layout,
+                            current_geometry,
+                            initial_geometry_ready(
+                                viewport_ready.get(),
+                                presented_scroll_extent.get(),
+                                layout.total_extent(),
+                            ),
+                        );
+                        let corrected_offset = initial_offset.or_else(|| {
+                            anchor.and_then(|(key, within_item)| {
+                                layout.anchored_offset(&key, within_item)
+                            })
                         });
                         if changed && let Some(list_ref) = &list_ref {
                             let (starts, ends) = layout.item_offsets();
@@ -600,11 +641,17 @@ pub fn virtualize<T, K>(
         let geometry = Rc::clone(&geometry);
         let reconcile_slot = Rc::clone(&reconcile_slot);
         let list_ref = list_ref.clone();
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
         Rc::new(move |content, handle| {
             let layout = Rc::clone(&layout);
             let geometry = Rc::clone(&geometry);
             let reconcile_slot = Rc::clone(&reconcile_slot);
             let list_ref = list_ref.clone();
+            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+            let viewport_ready = Rc::clone(&viewport_ready);
+            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
@@ -622,8 +669,20 @@ pub fn virtualize<T, K>(
                             .flatten();
                         let changed =
                             layout.update_aux_measurement(content, measured_size.max(0.0));
-                        let corrected_offset = anchor.and_then(|(key, within_item)| {
-                            layout.anchored_offset(&key, within_item)
+                        let initial_offset = resolve_pending_initial_target(
+                            &mut pending_initial_scroll.borrow_mut(),
+                            &layout,
+                            current_geometry,
+                            initial_geometry_ready(
+                                viewport_ready.get(),
+                                presented_scroll_extent.get(),
+                                layout.total_extent(),
+                            ),
+                        );
+                        let corrected_offset = initial_offset.or_else(|| {
+                            anchor.and_then(|(key, within_item)| {
+                                layout.anchored_offset(&key, within_item)
+                            })
                         });
                         if changed && let Some(list_ref) = &list_ref {
                             let (starts, ends) = layout.item_offsets();
@@ -680,10 +739,18 @@ pub fn virtualize<T, K>(
         let observe_entry = Rc::clone(&observe_entry);
         let observe_track = Rc::clone(&observe_track);
         let virtual_layout = virtual_layout.clone();
+        let configured_scroll_extent = Rc::clone(&configured_scroll_extent);
         Rc::new(move || {
             let geometry = *geometry.borrow();
             let window = {
                 let layout = layout.borrow();
+                let total_extent = layout.total_extent();
+                let configured_extent = configured_scroll_extent.get();
+                if !configured_extent.is_finite() || (configured_extent - total_extent).abs() >= 0.5
+                {
+                    configured_scroll_extent.set(total_extent);
+                    set_scroll_extent_size(scroll_extent, total_extent, axis);
+                }
                 let window = layout.window(geometry);
                 if rendered_window
                     .get()
@@ -843,6 +910,116 @@ pub fn virtualize<T, K>(
     *reconcile_slot.borrow_mut() = Some(Rc::clone(&reconcile));
 
     {
+        let geometry = Rc::clone(&geometry);
+        let layout = Rc::clone(&layout);
+        let reconcile = Rc::clone(&reconcile);
+        let list_ref = list_ref.clone();
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        observe_layout(
+            scroll_extent,
+            Box::new(move |layout_geometry| {
+                let extent = match axis {
+                    ScrollAxis::Vertical => layout_geometry.border_box.height,
+                    ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                };
+                if !extent.is_finite() || extent < 0.0 {
+                    return;
+                }
+                presented_scroll_extent.set(extent);
+                let current_geometry = *geometry.borrow();
+                let initial_offset = {
+                    let layout = layout.borrow();
+                    resolve_pending_initial_target(
+                        &mut pending_initial_scroll.borrow_mut(),
+                        &layout,
+                        current_geometry,
+                        initial_geometry_ready(viewport_ready.get(), extent, layout.total_extent()),
+                    )
+                };
+                if let Some(offset) = initial_offset
+                    && (offset - current_geometry.offset).abs() >= 0.5
+                {
+                    geometry.borrow_mut().offset = offset;
+                    if let Some(list_ref) = &list_ref {
+                        list_ref.update_geometry(offset, current_geometry.viewport);
+                    }
+                    let _ = try_invoke_element_command(
+                        scroll_view,
+                        "scrollTo",
+                        WhiskerValue::map([
+                            ("offset", WhiskerValue::Float(f64::from(offset))),
+                            ("smooth", WhiskerValue::Bool(false)),
+                        ]),
+                    );
+                }
+                reconcile();
+            }),
+        );
+    }
+
+    {
+        let geometry = Rc::clone(&geometry);
+        let layout = Rc::clone(&layout);
+        let reconcile = Rc::clone(&reconcile);
+        let list_ref = list_ref.clone();
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        observe_layout(
+            scroll_view,
+            Box::new(move |layout_geometry| {
+                let viewport = match axis {
+                    ScrollAxis::Vertical => layout_geometry.border_box.height,
+                    ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                };
+                if !viewport.is_finite() || viewport <= 0.0 {
+                    return;
+                }
+                viewport_ready.set(true);
+                let current_geometry = *geometry.borrow();
+                let next_geometry = ScrollGeometry {
+                    offset: current_geometry.offset,
+                    viewport,
+                };
+                let initial_offset = {
+                    let layout = layout.borrow();
+                    resolve_pending_initial_target(
+                        &mut pending_initial_scroll.borrow_mut(),
+                        &layout,
+                        next_geometry,
+                        initial_geometry_ready(
+                            true,
+                            presented_scroll_extent.get(),
+                            layout.total_extent(),
+                        ),
+                    )
+                };
+                let next_offset = initial_offset.unwrap_or(current_geometry.offset);
+                *geometry.borrow_mut() = ScrollGeometry {
+                    offset: next_offset,
+                    viewport,
+                };
+                if let Some(list_ref) = &list_ref {
+                    list_ref.update_geometry(next_offset, viewport);
+                }
+                if (next_offset - current_geometry.offset).abs() >= 0.5 {
+                    let _ = try_invoke_element_command(
+                        scroll_view,
+                        "scrollTo",
+                        WhiskerValue::map([
+                            ("offset", WhiskerValue::Float(f64::from(next_offset))),
+                            ("smooth", WhiskerValue::Bool(false)),
+                        ]),
+                    );
+                }
+                reconcile();
+            }),
+        );
+    }
+
+    {
         let each = Rc::clone(&each);
         let key = Rc::clone(&key);
         let layout = Rc::clone(&layout);
@@ -850,6 +1027,8 @@ pub fn virtualize<T, K>(
         let reconcile = Rc::clone(&reconcile);
         let list_ref = list_ref.clone();
         let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
         effect(move || {
             let items = each();
             let current_geometry = *geometry.borrow();
@@ -857,13 +1036,16 @@ pub fn virtualize<T, K>(
                 let mut layout = layout.borrow_mut();
                 let anchor = layout.anchor(current_geometry.offset);
                 layout.replace(items, |item| key(item));
-                let initial_offset = pending_initial_scroll
-                    .borrow()
-                    .as_ref()
-                    .and_then(|target| resolve_layout_target(&layout, target, current_geometry));
-                if initial_offset.is_some() {
-                    pending_initial_scroll.borrow_mut().take();
-                }
+                let initial_offset = resolve_pending_initial_target(
+                    &mut pending_initial_scroll.borrow_mut(),
+                    &layout,
+                    current_geometry,
+                    initial_geometry_ready(
+                        viewport_ready.get(),
+                        presented_scroll_extent.get(),
+                        layout.total_extent(),
+                    ),
+                );
                 initial_offset.or_else(|| {
                     anchor.and_then(|(key, within_item)| layout.anchored_offset(&key, within_item))
                 })
@@ -963,6 +1145,9 @@ pub fn virtualize<T, K>(
         if attached.contains(&trailing_spacer) {
             remove_child(content, trailing_spacer);
         }
+        if children_of(scroll_view).contains(&scroll_extent) {
+            remove_child(scroll_view, scroll_extent);
+        }
         if let Some(header) = header
             && children_of(content).contains(&header)
         {
@@ -983,6 +1168,53 @@ pub fn virtualize<T, K>(
             list_ref.unbind();
         }
     });
+}
+
+fn resolve_pending_initial_target<T, K: Eq + Hash + Clone>(
+    pending: &mut Option<ListScrollTarget<K>>,
+    layout: &LayoutIndex<T, K>,
+    geometry: ScrollGeometry,
+    geometry_ready: bool,
+) -> Option<f32> {
+    if !geometry_ready {
+        return None;
+    }
+    let target = pending.as_ref()?;
+    let offset = resolve_layout_target(layout, target, geometry)?;
+    if initial_target_is_measured(layout, target) {
+        pending.take();
+    }
+    Some(offset)
+}
+
+fn initial_geometry_ready(
+    viewport_ready: bool,
+    presented_extent: f32,
+    current_extent: f32,
+) -> bool {
+    viewport_ready && (presented_extent - current_extent).abs() < 0.5
+}
+
+fn initial_target_is_measured<T, K: Eq + Hash + Clone>(
+    layout: &LayoutIndex<T, K>,
+    target: &ListScrollTarget<K>,
+) -> bool {
+    let target_index = match target {
+        ListScrollTarget::Start | ListScrollTarget::Offset(_) => return true,
+        ListScrollTarget::End => layout.items.len().checked_sub(1),
+        ListScrollTarget::Index { index, .. } => Some(*index),
+        ListScrollTarget::Key { key, .. } => {
+            layout.keys.iter().position(|candidate| candidate == key)
+        }
+    };
+    let Some(target_index) = target_index.filter(|index| *index < layout.items.len()) else {
+        return false;
+    };
+    let track_start = layout.track_start_item(layout.track_for_item(target_index));
+    layout
+        .keys
+        .get(track_start)
+        .is_some_and(|key| layout.measured_sizes.contains_key(key))
 }
 
 fn resolve_layout_target<T, K: Eq + Hash + Clone>(
@@ -1326,6 +1558,37 @@ fn set_spacer_size(element: Element, size: f32, axis: ScrollAxis) {
         .push(
             StyleProperty::FlexShrink,
             StyleValue::Number(StyleNumber::new(0.0)),
+        );
+    set_specified_style(element, &style);
+}
+
+fn set_scroll_extent_size(element: Element, size: f32, axis: ScrollAxis) {
+    let px = |value: f32| {
+        LengthPercentageValue::Length(if value == 0.0 {
+            LengthValue::Zero
+        } else {
+            LengthValue::Dimension {
+                value: StyleNumber::new(value),
+                unit: LengthUnit::Px,
+            }
+        })
+    };
+    let (width, height) = match axis {
+        ScrollAxis::Vertical => (px(1.0), px(size)),
+        ScrollAxis::Horizontal => (px(size), px(1.0)),
+    };
+    let style = SpecifiedStyle::new()
+        .push(
+            StyleProperty::Position,
+            StyleValue::Position(PositionValue::Absolute),
+        )
+        .push(
+            StyleProperty::Width,
+            StyleValue::Size(SizeValue::LengthPercentage(width)),
+        )
+        .push(
+            StyleProperty::Height,
+            StyleValue::Size(SizeValue::LengthPercentage(height)),
         );
     set_specified_style(element, &style);
 }

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::rc::Rc;
 
@@ -313,6 +314,195 @@ fn list_virtualizes_through_scroll_view_and_reacts_to_host_scroll_geometry() {
                 .and_then(|index| index.parse::<u32>().ok())
                 .is_some_and(|index| index >= 20))
             )
+    );
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn horizontal_list_mounted_by_show_lays_out_initial_items() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(57).unwrap(),
+        StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+    );
+    let visible = owner.with(|| signal(false));
+    let observed = owner.with(|| signal(None::<(f32, f32)>));
+    let list_handle = owner.with(ListHandle::<u32>::new);
+    let list_ref = list_handle.r();
+
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            render! {
+                View(style: css!(width: px(320), height: px(100))) {
+                    Show(when: move || visible.get()) {
+                        List(
+                            axis: ScrollAxis::Horizontal,
+                            style: css!(width: percent(100), height: percent(100)),
+                            content_style: css!(height: percent(100)),
+                            list_ref: list_ref.clone(),
+                            initial_scroll: ListScrollTarget::index(17, ScrollAlignment::Start),
+                            each: || (0_u32..18).collect::<Vec<_>>(),
+                            key: |row: &u32| *row,
+                            children: move |_row: ReadSignal<u32>| {
+                                let page = render! {
+                                    View(style: css!(
+                                        width: px(320),
+                                        height: percent(100),
+                                        flex_shrink: 0.0,
+                                    ))
+                                };
+                                whisker::runtime::view::observe_layout(
+                                    page,
+                                    Box::new(move |geometry| {
+                                        observed.set(Some((
+                                            geometry.border_box.width,
+                                            geometry.border_box.height,
+                                        )))
+                                    }),
+                                );
+                                page
+                            },
+                        )
+                    }
+                    Show(when: move || !visible.get()) {
+                        View(style: css!(
+                            width: px(1),
+                            height: px(1),
+                        ))
+                    }
+                }
+            }
+        });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(320.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(observed.get(), None);
+
+    with_installed_renderer(surface.renderer(), || {
+        visible.set(true);
+        whisker::flush();
+    });
+    surface
+        .render_frame(
+            LayoutSize::new(320.0, 100.0),
+            1,
+            2,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    surface
+        .render_frame(
+            LayoutSize::new(320.0, 100.0),
+            1,
+            3,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    let observed_geometry = observed.get();
+    assert!(
+        observed_geometry.is_some_and(|(width, height)| width > 0.0 && height > 0.0),
+        "items mounted in a dynamic horizontal List must join layout with non-zero geometry, got {observed_geometry:?}"
+    );
+    let snapshot = list_handle.snapshot().expect("dynamic List is bound");
+    assert!(
+        (snapshot.offset - 5_440.0).abs() < 0.01,
+        "initial end item must be aligned after the real viewport and row sizes are known, got {snapshot:?}"
+    );
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn horizontal_list_exposes_its_complete_extent_to_the_host_scroll_view() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(58).unwrap(),
+        StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+    );
+    let list_handle = owner.with(ListHandle::<u32>::new);
+
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            render! {
+                List(
+                    axis: ScrollAxis::Horizontal,
+                    style: css!(width: px(320), height: px(100)),
+                    content_style: css!(height: percent(100)),
+                    list_ref: list_handle.r(),
+                    initial_scroll: ListScrollTarget::index(17, ScrollAlignment::Start),
+                    each: || (0_u32..18).collect::<Vec<_>>(),
+                    key: |row: &u32| *row,
+                    children: |_row: ReadSignal<u32>| render! {
+                        View(style: css!(
+                            width: px(320),
+                            height: percent(100),
+                            flex_shrink: 0.0,
+                        ))
+                    },
+                )
+            }
+        });
+        set_root(root);
+    });
+
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    for frame in 1..=2 {
+        surface
+            .render_frame(
+                LayoutSize::new(320.0, 100.0),
+                1,
+                frame,
+                &mut host,
+                &mut renderer,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+    }
+
+    let mut layouts = HashMap::new();
+    for frame in renderer.frames() {
+        for operation in &frame.packet.operations {
+            if let Operation::SetLayout { node, geometry } = operation {
+                layouts.insert(*node, geometry.border_box);
+            }
+        }
+    }
+    let root = surface.root().expect("List ScrollView root");
+    let root = renderer
+        .projection()
+        .node(root)
+        .expect("projected List root");
+    let content_extent = list_handle.snapshot().unwrap().content_extent as f32;
+    assert!(
+        root.children().iter().any(|child| {
+            layouts
+                .get(child)
+                .is_some_and(|layout| layout.width >= content_extent)
+        }),
+        "the Host ScrollView needs a direct child spanning the full {content_extent}px extent; direct child layouts were {:?}",
+        root.children()
+            .iter()
+            .filter_map(|child| layouts.get(child))
+            .collect::<Vec<_>>()
     );
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -996,7 +996,10 @@ fn list_applies_axis_scroll_control_and_initial_key_target() {
                     each: || (0_u32..20).collect::<Vec<_>>(),
                     key: |row: &u32| *row,
                     children: |row: ReadSignal<u32>| render! {
-                        Text(value: computed(move || row.get().to_string()), style: css!(width: px(44), font_size: px(20)))
+                        Text(
+                            value: computed(move || row.get().to_string()),
+                            style: css!(width: px(44), flex_shrink: 0.0, font_size: px(20)),
+                        )
                     },
                 )
             }
@@ -1031,7 +1034,25 @@ fn list_applies_axis_scroll_control_and_initial_key_target() {
         )
         .unwrap();
 
-    let operations = &renderer.frames()[0].packet.operations;
+    // Initial scrolling waits for the first resolved viewport, measured target,
+    // and Host-facing scroll extent. Their layout observers queue the command
+    // for the following frame instead of acting on the pre-layout estimate.
+    surface
+        .render_frame(
+            LayoutSize::new(320.0, 100.0),
+            1,
+            2,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    let operations = renderer
+        .frames()
+        .iter()
+        .flat_map(|frame| frame.packet.operations.iter())
+        .collect::<Vec<_>>();
     assert!(operations.iter().any(|operation| matches!(
         operation,
         Operation::SetProperty {

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -255,13 +255,22 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
 
     public fun scrollToLogicalOffset(offset: Double, smooth: Boolean) {
         val pixels = (offset * resources.displayMetrics.density).roundToInt()
-        if (horizontal) {
-            if (smooth) horizontalScroller.smoothScrollTo(pixels, 0)
-            else horizontalScroller.scrollTo(pixels, 0)
-        } else {
-            if (smooth) verticalScroller.smoothScrollTo(0, pixels)
-            else verticalScroller.scrollTo(0, pixels)
+        val isHorizontal = horizontal
+        val apply = {
+            if (isHorizontal) {
+                if (smooth) horizontalScroller.smoothScrollTo(pixels, 0)
+                else horizontalScroller.scrollTo(pixels, 0)
+            } else {
+                if (smooth) verticalScroller.smoothScrollTo(0, pixels)
+                else verticalScroller.scrollTo(0, pixels)
+            }
         }
+        // A FramePacket can resize the scroll content and issue scrollTo in
+        // the same Host turn. Applying synchronously lets the following
+        // Android layout pass clamp the offset against the previous extent
+        // and reset it to zero. Defer every command until all operations in
+        // the packet have been staged and the pending layout has completed.
+        post { apply() }
     }
 
     public fun scrollByLogicalOffset(offset: Double, smooth: Boolean) {


### PR DESCRIPTION
## Summary
- expose the complete virtualized List extent to native ScrollView hosts through a presentation-only direct child
- keep initial indexed/keyed scroll targets pending until the viewport, target measurement, and presented extent are ready
- defer Android scrollTo commands until the pending Host layout has completed
- avoid redundant extent style updates after the List geometry settles

## Why
A horizontal paged List could initially show only its leading spacer. Android accepted the requested scroll offset, then a subsequent content layout clamped it back to zero because the native scroll extent had not settled yet. This appeared as a completely white reader even though its images had loaded.

## Verification
- reproduced and verified the Giga reader page on an Android emulator
- cargo test -p whisker --test surface_render_pipeline horizontal_list_
- cargo test -p whisker-runtime
- Android :module:testDebugUnitTest and :runtime:testDebugUnitTest