### PR TITLE
perf(list): optimize retained virtual layout

### DIFF
--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -74,6 +74,21 @@ where
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LayoutSnapshot {
     boxes: BTreeMap<NodeId, LayoutGeometry>,
+    suppressed_by_display_none: BTreeSet<NodeId>,
+}
+
+/// Whether a node has a meaningful result in the current layout tree.
+///
+/// This is intentionally narrower than paint visibility. Properties such as
+/// `visibility:hidden` and `opacity:0` still participate in layout; only an
+/// explicit `display:none` on the node or one of its ancestors suppresses it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LayoutParticipation {
+    /// The node participates in layout, including when its resolved size is zero.
+    #[default]
+    Participating,
+    /// The node or one of its ancestors has `display:none`.
+    SuppressedByDisplayNone,
 }
 
 impl LayoutSnapshot {
@@ -85,6 +100,27 @@ impl LayoutSnapshot {
     /// Iterates in stable node-ID order.
     pub fn iter(&self) -> impl Iterator<Item = (NodeId, &LayoutGeometry)> {
         self.boxes.iter().map(|(node, rect)| (*node, rect))
+    }
+
+    /// Returns why a retained node does or does not participate in layout.
+    pub fn participation(&self, node: NodeId) -> Option<LayoutParticipation> {
+        self.get_with_participation(node)
+            .map(|(_, participation)| participation)
+    }
+
+    /// Returns geometry and layout participation with one node lookup.
+    pub fn get_with_participation(
+        &self,
+        node: NodeId,
+    ) -> Option<(&LayoutGeometry, LayoutParticipation)> {
+        self.boxes.get(&node).map(|geometry| {
+            let participation = if self.suppressed_by_display_none.contains(&node) {
+                LayoutParticipation::SuppressedByDisplayNone
+            } else {
+                LayoutParticipation::Participating
+            };
+            (geometry, participation)
+        })
     }
 
     /// Returns the number of laid-out nodes.
@@ -563,7 +599,7 @@ impl LayoutTree {
             return Err(LayoutError::InvalidMeasurement(node));
         }
         let mut snapshot = LayoutSnapshot::default();
-        self.collect_snapshot(root, &mut snapshot);
+        self.collect_snapshot(root, false, &mut snapshot);
         Ok(snapshot)
     }
 
@@ -610,8 +646,14 @@ impl LayoutTree {
         output.push(node);
     }
 
-    fn collect_snapshot(&self, node: NodeId, snapshot: &mut LayoutSnapshot) {
+    fn collect_snapshot(
+        &self,
+        node: NodeId,
+        ancestor_suppressed: bool,
+        snapshot: &mut LayoutSnapshot,
+    ) {
         let retained = self.nodes.get(&node).expect("retained snapshot node");
+        let suppressed = ancestor_suppressed || retained.style.display == DisplayValue::None;
         let layout = self
             .backend
             .layout(retained.backend)
@@ -633,8 +675,11 @@ impl LayoutTree {
                 },
             },
         );
+        if suppressed {
+            snapshot.suppressed_by_display_none.insert(node);
+        }
         for child in &retained.children {
-            self.collect_snapshot(*child, snapshot);
+            self.collect_snapshot(*child, suppressed, snapshot);
         }
     }
 }
@@ -1127,6 +1172,61 @@ mod tests {
             })
             .unwrap();
         assert_eq!(snapshot.get(leaf).unwrap().border_box.width, 50.0);
+    }
+
+    #[test]
+    fn participation_distinguishes_display_none_from_zero_size() {
+        let root = id(1);
+        let hidden = id(2);
+        let hidden_child = id(3);
+        let zero_sized = id(4);
+        let mut tree = LayoutTree::new();
+        tree.create_node(root, sized(100.0, 100.0)).unwrap();
+        tree.create_node(
+            hidden,
+            ComputedLayoutStyle {
+                display: DisplayValue::None,
+                ..sized(50.0, 50.0)
+            },
+        )
+        .unwrap();
+        tree.create_node(hidden_child, sized(20.0, 20.0)).unwrap();
+        tree.create_node(zero_sized, sized(0.0, 0.0)).unwrap();
+        tree.set_children(root, &[hidden, zero_sized]).unwrap();
+        tree.set_children(hidden, &[hidden_child]).unwrap();
+
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(
+            snapshot.participation(root),
+            Some(LayoutParticipation::Participating)
+        );
+        assert_eq!(
+            snapshot.participation(hidden),
+            Some(LayoutParticipation::SuppressedByDisplayNone)
+        );
+        assert_eq!(
+            snapshot.participation(hidden_child),
+            Some(LayoutParticipation::SuppressedByDisplayNone)
+        );
+        assert_eq!(
+            snapshot.participation(zero_sized),
+            Some(LayoutParticipation::Participating)
+        );
+        assert_eq!(
+            snapshot.get(zero_sized).unwrap().border_box,
+            LayoutRect::default()
+        );
+
+        tree.update_style(hidden, sized(50.0, 50.0)).unwrap();
+        let snapshot = tree
+            .compute(root, LayoutSize::new(100.0, 100.0), &mut zero_measure)
+            .unwrap();
+        assert_eq!(
+            snapshot.participation(hidden_child),
+            Some(LayoutParticipation::Participating)
+        );
     }
 
     #[test]

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -17,12 +17,12 @@ use crate::transform_interpolation::interpolate_transform_style;
 #[cfg(test)]
 use crate::transform_interpolation::{identity_transform_function, interpolate_transform_function};
 use crate::value::WhiskerValue;
-use crate::view::{BindType, DynRenderer, Element, with_installed_renderer};
+use crate::view::{BindType, DynRenderer, Element, LayoutObservation, with_installed_renderer};
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
     Accessibility, BoxPaint, ElementRegistration, ElementSchema, ElementValueKind, HitTestBehavior,
-    HostPresentationUpdate, InputEvent, InputEventError, LayoutGeometry, MeasurementReady, NodeId,
-    PaintColor, ResourceCommand, ResourceEvent, ResourceId, ResourceMessageError, SurfaceId,
+    HostPresentationUpdate, InputEvent, InputEventError, MeasurementReady, NodeId, PaintColor,
+    ResourceCommand, ResourceEvent, ResourceId, ResourceMessageError, SurfaceId,
 };
 #[cfg(test)]
 use whisker_engine::whisker_style::ComputedTransformFunction;
@@ -701,24 +701,30 @@ impl SurfaceRuntime {
                 } = &mut *state;
                 if let Some(last_layout) = surface.last_layout() {
                     for entry in elements.values_mut() {
-                        let Some(geometry) =
-                            entry.node.and_then(|node| last_layout.get(node)).copied()
-                        else {
+                        let Some((geometry, participation)) = entry.node.and_then(|node| {
+                            last_layout
+                                .get_with_participation(node)
+                                .map(|(geometry, participation)| (*geometry, participation))
+                        }) else {
                             continue;
+                        };
+                        let observation = LayoutObservation {
+                            geometry,
+                            participation,
                         };
                         let Some(observers) = entry.layout_observers.as_mut() else {
                             continue;
                         };
-                        if observers.last_notified == Some(geometry) {
+                        if observers.last_notified == Some(observation) {
                             continue;
                         }
-                        observers.last_notified = Some(geometry);
+                        observers.last_notified = Some(observation);
                         notifications.extend(
                             observers
                                 .callbacks
                                 .iter()
                                 .cloned()
-                                .map(|callback| (callback, geometry)),
+                                .map(|callback| (callback, observation)),
                         );
                     }
                 }
@@ -739,8 +745,8 @@ impl SurfaceRuntime {
         };
         if !notifications.is_empty() || !batch_end_notifications.is_empty() {
             with_installed_renderer(self.renderer(), || {
-                for (callback, geometry) in notifications {
-                    callback(geometry);
+                for (callback, observation) in notifications {
+                    callback(observation);
                 }
                 for callback in batch_end_notifications {
                     callback();
@@ -835,8 +841,8 @@ struct BoundElement {
 
 #[derive(Clone, Default)]
 struct LayoutObservers {
-    callbacks: Vec<Rc<dyn Fn(LayoutGeometry) + 'static>>,
-    last_notified: Option<LayoutGeometry>,
+    callbacks: Vec<Rc<dyn Fn(LayoutObservation) + 'static>>,
+    last_notified: Option<LayoutObservation>,
 }
 
 #[derive(Clone)]
@@ -1928,7 +1934,7 @@ mod input_tests {
 
 #[cfg(test)]
 mod layout_observer_tests {
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
     use std::convert::Infallible;
     use std::rc::Rc;
 
@@ -1938,10 +1944,11 @@ mod layout_observer_tests {
         append_child, create_element, observe_layout, observe_layout_batch_end,
         set_specified_style, with_installed_renderer,
     };
+    use whisker_engine::whisker_layout::LayoutParticipation;
     use whisker_engine::whisker_protocol::{MeasurementRequest, MeasurementResponse};
     use whisker_engine::whisker_style::{
-        LengthPercentageValue, LengthUnit, LengthValue, PositionValue, SizeValue, StyleNumber,
-        StyleProperty, StyleValue,
+        DisplayValue, LengthPercentageValue, LengthUnit, LengthValue, PositionValue, SizeValue,
+        StyleNumber, StyleProperty, StyleValue,
     };
 
     struct NoMeasurements;
@@ -2048,6 +2055,94 @@ mod layout_observer_tests {
             completed_batches.get(),
             2,
             "batch-end observers run once after each completed layout notification batch"
+        );
+    }
+
+    #[test]
+    fn layout_observers_report_display_none_separately_from_zero_geometry() {
+        crate::reactive::__reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(93).unwrap(),
+            StyleEnvironment::new(320.0, 480.0, 1.0, 14.0),
+        );
+        let mut runtime =
+            crate::RuntimeInstance::new(surface.clone(), crate::RuntimeWakeHandle::new(|| {}));
+        let observations = Rc::new(RefCell::new(Vec::new()));
+        let root_handle = Rc::new(Cell::new(None));
+
+        runtime
+            .mount({
+                let observations = Rc::clone(&observations);
+                let root_handle = Rc::clone(&root_handle);
+                move || {
+                    let root = create_element(ElementTag::View);
+                    let child = create_element(ElementTag::View);
+                    set_specified_style(root, &absolute_box(100.0, 100.0));
+                    set_specified_style(child, &absolute_box(0.0, 0.0));
+                    append_child(root, child);
+                    observe_layout(
+                        child,
+                        Box::new(move |observation| observations.borrow_mut().push(observation)),
+                    );
+                    root_handle.set(Some(root));
+                    root
+                }
+            })
+            .unwrap();
+
+        let mut provider = NoMeasurements;
+        surface
+            .drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut provider,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(observations.borrow().len(), 1);
+        assert_eq!(
+            observations.borrow()[0].participation,
+            LayoutParticipation::Participating
+        );
+        assert_eq!(observations.borrow()[0].geometry.border_box.width, 0.0);
+        assert_eq!(observations.borrow()[0].geometry.border_box.height, 0.0);
+
+        with_installed_renderer(surface.renderer(), || {
+            let hidden = absolute_box(100.0, 100.0).push(
+                StyleProperty::Display,
+                StyleValue::Display(DisplayValue::None),
+            );
+            set_specified_style(root_handle.get().unwrap(), &hidden);
+        });
+        surface
+            .drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut provider,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(observations.borrow().len(), 2);
+        assert_eq!(
+            observations.borrow()[1].participation,
+            LayoutParticipation::SuppressedByDisplayNone
+        );
+
+        with_installed_renderer(surface.renderer(), || {
+            set_specified_style(root_handle.get().unwrap(), &absolute_box(100.0, 100.0));
+        });
+        surface
+            .drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut provider,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(observations.borrow().len(), 3);
+        assert_eq!(
+            observations.borrow()[2].participation,
+            LayoutParticipation::Participating
         );
     }
 }

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -677,7 +677,7 @@ impl SurfaceRuntime {
         provider: &mut Provider,
         options: LayoutOptions,
     ) -> Result<LayoutProgress, RuntimeLayoutError<Provider::Error>> {
-        let (layout, notifications) = {
+        let (layout, notifications, batch_end_notifications) = {
             let mut state = self.state.borrow_mut();
             state
                 .take_binding_error()
@@ -695,30 +695,55 @@ impl SurfaceRuntime {
             BindingState::apply_transform_updates(transform_updates, &mut state.surface)
                 .map_err(RuntimeLayoutError::Binding)?;
             let notifications = if layout.has_layout() {
+                let mut notifications = Vec::new();
+                let BindingState {
+                    surface, elements, ..
+                } = &mut *state;
+                if let Some(last_layout) = surface.last_layout() {
+                    for entry in elements.values_mut() {
+                        let Some(geometry) =
+                            entry.node.and_then(|node| last_layout.get(node)).copied()
+                        else {
+                            continue;
+                        };
+                        let Some(observers) = entry.layout_observers.as_mut() else {
+                            continue;
+                        };
+                        if observers.last_notified == Some(geometry) {
+                            continue;
+                        }
+                        observers.last_notified = Some(geometry);
+                        notifications.extend(
+                            observers
+                                .callbacks
+                                .iter()
+                                .cloned()
+                                .map(|callback| (callback, geometry)),
+                        );
+                    }
+                }
+                notifications
+            } else {
+                Vec::new()
+            };
+            let batch_end_notifications = if layout.has_layout() {
                 state
                     .elements
                     .values()
-                    .filter_map(|entry| {
-                        let geometry = state.surface.last_layout()?.get(entry.node?).copied()?;
-                        Some(
-                            entry
-                                .layout_observers
-                                .iter()
-                                .cloned()
-                                .map(move |callback| (callback, geometry)),
-                        )
-                    })
-                    .flatten()
+                    .flat_map(|entry| entry.layout_batch_end_observers.iter().cloned())
                     .collect::<Vec<_>>()
             } else {
                 Vec::new()
             };
-            (layout, notifications)
+            (layout, notifications, batch_end_notifications)
         };
-        if !notifications.is_empty() {
+        if !notifications.is_empty() || !batch_end_notifications.is_empty() {
             with_installed_renderer(self.renderer(), || {
                 for (callback, geometry) in notifications {
                     callback(geometry);
+                }
+                for callback in batch_end_notifications {
+                    callback();
                 }
             });
         }
@@ -796,7 +821,8 @@ struct BoundElement {
     dataset: BTreeMap<String, WhiskerValue>,
     accessibility: Accessibility,
     listeners: HashMap<String, Vec<RuntimeListener>>,
-    layout_observers: Vec<Rc<dyn Fn(LayoutGeometry) + 'static>>,
+    layout_observers: Option<Box<LayoutObservers>>,
+    layout_batch_end_observers: Vec<Rc<dyn Fn() + 'static>>,
     style_initialized: bool,
     opacity_transition: Option<Box<ActiveTransition<f32>>>,
     color_transitions: Option<Box<ActiveColorTransitions>>,
@@ -805,6 +831,12 @@ struct BoundElement {
     layout_transitions: Option<Box<ActivePropertyTransitions>>,
     animations: Vec<ActiveKeyframeAnimation>,
     pending_motion_events: VecDeque<PendingMotionEvent>,
+}
+
+#[derive(Clone, Default)]
+struct LayoutObservers {
+    callbacks: Vec<Rc<dyn Fn(LayoutGeometry) + 'static>>,
+    last_notified: Option<LayoutGeometry>,
 }
 
 #[derive(Clone)]
@@ -1309,7 +1341,8 @@ impl BindingState {
                 dataset: BTreeMap::new(),
                 accessibility: Accessibility::default(),
                 listeners: HashMap::new(),
-                layout_observers: Vec::new(),
+                layout_observers: None,
+                layout_batch_end_observers: Vec::new(),
                 style_initialized: false,
                 opacity_transition: None,
                 color_transitions: None,
@@ -1889,6 +1922,132 @@ mod input_tests {
                 .unwrap()
                 .host_scroll_offset(),
             [3.0, 4.0]
+        );
+    }
+}
+
+#[cfg(test)]
+mod layout_observer_tests {
+    use std::cell::Cell;
+    use std::convert::Infallible;
+    use std::rc::Rc;
+
+    use super::*;
+    use crate::element::ElementTag;
+    use crate::view::{
+        append_child, create_element, observe_layout, observe_layout_batch_end,
+        set_specified_style, with_installed_renderer,
+    };
+    use whisker_engine::whisker_protocol::{MeasurementRequest, MeasurementResponse};
+    use whisker_engine::whisker_style::{
+        LengthPercentageValue, LengthUnit, LengthValue, PositionValue, SizeValue, StyleNumber,
+        StyleProperty, StyleValue,
+    };
+
+    struct NoMeasurements;
+
+    impl MeasurementProvider for NoMeasurements {
+        type Error = Infallible;
+
+        fn measure_batch(
+            &mut self,
+            _surface: SurfaceId,
+            requests: &[MeasurementRequest],
+            _responses: &mut Vec<MeasurementResponse>,
+        ) -> Result<(), Self::Error> {
+            assert!(requests.is_empty());
+            Ok(())
+        }
+    }
+
+    fn absolute_box(width: f32, height: f32) -> SpecifiedStyle {
+        let px = |value| {
+            StyleValue::Size(SizeValue::LengthPercentage(LengthPercentageValue::Length(
+                LengthValue::Dimension {
+                    value: StyleNumber::new(value),
+                    unit: LengthUnit::Px,
+                },
+            )))
+        };
+        SpecifiedStyle::new()
+            .push(
+                StyleProperty::Position,
+                StyleValue::Position(PositionValue::Absolute),
+            )
+            .push(StyleProperty::Width, px(width))
+            .push(StyleProperty::Height, px(height))
+    }
+
+    #[test]
+    fn layout_observers_skip_unchanged_geometry_after_another_node_relayouts() {
+        crate::reactive::__reset_for_tests();
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(92).unwrap(),
+            StyleEnvironment::new(320.0, 480.0, 1.0, 14.0),
+        );
+        let mut runtime =
+            crate::RuntimeInstance::new(surface.clone(), crate::RuntimeWakeHandle::new(|| {}));
+        let observed = Rc::new(Cell::new(0));
+        let completed_batches = Rc::new(Cell::new(0));
+        let sibling = Rc::new(Cell::new(None));
+
+        runtime
+            .mount({
+                let observed = Rc::clone(&observed);
+                let completed_batches = Rc::clone(&completed_batches);
+                let sibling = Rc::clone(&sibling);
+                move || {
+                    let root = create_element(ElementTag::View);
+                    let child = create_element(ElementTag::View);
+                    let other = create_element(ElementTag::View);
+                    set_specified_style(child, &absolute_box(20.0, 20.0));
+                    set_specified_style(other, &absolute_box(10.0, 10.0));
+                    append_child(root, child);
+                    append_child(root, other);
+                    observe_layout(child, Box::new(move |_| observed.set(observed.get() + 1)));
+                    observe_layout_batch_end(
+                        root,
+                        Box::new(move || completed_batches.set(completed_batches.get() + 1)),
+                    );
+                    sibling.set(Some(other));
+                    root
+                }
+            })
+            .unwrap();
+
+        let mut provider = NoMeasurements;
+        surface
+            .drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut provider,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+        assert_eq!(observed.get(), 1);
+        assert_eq!(completed_batches.get(), 1);
+
+        with_installed_renderer(surface.renderer(), || {
+            set_specified_style(sibling.get().unwrap(), &absolute_box(30.0, 10.0));
+        });
+        surface
+            .drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut provider,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            observed.get(),
+            1,
+            "an unrelated layout pass must not re-notify unchanged geometry"
+        );
+        assert_eq!(
+            completed_batches.get(),
+            2,
+            "batch-end observers run once after each completed layout notification batch"
         );
     }
 }

--- a/crates/whisker-runtime/src/surface_runtime/renderer.rs
+++ b/crates/whisker-runtime/src/surface_runtime/renderer.rs
@@ -274,9 +274,24 @@ impl DynRenderer for SurfaceRuntime {
 
     fn observe_layout(&self, handle: Element, callback: Box<dyn Fn(LayoutGeometry) + 'static>) {
         let mut state = self.state.borrow_mut();
+        let result = state.element_mut(handle).map(|entry| {
+            let observers = entry
+                .layout_observers
+                .get_or_insert_with(|| Box::new(super::LayoutObservers::default()));
+            observers.callbacks.push(Rc::from(callback));
+            // A newly registered observer must receive the current geometry
+            // on the next completed layout even when it equals the geometry
+            // seen by older observers.
+            observers.last_notified = None;
+        });
+        state.record(result);
+    }
+
+    fn observe_layout_batch_end(&self, handle: Element, callback: Box<dyn Fn() + 'static>) {
+        let mut state = self.state.borrow_mut();
         let result = state
             .element_mut(handle)
-            .map(|entry| entry.layout_observers.push(Rc::from(callback)));
+            .map(|entry| entry.layout_batch_end_observers.push(Rc::from(callback)));
         state.record(result);
     }
 

--- a/crates/whisker-runtime/src/surface_runtime/renderer.rs
+++ b/crates/whisker-runtime/src/surface_runtime/renderer.rs
@@ -272,7 +272,7 @@ impl DynRenderer for SurfaceRuntime {
         state.record(result);
     }
 
-    fn observe_layout(&self, handle: Element, callback: Box<dyn Fn(LayoutGeometry) + 'static>) {
+    fn observe_layout(&self, handle: Element, callback: Box<dyn Fn(LayoutObservation) + 'static>) {
         let mut state = self.state.borrow_mut();
         let result = state.element_mut(handle).map(|entry| {
             let observers = entry

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -62,6 +62,7 @@ pub use renderer::{
 // module-author API, hence `#[doc(hidden)]`.
 #[doc(hidden)]
 pub use renderer::{
-    DynRenderer, EventDispatchPlan, PHANTOM_BASE, current_renderer_id, install_renderer,
-    specified_style, try_invoke_element_command, uninstall_renderer, with_installed_renderer,
+    DynRenderer, EventDispatchPlan, LayoutObservation, PHANTOM_BASE, current_renderer_id,
+    install_renderer, specified_style, try_invoke_element_command, uninstall_renderer,
+    with_installed_renderer,
 };

--- a/crates/whisker-runtime/src/view/mod.rs
+++ b/crates/whisker-runtime/src/view/mod.rs
@@ -50,10 +50,10 @@ pub use virtualizer::{VirtualGridLayout, VirtualListLayout, VirtualListOptions, 
 pub use renderer::{
     BindType, append_child, child_index, children_of, create_element, create_element_by_name,
     create_element_by_schema, create_phantom_element, dispatch_event, flush, insert_child_at,
-    is_phantom, observe_layout, previous_sibling, release_element, remove_child, set_accessibility,
-    set_attribute, set_attribute_bool, set_attribute_double, set_attribute_int,
-    set_attribute_object, set_dataset, set_element_id, set_event_listener, set_root,
-    set_specified_style, set_text_max_lines,
+    is_phantom, observe_layout, observe_layout_batch_end, previous_sibling, release_element,
+    remove_child, set_accessibility, set_attribute, set_attribute_bool, set_attribute_double,
+    set_attribute_int, set_attribute_object, set_dataset, set_element_id, set_event_listener,
+    set_root, set_specified_style, set_text_max_lines,
 };
 
 // Renderer-wiring internals. Public because Hosts and test renderers link

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -186,6 +186,11 @@ pub trait DynRenderer {
     /// successful Taffy pass without involving a Host event.
     fn observe_layout(&self, _handle: Element, _callback: Box<dyn Fn(LayoutGeometry) + 'static>) {}
 
+    /// Registers a callback that runs once after all per-element layout
+    /// notifications for a completed layout pass. Renderers without retained
+    /// layout notification batches may ignore it.
+    fn observe_layout_batch_end(&self, _handle: Element, _callback: Box<dyn Fn() + 'static>) {}
+
     /// Plan how a reported event (`event_name` at `target_sign`,
     /// carrying `body`) propagates through Whisker's reconstructed
     /// chain — capture phase (root → target) then bubble phase
@@ -895,6 +900,20 @@ pub fn observe_layout(handle: Element, callback: Box<dyn Fn(LayoutGeometry) + 's
         return;
     }
     with_renderer(|renderer| renderer.observe_layout(handle, callback), ())
+}
+
+/// Registers an internal callback at the end of each completed resolved-layout
+/// notification batch. The callback is owned by `handle`, so removing that
+/// element also removes the registration.
+pub fn observe_layout_batch_end(handle: Element, callback: Box<dyn Fn() + 'static>) {
+    if is_phantom(handle) {
+        drop(callback);
+        return;
+    }
+    with_renderer(
+        |renderer| renderer.observe_layout_batch_end(handle, callback),
+        (),
+    )
 }
 
 /// Gives the installed renderer the first opportunity to handle an element

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -26,8 +26,23 @@ use super::handle::Element;
 use crate::element::ElementTag;
 use crate::event::Dataset;
 use crate::value::WhiskerValue;
+use whisker_engine::whisker_layout::LayoutParticipation;
 use whisker_protocol::{Accessibility, ElementSchema, LayoutGeometry};
 use whisker_style::SpecifiedStyle;
+
+/// One internal resolved-layout notification.
+///
+/// Participation is kept outside [`LayoutGeometry`] because geometry is part
+/// of the Host protocol while this state is consumed only by Rust control
+/// primitives.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct LayoutObservation {
+    /// Resolved box geometry for the retained node.
+    pub geometry: LayoutGeometry,
+    /// Whether the node belongs to the active layout tree.
+    pub participation: LayoutParticipation,
+}
 
 /// Event-handler propagation type for the four supported handler kinds
 /// (`bind` / `catch` / `capture-bind` /
@@ -184,7 +199,12 @@ pub trait DynRenderer {
     /// Observes resolved Rust layout for framework control primitives.
     /// Ordinary renderers may ignore this; SurfaceRuntime reports after each
     /// successful Taffy pass without involving a Host event.
-    fn observe_layout(&self, _handle: Element, _callback: Box<dyn Fn(LayoutGeometry) + 'static>) {}
+    fn observe_layout(
+        &self,
+        _handle: Element,
+        _callback: Box<dyn Fn(LayoutObservation) + 'static>,
+    ) {
+    }
 
     /// Registers a callback that runs once after all per-element layout
     /// notifications for a completed layout pass. Renderers without retained
@@ -894,7 +914,7 @@ pub fn set_event_listener(
 }
 
 /// Registers an internal resolved-layout observer on one real element.
-pub fn observe_layout(handle: Element, callback: Box<dyn Fn(LayoutGeometry) + 'static>) {
+pub fn observe_layout(handle: Element, callback: Box<dyn Fn(LayoutObservation) + 'static>) {
     if is_phantom(handle) {
         drop(callback);
         return;

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -12,6 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::rc::Rc;
 
+use whisker_engine::whisker_layout::LayoutParticipation;
 use whisker_style::{
     GridPlacementValue, LengthPercentageAutoValue, LengthPercentageValue, LengthUnit, LengthValue,
     PositionValue, SizeValue, SpecifiedStyle, StyleNumber, StyleProperty, StyleValue,
@@ -486,7 +487,7 @@ pub fn virtualize<T, K>(
     let rendered_window = Rc::new(Cell::new(None::<LayoutWindow>));
     let pending_initial_scroll = Rc::new(RefCell::new(initial_scroll));
     let viewport_ready = Rc::new(Cell::new(false));
-    let layout_participating = Rc::new(Cell::new(false));
+    let layout_participation = Rc::new(Cell::new(LayoutParticipation::Participating));
     let presented_scroll_extent = Rc::new(Cell::new(0.0));
     let configured_scroll_extent = Rc::new(Cell::new(f32::NAN));
     let inside_start_threshold = Rc::new(Cell::new(false));
@@ -512,7 +513,8 @@ pub fn virtualize<T, K>(
             let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
-                Box::new(move |layout_geometry| {
+                Box::new(move |observation| {
+                    let layout_geometry = observation.geometry;
                     let size = match axis {
                         ScrollAxis::Vertical => layout_geometry.border_box.height,
                         ScrollAxis::Horizontal => layout_geometry.border_box.width,
@@ -537,7 +539,8 @@ pub fn virtualize<T, K>(
             let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
-                Box::new(move |layout_geometry| {
+                Box::new(move |observation| {
+                    let layout_geometry = observation.geometry;
                     let size = match axis {
                         ScrollAxis::Vertical => layout_geometry.border_box.height,
                         ScrollAxis::Horizontal => layout_geometry.border_box.width,
@@ -563,7 +566,8 @@ pub fn virtualize<T, K>(
             let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
-                Box::new(move |layout_geometry| {
+                Box::new(move |observation| {
+                    let layout_geometry = observation.geometry;
                     let size = match axis {
                         ScrollAxis::Vertical => layout_geometry.border_box.height,
                         ScrollAxis::Horizontal => layout_geometry.border_box.width,
@@ -769,7 +773,8 @@ pub fn virtualize<T, K>(
         let pending_layout_notification = Rc::clone(&pending_layout_notification);
         observe_layout(
             scroll_extent,
-            Box::new(move |layout_geometry| {
+            Box::new(move |observation| {
+                let layout_geometry = observation.geometry;
                 let extent = match axis {
                     ScrollAxis::Vertical => layout_geometry.border_box.height,
                     ScrollAxis::Horizontal => layout_geometry.border_box.width,
@@ -777,7 +782,9 @@ pub fn virtualize<T, K>(
                 if !extent.is_finite() || extent < 0.0 {
                     return;
                 }
-                presented_scroll_extent.set(extent);
+                if observation.participation == LayoutParticipation::Participating {
+                    presented_scroll_extent.set(extent);
+                }
                 pending_layout_notification.set(true);
             }),
         );
@@ -787,11 +794,12 @@ pub fn virtualize<T, K>(
         let geometry = Rc::clone(&geometry);
         let list_ref = list_ref.clone();
         let viewport_ready = Rc::clone(&viewport_ready);
-        let layout_participating = Rc::clone(&layout_participating);
+        let layout_participation = Rc::clone(&layout_participation);
         let pending_layout_notification = Rc::clone(&pending_layout_notification);
         observe_layout(
             scroll_view,
-            Box::new(move |layout_geometry| {
+            Box::new(move |observation| {
+                let layout_geometry = observation.geometry;
                 let viewport = match axis {
                     ScrollAxis::Vertical => layout_geometry.border_box.height,
                     ScrollAxis::Horizontal => layout_geometry.border_box.width,
@@ -799,9 +807,9 @@ pub fn virtualize<T, K>(
                 if !viewport.is_finite() || viewport < 0.0 {
                     return;
                 }
-                layout_participating.set(viewport > 0.0);
+                layout_participation.set(observation.participation);
                 pending_layout_notification.set(true);
-                if viewport <= 0.0 {
+                if observation.participation == LayoutParticipation::SuppressedByDisplayNone {
                     return;
                 }
                 viewport_ready.set(true);
@@ -832,7 +840,7 @@ pub fn virtualize<T, K>(
         let pending_layout_notification = Rc::clone(&pending_layout_notification);
         let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
         let viewport_ready = Rc::clone(&viewport_ready);
-        let layout_participating = Rc::clone(&layout_participating);
+        let layout_participation = Rc::clone(&layout_participation);
         let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
         let alive = Rc::clone(&alive);
         let reconcile = Rc::clone(&reconcile);
@@ -847,11 +855,12 @@ pub fn virtualize<T, K>(
                     return;
                 }
 
-                // `display:none` legitimately collapses the List subtree to
-                // zero. Those geometries describe an absent ancestor, not
-                // new row measurements; retain the last active index and
-                // scroll anchor until the List participates in layout again.
-                if !layout_participating.get() {
+                // An explicit `display:none` on the List or an ancestor makes
+                // descendant geometries inapplicable. Retain the last active
+                // index and scroll anchor until the List participates again.
+                // A participating zero-sized viewport is intentionally not
+                // treated as hidden.
+                if layout_participation.get() == LayoutParticipation::SuppressedByDisplayNone {
                     pending_entry_measurements.borrow_mut().clear();
                     pending_track_measurements.borrow_mut().clear();
                     pending_aux_measurements.borrow_mut().clear();

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -121,7 +121,13 @@ struct LayoutIndex<T, K> {
     /// entry is the complete estimated extent.
     offsets: Vec<f32>,
     sizes: Vec<f32>,
+    /// Measured main-axis content size keyed by the first item in a virtual
+    /// track. Grid gaps are added separately from the measured content.
     measured_sizes: HashMap<K, f32>,
+    /// Automatically learned fallback for tracks that have not been mounted
+    /// yet. A developer-provided estimate is deliberately not part of the
+    /// public List API.
+    estimated_track_size: f32,
     header_extent: f32,
     footer_extent: f32,
     empty_extent: f32,
@@ -143,6 +149,7 @@ where
             offsets: vec![0.0],
             sizes: Vec::new(),
             measured_sizes: HashMap::new(),
+            estimated_track_size: DEFAULT_ITEM_SIZE,
             header_extent: 0.0,
             footer_extent: 0.0,
             empty_extent: 0.0,
@@ -159,11 +166,6 @@ where
         self.keys.reserve(items.len());
         self.key_to_index.clear();
         self.key_to_index.reserve(items.len());
-        self.offsets.clear();
-        self.offsets.reserve(items.len() + 1);
-        self.offsets.push(self.header_extent);
-        self.sizes.clear();
-        self.sizes.reserve(items.len());
         for (index, item) in items.iter().enumerate() {
             let key = key(item);
             assert!(
@@ -171,29 +173,19 @@ where
                 "virtualized List keys must be unique"
             );
             self.key_to_index.insert(key.clone(), index);
-            let size = if index % self.items_per_track == 0 {
-                let has_successor = index + self.items_per_track < items.len();
-                self.measured_sizes
-                    .get(&key)
-                    .copied()
-                    .unwrap_or(DEFAULT_ITEM_SIZE + if has_successor { self.main_gap } else { 0.0 })
-            } else {
-                0.0
-            };
             self.keys.push(key);
-            self.sizes.push(size);
-            self.offsets
-                .push(self.offsets.last().copied().unwrap_or(self.header_extent) + size);
         }
         self.measured_sizes
             .retain(|key, _| unique_keys.contains(key));
+        self.refresh_estimated_track_size();
+        self.rebuild_sizes_and_offsets();
         self.items = items;
         self.generation = self.generation.wrapping_add(1);
         self.source_generation = self.source_generation.wrapping_add(1);
     }
 
     fn update_measurements(&mut self, measurements: impl IntoIterator<Item = (K, f32)>) -> bool {
-        let mut first_changed = None::<usize>;
+        let mut cache_changed = false;
         for (key, size) in measurements {
             if !size.is_finite() || size < 0.0 {
                 continue;
@@ -202,10 +194,28 @@ where
                 continue;
             };
             let index = self.track_start_item(self.track_for_item(item_index));
+            let track_key = self.keys[index].clone();
+            if self
+                .measured_sizes
+                .get(&track_key)
+                .is_some_and(|measured| (*measured - size).abs() < 0.5)
+            {
+                continue;
+            }
+            self.measured_sizes.insert(track_key, size);
+            cache_changed = true;
+        }
+        if !cache_changed {
+            return false;
+        }
+
+        self.refresh_estimated_track_size();
+        let mut first_changed = None::<usize>;
+        for index in (0..self.keys.len()).step_by(self.items_per_track) {
+            let size = self.track_extent(index);
             if (self.sizes[index] - size).abs() < 0.5 {
                 continue;
             }
-            self.measured_sizes.insert(key, size);
             self.sizes[index] = size;
             first_changed = Some(first_changed.map_or(index, |first| first.min(index)));
         }
@@ -218,6 +228,52 @@ where
         }
         self.generation = self.generation.wrapping_add(1);
         true
+    }
+
+    fn refresh_estimated_track_size(&mut self) {
+        let mut total = 0.0_f64;
+        let mut samples = 0_usize;
+        for (key, size) in &self.measured_sizes {
+            let Some(index) = self.key_to_index.get(key).copied() else {
+                continue;
+            };
+            if index % self.items_per_track != 0 || *size <= 0.0 {
+                continue;
+            }
+            total += f64::from(*size);
+            samples += 1;
+        }
+        if samples > 0 {
+            self.estimated_track_size = (total / samples as f64) as f32;
+        }
+    }
+
+    fn rebuild_sizes_and_offsets(&mut self) {
+        self.offsets.clear();
+        self.offsets.reserve(self.keys.len() + 1);
+        self.offsets.push(self.header_extent);
+        self.sizes.clear();
+        self.sizes.reserve(self.keys.len());
+        for index in 0..self.keys.len() {
+            let size = if index % self.items_per_track == 0 {
+                self.track_extent(index)
+            } else {
+                0.0
+            };
+            self.sizes.push(size);
+            self.offsets
+                .push(self.offsets.last().copied().unwrap_or(self.header_extent) + size);
+        }
+    }
+
+    fn track_extent(&self, index: usize) -> f32 {
+        let content_size = self
+            .measured_sizes
+            .get(&self.keys[index])
+            .copied()
+            .unwrap_or(self.estimated_track_size);
+        let has_successor = index + self.items_per_track < self.keys.len();
+        content_size + if has_successor { self.main_gap } else { 0.0 }
     }
 
     fn update_aux_measurement(&mut self, content: AuxContent, size: f32) -> bool {
@@ -913,17 +969,11 @@ pub fn virtualize<T, K>(
                             layout.update_aux_measurement(pending.content, pending.size.max(0.0));
                     }
                     let mut measurements = entry_measurements;
-                    measurements.extend(track_measurements.into_iter().map(
-                        |(track, key, size)| {
-                            let extent = size
-                                + if track + 1 < layout.track_count() {
-                                    main_gap
-                                } else {
-                                    0.0
-                                };
-                            (key, extent)
-                        },
-                    ));
+                    measurements.extend(
+                        track_measurements
+                            .into_iter()
+                            .map(|(_track, key, size)| (key, size)),
+                    );
                     changed |= layout.update_measurements(measurements);
 
                     let initial_offset = resolve_pending_initial_target(
@@ -1691,8 +1741,38 @@ mod tests {
         assert!(index.update_measurements([(1, 20.0), (3, 80.0)]));
 
         assert_eq!(index.generation, generation + 1);
-        assert_eq!(index.offsets, vec![0.0, 44.0, 64.0, 108.0, 188.0, 232.0]);
+        assert_eq!(index.estimated_track_size, 50.0);
+        assert_eq!(index.offsets, vec![0.0, 50.0, 70.0, 120.0, 200.0, 250.0]);
         assert_eq!(index.measured_sizes.get(&1), Some(&20.0));
         assert_eq!(index.measured_sizes.get(&3), Some(&80.0));
+    }
+
+    #[test]
+    fn zero_sized_tracks_do_not_collapse_the_unmeasured_estimate() {
+        let mut index = LayoutIndex::new(1, 0.0);
+        index.replace((0_u32..3).collect(), |item| *item);
+
+        assert!(index.update_measurements([(0, 0.0)]));
+        assert_eq!(index.estimated_track_size, DEFAULT_ITEM_SIZE);
+        assert_eq!(index.sizes, vec![0.0, 44.0, 44.0]);
+
+        assert!(index.update_measurements([(1, 100.0)]));
+        assert_eq!(index.estimated_track_size, 100.0);
+        assert_eq!(index.sizes, vec![0.0, 100.0, 100.0]);
+    }
+
+    #[test]
+    fn grid_estimates_track_content_and_applies_gap_separately() {
+        let mut index = LayoutIndex::new(2, 8.0);
+        index.replace((0_u32..6).collect(), |item| *item);
+        assert_eq!(index.sizes, vec![52.0, 0.0, 52.0, 0.0, 44.0, 0.0]);
+
+        assert!(index.update_measurements([(0, 100.0), (2, 60.0)]));
+
+        assert_eq!(index.estimated_track_size, 80.0);
+        assert_eq!(index.measured_sizes.get(&0), Some(&100.0));
+        assert_eq!(index.measured_sizes.get(&2), Some(&60.0));
+        assert_eq!(index.sizes, vec![108.0, 0.0, 68.0, 0.0, 80.0, 0.0]);
+        assert_eq!(index.total_extent(), 256.0);
     }
 }

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -25,8 +25,8 @@ use super::handle::Element;
 use super::list::{ListRef, ListScrollTarget, ScrollAlignment, ScrollAxis};
 use super::renderer::{
     BindType, append_child, children_of, create_element, insert_child_at, observe_layout,
-    remove_child, set_event_listener, set_specified_style, specified_style,
-    try_invoke_element_command,
+    observe_layout_batch_end, remove_child, set_event_listener, set_specified_style,
+    specified_style, try_invoke_element_command,
 };
 
 const DEFAULT_ITEM_SIZE: f32 = 44.0;
@@ -78,6 +78,25 @@ pub struct VirtualListOptions<K: 'static> {
 type ReconcileCallback = Rc<dyn Fn()>;
 type EntryLayoutObserver<K> = Rc<dyn Fn(&K, Element)>;
 
+struct PendingEntryMeasurement<K> {
+    key: K,
+    handle: Element,
+    size: f32,
+}
+
+#[derive(Clone, Copy)]
+struct PendingTrackMeasurement {
+    track: usize,
+    handle: Element,
+    size: f32,
+}
+
+#[derive(Clone, Copy)]
+struct PendingAuxMeasurement {
+    content: AuxContent,
+    size: f32,
+}
+
 struct MountedEntry<T: 'static> {
     owner: Owner,
     handle: Element,
@@ -94,6 +113,9 @@ struct MountedTrack<K> {
 struct LayoutIndex<T, K> {
     items: Vec<T>,
     keys: Vec<K>,
+    /// Stable-key lookup kept in sync with `keys`. Hot measurement, anchor,
+    /// and imperative-scroll paths must not linearly scan large data sets.
+    key_to_index: HashMap<K, usize>,
     /// Prefix offsets. `offsets[i]` is the start of item `i` and the final
     /// entry is the complete estimated extent.
     offsets: Vec<f32>,
@@ -116,6 +138,7 @@ where
         Self {
             items: Vec::new(),
             keys: Vec::new(),
+            key_to_index: HashMap::new(),
             offsets: vec![0.0],
             sizes: Vec::new(),
             measured_sizes: HashMap::new(),
@@ -133,6 +156,8 @@ where
         let mut unique_keys = HashSet::with_capacity(items.len());
         self.keys.clear();
         self.keys.reserve(items.len());
+        self.key_to_index.clear();
+        self.key_to_index.reserve(items.len());
         self.offsets.clear();
         self.offsets.reserve(items.len() + 1);
         self.offsets.push(self.header_extent);
@@ -144,6 +169,7 @@ where
                 unique_keys.insert(key.clone()),
                 "virtualized List keys must be unique"
             );
+            self.key_to_index.insert(key.clone(), index);
             let size = if index % self.items_per_track == 0 {
                 let has_successor = index + self.items_per_track < items.len();
                 self.measured_sizes
@@ -165,20 +191,27 @@ where
         self.source_generation = self.source_generation.wrapping_add(1);
     }
 
-    fn update_measurement(&mut self, key: &K, size: f32) -> bool {
-        if !size.is_finite() || size < 0.0 {
-            return false;
+    fn update_measurements(&mut self, measurements: impl IntoIterator<Item = (K, f32)>) -> bool {
+        let mut first_changed = None::<usize>;
+        for (key, size) in measurements {
+            if !size.is_finite() || size < 0.0 {
+                continue;
+            }
+            let Some(&item_index) = self.key_to_index.get(&key) else {
+                continue;
+            };
+            let index = self.track_start_item(self.track_for_item(item_index));
+            if (self.sizes[index] - size).abs() < 0.5 {
+                continue;
+            }
+            self.measured_sizes.insert(key, size);
+            self.sizes[index] = size;
+            first_changed = Some(first_changed.map_or(index, |first| first.min(index)));
         }
-        let Some(item_index) = self.keys.iter().position(|candidate| candidate == key) else {
+        let Some(first_changed) = first_changed else {
             return false;
         };
-        let index = self.track_start_item(self.track_for_item(item_index));
-        if (self.sizes[index] - size).abs() < 0.5 {
-            return false;
-        }
-        self.measured_sizes.insert(key.clone(), size);
-        self.sizes[index] = size;
-        for offset_index in index + 1..self.offsets.len() {
+        for offset_index in first_changed + 1..self.offsets.len() {
             self.offsets[offset_index] =
                 self.offsets[offset_index - 1] + self.sizes[offset_index - 1];
         }
@@ -301,7 +334,7 @@ where
     }
 
     fn anchored_offset(&self, key: &K, within_item: f32) -> Option<f32> {
-        let index = self.keys.iter().position(|candidate| candidate == key)?;
+        let index = *self.key_to_index.get(key)?;
         Some(self.item_start(index)? + within_item)
     }
 
@@ -453,268 +486,92 @@ pub fn virtualize<T, K>(
     let rendered_window = Rc::new(Cell::new(None::<LayoutWindow>));
     let pending_initial_scroll = Rc::new(RefCell::new(initial_scroll));
     let viewport_ready = Rc::new(Cell::new(false));
+    let layout_participating = Rc::new(Cell::new(false));
     let presented_scroll_extent = Rc::new(Cell::new(0.0));
     let configured_scroll_extent = Rc::new(Cell::new(f32::NAN));
     let inside_start_threshold = Rc::new(Cell::new(false));
     let inside_end_threshold = Rc::new(Cell::new(false));
+    let alive = Rc::new(Cell::new(true));
+    let pending_entry_measurements: Rc<RefCell<Vec<PendingEntryMeasurement<K>>>> =
+        Rc::new(RefCell::new(Vec::new()));
+    let pending_track_measurements: Rc<RefCell<Vec<PendingTrackMeasurement>>> =
+        Rc::new(RefCell::new(Vec::new()));
+    let pending_aux_measurements: Rc<RefCell<Vec<PendingAuxMeasurement>>> =
+        Rc::new(RefCell::new(Vec::new()));
+    let pending_layout_notification = Rc::new(Cell::new(false));
     if let Some(list_ref) = &list_ref {
         list_ref.bind(scroll_view);
         list_ref.update_geometry(0.0, DEFAULT_VIEWPORT_SIZE);
     }
-    let reconcile_slot: Rc<RefCell<Option<ReconcileCallback>>> = Rc::new(RefCell::new(None));
     let observe_entry: EntryLayoutObserver<K> = {
-        let layout = Rc::clone(&layout);
-        let geometry = Rc::clone(&geometry);
-        let reconcile_slot = Rc::clone(&reconcile_slot);
-        let list_ref = list_ref.clone();
-        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-        let viewport_ready = Rc::clone(&viewport_ready);
-        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        let pending_entry_measurements = Rc::clone(&pending_entry_measurements);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
         Rc::new(move |key, handle| {
             let key = key.clone();
-            let layout = Rc::clone(&layout);
-            let geometry = Rc::clone(&geometry);
-            let reconcile_slot = Rc::clone(&reconcile_slot);
-            let list_ref = list_ref.clone();
-            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-            let viewport_ready = Rc::clone(&viewport_ready);
-            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+            let pending_entry_measurements = Rc::clone(&pending_entry_measurements);
+            let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
-                    let current_geometry = *geometry.borrow();
-                    let (changed, corrected_offset) = {
-                        let mut layout = layout.borrow_mut();
-                        let anchor = layout.anchor(current_geometry.offset);
-                        let measured_size = match axis {
-                            ScrollAxis::Vertical => layout_geometry.border_box.height,
-                            ScrollAxis::Horizontal => layout_geometry.border_box.width,
-                        };
-                        let changed = layout.update_measurement(&key, measured_size.max(0.0));
-                        let initial_offset = resolve_pending_initial_target(
-                            &mut pending_initial_scroll.borrow_mut(),
-                            &layout,
-                            current_geometry,
-                            initial_geometry_ready(
-                                viewport_ready.get(),
-                                presented_scroll_extent.get(),
-                                layout.total_extent(),
-                            ),
-                        );
-                        let corrected_offset = initial_offset.or_else(|| {
-                            anchor.and_then(|(key, within_item)| {
-                                layout.anchored_offset(&key, within_item)
-                            })
-                        });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
-                        }
-                        (changed, corrected_offset)
+                    let size = match axis {
+                        ScrollAxis::Vertical => layout_geometry.border_box.height,
+                        ScrollAxis::Horizontal => layout_geometry.border_box.width,
                     };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
-                        }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
-                    }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
-                    }
+                    pending_entry_measurements
+                        .borrow_mut()
+                        .push(PendingEntryMeasurement {
+                            key: key.clone(),
+                            handle,
+                            size,
+                        });
+                    pending_layout_notification.set(true);
                 }),
             );
         })
     };
-    let observe_track: Rc<dyn Fn(Vec<K>, Element)> = {
-        let layout = Rc::clone(&layout);
-        let geometry = Rc::clone(&geometry);
-        let reconcile_slot = Rc::clone(&reconcile_slot);
-        let list_ref = list_ref.clone();
-        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-        let viewport_ready = Rc::clone(&viewport_ready);
-        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
-        let main_gap = match &virtual_layout {
-            VirtualListLayout::Linear => 0.0,
-            VirtualListLayout::Grid(grid) => grid.main_gap,
-        };
-        Rc::new(move |keys, handle| {
-            let layout = Rc::clone(&layout);
-            let geometry = Rc::clone(&geometry);
-            let reconcile_slot = Rc::clone(&reconcile_slot);
-            let list_ref = list_ref.clone();
-            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-            let viewport_ready = Rc::clone(&viewport_ready);
-            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+    let observe_track: Rc<dyn Fn(usize, Element)> = {
+        let pending_track_measurements = Rc::clone(&pending_track_measurements);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
+        Rc::new(move |track, handle| {
+            let pending_track_measurements = Rc::clone(&pending_track_measurements);
+            let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
-                    let Some(first_key) = keys.first() else {
-                        return;
+                    let size = match axis {
+                        ScrollAxis::Vertical => layout_geometry.border_box.height,
+                        ScrollAxis::Horizontal => layout_geometry.border_box.width,
                     };
-                    let current_geometry = *geometry.borrow();
-                    let (changed, corrected_offset) = {
-                        let mut layout = layout.borrow_mut();
-                        let anchor = layout.anchor(current_geometry.offset);
-                        let measured_size = match axis {
-                            ScrollAxis::Vertical => layout_geometry.border_box.height,
-                            ScrollAxis::Horizontal => layout_geometry.border_box.width,
-                        };
-                        let track_has_successor = layout
-                            .keys
-                            .iter()
-                            .position(|candidate| candidate == first_key)
-                            .is_some_and(|item| {
-                                layout.track_for_item(item) + 1 < layout.track_count()
-                            });
-                        let extent = measured_size.max(0.0)
-                            + if track_has_successor { main_gap } else { 0.0 };
-                        let changed = layout.update_measurement(first_key, extent);
-                        let initial_offset = resolve_pending_initial_target(
-                            &mut pending_initial_scroll.borrow_mut(),
-                            &layout,
-                            current_geometry,
-                            initial_geometry_ready(
-                                viewport_ready.get(),
-                                presented_scroll_extent.get(),
-                                layout.total_extent(),
-                            ),
-                        );
-                        let corrected_offset = initial_offset.or_else(|| {
-                            anchor.and_then(|(key, within_item)| {
-                                layout.anchored_offset(&key, within_item)
-                            })
+                    pending_track_measurements
+                        .borrow_mut()
+                        .push(PendingTrackMeasurement {
+                            track,
+                            handle,
+                            size,
                         });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
-                        }
-                        (changed, corrected_offset)
-                    };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
-                        }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
-                    }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
-                    }
+                    pending_layout_notification.set(true);
                 }),
             );
         })
     };
 
     let observe_aux: Rc<dyn Fn(AuxContent, Element)> = {
-        let layout = Rc::clone(&layout);
-        let geometry = Rc::clone(&geometry);
-        let reconcile_slot = Rc::clone(&reconcile_slot);
-        let list_ref = list_ref.clone();
-        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-        let viewport_ready = Rc::clone(&viewport_ready);
-        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        let pending_aux_measurements = Rc::clone(&pending_aux_measurements);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
         Rc::new(move |content, handle| {
-            let layout = Rc::clone(&layout);
-            let geometry = Rc::clone(&geometry);
-            let reconcile_slot = Rc::clone(&reconcile_slot);
-            let list_ref = list_ref.clone();
-            let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-            let viewport_ready = Rc::clone(&viewport_ready);
-            let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+            let pending_aux_measurements = Rc::clone(&pending_aux_measurements);
+            let pending_layout_notification = Rc::clone(&pending_layout_notification);
             observe_layout(
                 handle,
                 Box::new(move |layout_geometry| {
-                    let current_geometry = *geometry.borrow();
-                    let measured_size = match axis {
+                    let size = match axis {
                         ScrollAxis::Vertical => layout_geometry.border_box.height,
                         ScrollAxis::Horizontal => layout_geometry.border_box.width,
                     };
-                    let (changed, corrected_offset) = {
-                        let mut layout = layout.borrow_mut();
-                        let preserve_item_anchor = !matches!(content, AuxContent::Header)
-                            || current_geometry.offset >= layout.header_extent;
-                        let anchor = preserve_item_anchor
-                            .then(|| layout.anchor(current_geometry.offset))
-                            .flatten();
-                        let changed =
-                            layout.update_aux_measurement(content, measured_size.max(0.0));
-                        let initial_offset = resolve_pending_initial_target(
-                            &mut pending_initial_scroll.borrow_mut(),
-                            &layout,
-                            current_geometry,
-                            initial_geometry_ready(
-                                viewport_ready.get(),
-                                presented_scroll_extent.get(),
-                                layout.total_extent(),
-                            ),
-                        );
-                        let corrected_offset = initial_offset.or_else(|| {
-                            anchor.and_then(|(key, within_item)| {
-                                layout.anchored_offset(&key, within_item)
-                            })
-                        });
-                        if changed && let Some(list_ref) = &list_ref {
-                            let (starts, ends) = layout.item_offsets();
-                            list_ref.update_layout(
-                                &layout.keys,
-                                &starts,
-                                &ends,
-                                layout.total_extent(),
-                            );
-                        }
-                        (changed, corrected_offset)
-                    };
-                    if changed
-                        && let Some(offset) = corrected_offset
-                        && (offset - current_geometry.offset).abs() >= 0.5
-                    {
-                        geometry.borrow_mut().offset = offset;
-                        if let Some(list_ref) = &list_ref {
-                            list_ref.update_geometry(offset, current_geometry.viewport);
-                        }
-                        let _ = try_invoke_element_command(
-                            scroll_view,
-                            "scrollTo",
-                            WhiskerValue::map([
-                                ("offset", WhiskerValue::Float(f64::from(offset))),
-                                ("smooth", WhiskerValue::Bool(false)),
-                            ]),
-                        );
-                    }
-                    if changed && let Some(reconcile) = reconcile_slot.borrow().as_ref().cloned() {
-                        reconcile();
-                    }
+                    pending_aux_measurements
+                        .borrow_mut()
+                        .push(PendingAuxMeasurement { content, size });
+                    pending_layout_notification.set(true);
                 }),
             );
         })
@@ -907,16 +764,9 @@ pub fn virtualize<T, K>(
             rendered_window.set(Some(window));
         })
     };
-    *reconcile_slot.borrow_mut() = Some(Rc::clone(&reconcile));
-
     {
-        let geometry = Rc::clone(&geometry);
-        let layout = Rc::clone(&layout);
-        let reconcile = Rc::clone(&reconcile);
-        let list_ref = list_ref.clone();
-        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-        let viewport_ready = Rc::clone(&viewport_ready);
         let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
         observe_layout(
             scroll_extent,
             Box::new(move |layout_geometry| {
@@ -928,17 +778,172 @@ pub fn virtualize<T, K>(
                     return;
                 }
                 presented_scroll_extent.set(extent);
+                pending_layout_notification.set(true);
+            }),
+        );
+    }
+
+    {
+        let geometry = Rc::clone(&geometry);
+        let list_ref = list_ref.clone();
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let layout_participating = Rc::clone(&layout_participating);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
+        observe_layout(
+            scroll_view,
+            Box::new(move |layout_geometry| {
+                let viewport = match axis {
+                    ScrollAxis::Vertical => layout_geometry.border_box.height,
+                    ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                };
+                if !viewport.is_finite() || viewport < 0.0 {
+                    return;
+                }
+                layout_participating.set(viewport > 0.0);
+                pending_layout_notification.set(true);
+                if viewport <= 0.0 {
+                    return;
+                }
+                viewport_ready.set(true);
                 let current_geometry = *geometry.borrow();
-                let initial_offset = {
-                    let layout = layout.borrow();
-                    resolve_pending_initial_target(
+                *geometry.borrow_mut() = ScrollGeometry {
+                    offset: current_geometry.offset,
+                    viewport,
+                };
+                if let Some(list_ref) = &list_ref {
+                    list_ref.update_geometry(current_geometry.offset, viewport);
+                }
+            }),
+        );
+    }
+
+    // A layout pass may resize dozens of mounted rows. Collect their
+    // callbacks first, then update the index, anchor, ListRef snapshot, and
+    // mounted window once. This mirrors FlashList's commit-level layout
+    // collection and avoids N suffix rebuilds plus N reconciliations.
+    {
+        let geometry = Rc::clone(&geometry);
+        let layout = Rc::clone(&layout);
+        let mounted = Rc::clone(&mounted);
+        let mounted_tracks = Rc::clone(&mounted_tracks);
+        let pending_entry_measurements = Rc::clone(&pending_entry_measurements);
+        let pending_track_measurements = Rc::clone(&pending_track_measurements);
+        let pending_aux_measurements = Rc::clone(&pending_aux_measurements);
+        let pending_layout_notification = Rc::clone(&pending_layout_notification);
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
+        let viewport_ready = Rc::clone(&viewport_ready);
+        let layout_participating = Rc::clone(&layout_participating);
+        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
+        let alive = Rc::clone(&alive);
+        let reconcile = Rc::clone(&reconcile);
+        let list_ref = list_ref.clone();
+        observe_layout_batch_end(
+            scroll_view,
+            Box::new(move || {
+                if !alive.get() {
+                    return;
+                }
+                if !pending_layout_notification.replace(false) {
+                    return;
+                }
+
+                // `display:none` legitimately collapses the List subtree to
+                // zero. Those geometries describe an absent ancestor, not
+                // new row measurements; retain the last active index and
+                // scroll anchor until the List participates in layout again.
+                if !layout_participating.get() {
+                    pending_entry_measurements.borrow_mut().clear();
+                    pending_track_measurements.borrow_mut().clear();
+                    pending_aux_measurements.borrow_mut().clear();
+                    return;
+                }
+
+                let current_geometry = *geometry.borrow();
+                let entry_measurements = pending_entry_measurements
+                    .borrow_mut()
+                    .drain(..)
+                    .filter_map(|pending| {
+                        mounted
+                            .borrow()
+                            .get(&pending.key)
+                            .is_some_and(|entry| entry.handle == pending.handle)
+                            .then_some((pending.key, pending.size.max(0.0)))
+                    })
+                    .collect::<Vec<_>>();
+
+                let track_measurements = pending_track_measurements
+                    .borrow_mut()
+                    .drain(..)
+                    .filter_map(|pending| {
+                        let tracks = mounted_tracks.borrow();
+                        let track = tracks.get(&pending.track)?;
+                        (track.handle == pending.handle)
+                            .then(|| track.keys.first().cloned())
+                            .flatten()
+                            .map(|key| (pending.track, key, pending.size.max(0.0)))
+                    })
+                    .collect::<Vec<_>>();
+                let aux_measurements = pending_aux_measurements
+                    .borrow_mut()
+                    .drain(..)
+                    .collect::<Vec<_>>();
+
+                let (changed, corrected_offset) = {
+                    let mut layout = layout.borrow_mut();
+                    let preserve_item_anchor = !aux_measurements
+                        .iter()
+                        .any(|pending| matches!(pending.content, AuxContent::Header))
+                        || current_geometry.offset >= layout.header_extent;
+                    let anchor = preserve_item_anchor
+                        .then(|| layout.anchor(current_geometry.offset))
+                        .flatten();
+
+                    let mut changed = false;
+                    for pending in aux_measurements {
+                        changed |=
+                            layout.update_aux_measurement(pending.content, pending.size.max(0.0));
+                    }
+                    let mut measurements = entry_measurements;
+                    measurements.extend(track_measurements.into_iter().map(
+                        |(track, key, size)| {
+                            let extent = size
+                                + if track + 1 < layout.track_count() {
+                                    main_gap
+                                } else {
+                                    0.0
+                                };
+                            (key, extent)
+                        },
+                    ));
+                    changed |= layout.update_measurements(measurements);
+
+                    let initial_offset = resolve_pending_initial_target(
                         &mut pending_initial_scroll.borrow_mut(),
                         &layout,
                         current_geometry,
-                        initial_geometry_ready(viewport_ready.get(), extent, layout.total_extent()),
-                    )
+                        initial_geometry_ready(
+                            viewport_ready.get(),
+                            presented_scroll_extent.get(),
+                            layout.total_extent(),
+                        ),
+                    );
+                    let corrected_offset = initial_offset.or_else(|| {
+                        if changed {
+                            anchor.and_then(|(key, within_item)| {
+                                layout.anchored_offset(&key, within_item)
+                            })
+                        } else {
+                            None
+                        }
+                    });
+                    if changed && let Some(list_ref) = &list_ref {
+                        let (starts, ends) = layout.item_offsets();
+                        list_ref.update_layout(&layout.keys, &starts, &ends, layout.total_extent());
+                    }
+                    (changed, corrected_offset)
                 };
-                if let Some(offset) = initial_offset
+
+                if let Some(offset) = corrected_offset
                     && (offset - current_geometry.offset).abs() >= 0.5
                 {
                     geometry.borrow_mut().offset = offset;
@@ -954,67 +959,9 @@ pub fn virtualize<T, K>(
                         ]),
                     );
                 }
-                reconcile();
-            }),
-        );
-    }
-
-    {
-        let geometry = Rc::clone(&geometry);
-        let layout = Rc::clone(&layout);
-        let reconcile = Rc::clone(&reconcile);
-        let list_ref = list_ref.clone();
-        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
-        let viewport_ready = Rc::clone(&viewport_ready);
-        let presented_scroll_extent = Rc::clone(&presented_scroll_extent);
-        observe_layout(
-            scroll_view,
-            Box::new(move |layout_geometry| {
-                let viewport = match axis {
-                    ScrollAxis::Vertical => layout_geometry.border_box.height,
-                    ScrollAxis::Horizontal => layout_geometry.border_box.width,
-                };
-                if !viewport.is_finite() || viewport <= 0.0 {
-                    return;
+                if changed || viewport_ready.get() {
+                    reconcile();
                 }
-                viewport_ready.set(true);
-                let current_geometry = *geometry.borrow();
-                let next_geometry = ScrollGeometry {
-                    offset: current_geometry.offset,
-                    viewport,
-                };
-                let initial_offset = {
-                    let layout = layout.borrow();
-                    resolve_pending_initial_target(
-                        &mut pending_initial_scroll.borrow_mut(),
-                        &layout,
-                        next_geometry,
-                        initial_geometry_ready(
-                            true,
-                            presented_scroll_extent.get(),
-                            layout.total_extent(),
-                        ),
-                    )
-                };
-                let next_offset = initial_offset.unwrap_or(current_geometry.offset);
-                *geometry.borrow_mut() = ScrollGeometry {
-                    offset: next_offset,
-                    viewport,
-                };
-                if let Some(list_ref) = &list_ref {
-                    list_ref.update_geometry(next_offset, viewport);
-                }
-                if (next_offset - current_geometry.offset).abs() >= 0.5 {
-                    let _ = try_invoke_element_command(
-                        scroll_view,
-                        "scrollTo",
-                        WhiskerValue::map([
-                            ("offset", WhiskerValue::Float(f64::from(next_offset))),
-                            ("smooth", WhiskerValue::Bool(false)),
-                        ]),
-                    );
-                }
-                reconcile();
             }),
         );
     }
@@ -1118,7 +1065,7 @@ pub fn virtualize<T, K>(
     }
 
     on_cleanup(move || {
-        reconcile_slot.borrow_mut().take();
+        alive.set(false);
         for (_, track) in mounted_tracks.borrow_mut().drain() {
             for key in &track.keys {
                 if let Some(entry) = mounted.borrow().get(key)
@@ -1203,9 +1150,7 @@ fn initial_target_is_measured<T, K: Eq + Hash + Clone>(
         ListScrollTarget::Start | ListScrollTarget::Offset(_) => return true,
         ListScrollTarget::End => layout.items.len().checked_sub(1),
         ListScrollTarget::Index { index, .. } => Some(*index),
-        ListScrollTarget::Key { key, .. } => {
-            layout.keys.iter().position(|candidate| candidate == key)
-        }
+        ListScrollTarget::Key { key, .. } => layout.key_to_index.get(key).copied(),
     };
     let Some(target_index) = target_index.filter(|index| *index < layout.items.len()) else {
         return false;
@@ -1245,7 +1190,7 @@ fn resolve_layout_target<T, K: Eq + Hash + Clone>(
         ListScrollTarget::Offset(offset) => *offset as f32,
         ListScrollTarget::Index { index, alignment } => item_offset(*index, *alignment)?,
         ListScrollTarget::Key { key, alignment } => {
-            let index = layout.keys.iter().position(|candidate| candidate == key)?;
+            let index = *layout.key_to_index.get(key)?;
             item_offset(index, *alignment)?
         }
     };
@@ -1321,7 +1266,7 @@ fn reconcile_grid_window<T, K>(
     mounted: &mut HashMap<K, MountedEntry<T>>,
     mounted_tracks: &mut HashMap<usize, MountedTrack<K>>,
     children: &dyn Fn(ReadSignal<T>) -> Element,
-    observe_track: &dyn Fn(Vec<K>, Element),
+    observe_track: &dyn Fn(usize, Element),
     grid: &VirtualGridLayout,
     axis: ScrollAxis,
     list_owner: Owner,
@@ -1428,7 +1373,7 @@ fn reconcile_grid_window<T, K>(
                     keys: keys.clone(),
                 },
             );
-            observe_track(keys.clone(), handle);
+            observe_track(track_index, handle);
             handle
         };
         set_specified_style(
@@ -1711,5 +1656,34 @@ mod tests {
             "bottom overscan {bottom_buffer}px must cover one {viewport}px viewport",
             viewport = geometry.viewport,
         );
+    }
+
+    #[test]
+    fn key_index_is_rebuilt_after_source_reordering() {
+        let mut index = LayoutIndex::new(1, 0.0);
+        index.replace(vec!["alpha", "beta", "gamma"], |item| *item);
+
+        assert_eq!(index.key_to_index.get("alpha"), Some(&0));
+        assert_eq!(index.key_to_index.get("gamma"), Some(&2));
+
+        index.replace(vec!["gamma", "alpha"], |item| *item);
+
+        assert_eq!(index.key_to_index.get("gamma"), Some(&0));
+        assert_eq!(index.key_to_index.get("alpha"), Some(&1));
+        assert!(!index.key_to_index.contains_key("beta"));
+    }
+
+    #[test]
+    fn measurement_batch_rebuilds_the_suffix_and_generation_once() {
+        let mut index = LayoutIndex::new(1, 0.0);
+        index.replace((0_u32..5).collect(), |item| *item);
+        let generation = index.generation;
+
+        assert!(index.update_measurements([(1, 20.0), (3, 80.0)]));
+
+        assert_eq!(index.generation, generation + 1);
+        assert_eq!(index.offsets, vec![0.0, 44.0, 64.0, 108.0, 188.0, 232.0]);
+        assert_eq!(index.measured_sizes.get(&1), Some(&20.0));
+        assert_eq!(index.measured_sizes.get(&3), Some(&80.0));
     }
 }

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -354,7 +354,8 @@ fn horizontal_list_mounted_by_show_lays_out_initial_items() {
                                 };
                                 whisker::runtime::view::observe_layout(
                                     page,
-                                    Box::new(move |geometry| {
+                                    Box::new(move |observation| {
+                                        let geometry = observation.geometry;
                                         observed.set(Some((
                                             geometry.border_box.width,
                                             geometry.border_box.height,

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -935,9 +935,9 @@ fn typed_list_handle_resolves_keys_from_the_rust_snapshot() {
             LayoutOptions::default(),
         )
         .unwrap();
-    // Key lookup is resolved entirely from the Rust-side layout index. Rows
-    // outside the mounted window retain the private initial extent until they
-    // have been observed, so key 10 starts at 10 × 44px.
+    // Key lookup is resolved entirely from the Rust-side layout index. The
+    // mounted rows teach the index a 44px estimate for rows outside the
+    // window, so key 10 starts at 10 × 44px.
     let expected_key_offset = 440.0;
 
     with_installed_renderer(surface.renderer(), || {
@@ -1290,6 +1290,62 @@ fn list_learns_variable_item_sizes_from_rust_layout() {
         )
         .unwrap();
     assert_eq!(list_handle.snapshot().unwrap().content_extent, 300.0);
+
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn list_applies_visible_measurements_to_unmounted_item_estimates() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(59).unwrap(),
+        StyleEnvironment::new(320.0, 100.0, 1.0, 14.0),
+    );
+    let list_handle = owner.with(ListHandle::<u32>::new);
+    let render_list_handle = list_handle.clone();
+    let item_builds = Rc::new(Cell::new(0_u32));
+
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with({
+            let item_builds = Rc::clone(&item_builds);
+            move || {
+                render! {
+                    List(
+                        list_ref: render_list_handle.r(),
+                        style: css!(width: percent(100), height: px(100)),
+                        each: || (0_u32..100).collect::<Vec<_>>(),
+                        key: |row: &u32| *row,
+                        children: move |_row: ReadSignal<u32>| {
+                            item_builds.set(item_builds.get() + 1);
+                            render! { View(style: css!(height: px(100), flex_shrink: 0.0)) }
+                        },
+                    )
+                }
+            }
+        });
+        set_root(root);
+    });
+
+    assert_eq!(list_handle.snapshot().unwrap().content_extent, 4_400.0);
+    let mut host = TextHost::default();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    surface
+        .render_frame(
+            LayoutSize::new(320.0, 100.0),
+            1,
+            1,
+            &mut host,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+
+    assert_eq!(list_handle.snapshot().unwrap().content_extent, 10_000.0);
+    assert!(
+        item_builds.get() < 100,
+        "the learned full extent must come from the mounted sample, not from mounting every row"
+    );
 
     with_installed_renderer(surface.renderer(), || owner.dispose());
 }


### PR DESCRIPTION
## Summary

- batch mounted row, grid track, and auxiliary layout measurements once per completed Taffy pass
- reject stale recycled-cell measurements and rebuild List offsets once from the earliest changed item
- add indexed key lookup for anchor restoration and key-based List operations
- represent layout participation explicitly in the Rust layout snapshot
- preserve List measurement and scroll-anchor state only when the List or an ancestor is `display:none`
- treat a participating zero-sized viewport as valid layout instead of inferring that it is hidden
- automatically learn the mean measured track size and use it for unmounted rows/tracks
- keep exact per-key measurements authoritative and keep Grid gaps outside the learned content size
- exclude zero-sized tracks from the fallback estimate so one collapsed row cannot collapse the unmeasured list

The List remains a Rust control primitive over the ordinary built-in ScrollView/View path. This adds no List-specific FramePacket operation, Host ABI, native Host view, or required size-estimate API. `LayoutParticipation` is Runtime-internal and does not alter the Host protocol.

## Verification

- `cargo test -p whisker-layout -p whisker-runtime`
- `cargo test -p whisker --test surface_render_pipeline`
- `cargo clippy -p whisker-layout -p whisker-runtime -p whisker --all-targets -- -D warnings`
- `git diff --check`