### PR TITLE
fix(runtime): recognize long presses and preserve List margins

### DIFF
--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -73,7 +73,7 @@ where
 /// A deterministic immutable result of one layout pass.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LayoutSnapshot {
-    boxes: BTreeMap<NodeId, LayoutGeometry>,
+    boxes: BTreeMap<NodeId, (LayoutGeometry, LayoutSize)>,
     suppressed_by_display_none: BTreeSet<NodeId>,
 }
 
@@ -94,12 +94,14 @@ pub enum LayoutParticipation {
 impl LayoutSnapshot {
     /// Returns the border box for a node relative to its parent content origin.
     pub fn get(&self, node: NodeId) -> Option<&LayoutGeometry> {
-        self.boxes.get(&node)
+        self.boxes.get(&node).map(|(geometry, _)| geometry)
     }
 
     /// Iterates in stable node-ID order.
     pub fn iter(&self) -> impl Iterator<Item = (NodeId, &LayoutGeometry)> {
-        self.boxes.iter().map(|(node, rect)| (*node, rect))
+        self.boxes
+            .iter()
+            .map(|(node, (geometry, _))| (*node, geometry))
     }
 
     /// Returns why a retained node does or does not participate in layout.
@@ -113,7 +115,7 @@ impl LayoutSnapshot {
         &self,
         node: NodeId,
     ) -> Option<(&LayoutGeometry, LayoutParticipation)> {
-        self.boxes.get(&node).map(|geometry| {
+        self.boxes.get(&node).map(|(geometry, _)| {
             let participation = if self.suppressed_by_display_none.contains(&node) {
                 LayoutParticipation::SuppressedByDisplayNone
             } else {
@@ -121,6 +123,12 @@ impl LayoutSnapshot {
             };
             (geometry, participation)
         })
+    }
+
+    /// Returns the occupied size, including resolved margins. Kept separate
+    /// from Host paint geometry for consumers such as virtualized lists.
+    pub fn margin_box_size(&self, node: NodeId) -> Option<LayoutSize> {
+        self.boxes.get(&node).map(|(_, size)| *size)
     }
 
     /// Returns the number of laid-out nodes.
@@ -660,20 +668,26 @@ impl LayoutTree {
             .expect("retained backend node");
         snapshot.boxes.insert(
             node,
-            LayoutGeometry {
-                border_box: LayoutRect {
-                    x: layout.location.x,
-                    y: layout.location.y,
-                    width: layout.size.width,
-                    height: layout.size.height,
+            (
+                LayoutGeometry {
+                    border_box: LayoutRect {
+                        x: layout.location.x,
+                        y: layout.location.y,
+                        width: layout.size.width,
+                        height: layout.size.height,
+                    },
+                    content_box: LayoutRect {
+                        x: layout.border.left + layout.padding.left,
+                        y: layout.border.top + layout.padding.top,
+                        width: layout.content_box_width().max(0.0),
+                        height: layout.content_box_height().max(0.0),
+                    },
                 },
-                content_box: LayoutRect {
-                    x: layout.border.left + layout.padding.left,
-                    y: layout.border.top + layout.padding.top,
-                    width: layout.content_box_width().max(0.0),
-                    height: layout.content_box_height().max(0.0),
-                },
-            },
+                LayoutSize::new(
+                    (layout.size.width + layout.margin.left + layout.margin.right).max(0.0),
+                    (layout.size.height + layout.margin.top + layout.margin.bottom).max(0.0),
+                ),
+            ),
         );
         if suppressed {
             snapshot.suppressed_by_display_none.insert(node);

--- a/crates/whisker-layout/src/lib.rs
+++ b/crates/whisker-layout/src/lib.rs
@@ -1664,6 +1664,49 @@ mod tests {
     }
 
     #[test]
+    fn margin_box_size_tracks_resolved_margins_without_changing_paint_geometry() {
+        let root = id(1);
+        let child = id(2);
+        let mut tree = LayoutTree::new();
+        tree.create_node(root, sized(200.0, 200.0)).unwrap();
+        let mut child_style = sized(40.0, 30.0);
+        child_style.margin = Edges {
+            top: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(3.0, 0.0)),
+            right: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(7.0, 0.0)),
+            bottom: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(0.0, 0.2)),
+            left: ComputedLengthPercentageAuto::Value(ComputedLengthPercentage::new(0.0, 0.1)),
+        };
+        tree.create_node(child, child_style).unwrap();
+        tree.set_children(root, &[child]).unwrap();
+
+        for (width, left, occupied) in [
+            (200.0, 20.0, LayoutSize::new(67.0, 73.0)),
+            (300.0, 30.0, LayoutSize::new(77.0, 93.0)),
+        ] {
+            tree.update_style(root, sized(width, 200.0)).unwrap();
+            let snapshot = tree
+                .compute(root, LayoutSize::new(width, 200.0), &mut zero_measure)
+                .unwrap();
+
+            assert_eq!(snapshot.margin_box_size(child), Some(occupied));
+            assert_eq!(
+                snapshot.margin_box_size(root),
+                Some(LayoutSize::new(width, 200.0))
+            );
+            assert_eq!(snapshot.margin_box_size(id(99)), None);
+            assert_eq!(
+                snapshot.get(child).unwrap().border_box,
+                LayoutRect {
+                    x: left,
+                    y: 3.0,
+                    width: 40.0,
+                    height: 30.0
+                },
+            );
+        }
+    }
+
+    #[test]
     fn retained_tree_measures_orders_and_snapshots_fractional_layout() {
         let root = id(1);
         let first = id(2);

--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -20,7 +20,7 @@ use crate::{
 use whisker_engine::whisker_layout::LayoutSize;
 use whisker_engine::whisker_protocol::{
     ApplyResult, HostPresentationUpdate, InputEvent, InputEventKind, InputPoint, MeasurementReady,
-    NodeId, PointerId, PointerKind, ResourceEvent, WhiskerValue,
+    NodeId, PointerId, PointerInput, PointerKind, ResourceEvent, WhiskerValue,
 };
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{DeferredMeasurementApply, FrameSink, LayoutOptions, MeasurementProvider};
@@ -565,6 +565,9 @@ struct ActivationCandidate {
     origin: InputPoint,
     started_at_ms: f64,
     pointer_kind: PointerKind,
+    pointer: PointerInput,
+    longpress_pending: bool,
+    longpress_fired: bool,
     cancelled: bool,
 }
 
@@ -610,10 +613,17 @@ impl ActivationRecognizer {
         &mut self,
         event: &InputEvent,
         hit_target: Option<NodeId>,
+        accepts_longpress: bool,
     ) -> Option<RecognizedActivation> {
         let pointer = event.pointer?;
         match event.kind {
             InputEventKind::PointerDown => {
+                let multiple_contacts = !self.pointers.is_empty();
+                if multiple_contacts {
+                    for candidate in self.pointers.values_mut() {
+                        candidate.cancelled = true;
+                    }
+                }
                 if let Some(target) = hit_target {
                     self.pointers.insert(
                         pointer.id,
@@ -622,7 +632,11 @@ impl ActivationRecognizer {
                             origin: pointer.position,
                             started_at_ms: event.timestamp_ms,
                             pointer_kind: pointer.kind,
-                            cancelled: false,
+                            pointer,
+                            longpress_pending: accepts_longpress
+                                && matches!(pointer.kind, PointerKind::Touch | PointerKind::Pen),
+                            longpress_fired: false,
+                            cancelled: multiple_contacts,
                         },
                     );
                 }
@@ -630,6 +644,7 @@ impl ActivationRecognizer {
             }
             InputEventKind::PointerMove => {
                 let candidate = self.pointers.get_mut(&pointer.id)?;
+                candidate.pointer = pointer;
                 let dx = pointer.position.x - candidate.origin.x;
                 let dy = pointer.position.y - candidate.origin.y;
                 if dx * dx + dy * dy > TAP_SLOP * TAP_SLOP {
@@ -647,6 +662,7 @@ impl ActivationRecognizer {
                 let dx = pointer.position.x - candidate.origin.x;
                 let dy = pointer.position.y - candidate.origin.y;
                 if candidate.cancelled
+                    || candidate.longpress_fired
                     || dx * dx + dy * dy > TAP_SLOP * TAP_SLOP
                     || !(0.0..=TAP_TIMEOUT_MS).contains(&elapsed)
                     || hit_target != Some(candidate.target)
@@ -669,6 +685,40 @@ impl ActivationRecognizer {
         }
     }
 
+    fn has_pending_longpress(&self) -> bool {
+        self.pointers.values().any(|candidate| {
+            candidate.longpress_pending && !candidate.cancelled && !candidate.longpress_fired
+        })
+    }
+
+    fn take_longpresses(
+        &mut self,
+        timestamp_ms: f64,
+        surface: whisker_engine::whisker_protocol::SurfaceId,
+    ) -> Vec<InputEvent> {
+        self.pointers
+            .values_mut()
+            .filter_map(|candidate| {
+                if !candidate.longpress_pending
+                    || candidate.cancelled
+                    || candidate.longpress_fired
+                    || timestamp_ms - candidate.started_at_ms < LONGPRESS_TIMEOUT_MS
+                {
+                    return None;
+                }
+                candidate.longpress_fired = true;
+                Some(InputEvent {
+                    surface,
+                    timestamp_ms,
+                    kind: InputEventKind::Named("longpress".into()),
+                    pointer: Some(candidate.pointer),
+                    target: Some(candidate.target),
+                    detail: WhiskerValue::Null,
+                })
+            })
+            .collect()
+    }
+
     fn clear(&mut self) {
         self.pointers.clear();
     }
@@ -676,6 +726,7 @@ impl ActivationRecognizer {
 
 const TAP_SLOP: f32 = 10.0;
 const TAP_TIMEOUT_MS: f64 = 500.0;
+const LONGPRESS_TIMEOUT_MS: f64 = 500.0;
 
 impl RuntimeInstance {
     /// Creates an unmounted runtime connected to one Host wake-up endpoint.
@@ -808,6 +859,7 @@ impl RuntimeInstance {
     ) -> Result<Element, RuntimeEventError> {
         self.require(RuntimeLifecycle::Running, "remount the application root")
             .map_err(RuntimeEventError::Lifecycle)?;
+        self.activations.borrow_mut().clear();
         let previous = self
             .owner
             .take()
@@ -1080,6 +1132,17 @@ impl RuntimeInstance {
                 crate::drain_runtime_dispatches();
                 self.drain_pending_host_events()
                     .map_err(RuntimeDriveError::HostEvent)?;
+                // Use the Host frame clock so idle, stationary pointers also
+                // reach the threshold without platform-specific recognizers.
+                let longpresses = self
+                    .activations
+                    .borrow_mut()
+                    .take_longpresses(timestamp_ms, surface.surface());
+                for event in longpresses {
+                    self.dispatch_input_active(&event, &[]).map_err(|error| {
+                        RuntimeDriveError::HostEvent(RuntimeEventError::Input(error))
+                    })?;
+                }
                 surface.begin_mutation_batch();
                 crate::anim_hook::step(timestamp_ms);
                 reactive::flush();
@@ -1113,6 +1176,7 @@ impl RuntimeInstance {
                 Ok(RuntimeDrive {
                     frame,
                     needs_frame: recovery
+                        || self.activations.borrow().has_pending_longpress()
                         || drained_events > 0
                         || reactive::has_pending_work()
                         || surface.has_active_motion()
@@ -1148,10 +1212,17 @@ impl RuntimeInstance {
             let mut dispatch = self
                 .surface
                 .dispatch_input_with_presentation(routed_event, presentation)?;
-            let activation = self
-                .activations
-                .borrow_mut()
-                .observe(event, dispatch.target);
+            let accepts_longpress = matches!(event.kind, InputEventKind::PointerDown)
+                && dispatch
+                    .target
+                    .is_some_and(|target| self.surface.has_input_listener(target, "longpress"));
+            let activation =
+                self.activations
+                    .borrow_mut()
+                    .observe(event, dispatch.target, accepts_longpress);
+            if self.activations.borrow().has_pending_longpress() {
+                self.wake.wake();
+            }
             if let Some(activation) = activation {
                 let synthesized = self.surface.dispatch_input(&activation.tap)?;
                 merge_input_dispatch(&mut dispatch, synthesized);

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -480,6 +480,15 @@ impl SurfaceRuntime {
         state.update_environment(environment)
     }
 
+    pub(crate) fn has_input_listener(&self, target: NodeId, event: &str) -> bool {
+        let state = self.state.borrow();
+        state.root.is_some_and(|root| {
+            state
+                .plan_event(root, target, event)
+                .is_ok_and(|firings| !firings.is_empty())
+        })
+    }
+
     /// Hit-tests and routes one Host-normalized event through Rust listeners.
     pub fn dispatch_input(&self, event: &InputEvent) -> Result<InputDispatch, RuntimeInputError> {
         self.dispatch_input_with_presentation(event, &[])
@@ -701,6 +710,9 @@ impl SurfaceRuntime {
                 } = &mut *state;
                 if let Some(last_layout) = surface.last_layout() {
                     for entry in elements.values_mut() {
+                        let Some(observers) = entry.layout_observers.as_mut() else {
+                            continue;
+                        };
                         let Some((geometry, participation)) = entry.node.and_then(|node| {
                             last_layout
                                 .get_with_participation(node)
@@ -710,10 +722,11 @@ impl SurfaceRuntime {
                         };
                         let observation = LayoutObservation {
                             geometry,
+                            margin_box_size: entry
+                                .node
+                                .and_then(|node| last_layout.margin_box_size(node))
+                                .expect("observed layout node"),
                             participation,
-                        };
-                        let Some(observers) = entry.layout_observers.as_mut() else {
-                            continue;
                         };
                         if observers.last_notified == Some(observation) {
                             continue;

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -40,6 +40,8 @@ use whisker_style::SpecifiedStyle;
 pub struct LayoutObservation {
     /// Resolved box geometry for the retained node.
     pub geometry: LayoutGeometry,
+    /// Occupied size including resolved margins, for virtual layout accounting.
+    pub margin_box_size: whisker_engine::whisker_layout::LayoutSize,
     /// Whether the node belongs to the active layout tree.
     pub participation: LayoutParticipation,
 }

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -590,10 +590,10 @@ pub fn virtualize<T, K>(
             observe_layout(
                 handle,
                 Box::new(move |observation| {
-                    let layout_geometry = observation.geometry;
+                    let occupied_size = observation.margin_box_size;
                     let size = match axis {
-                        ScrollAxis::Vertical => layout_geometry.border_box.height,
-                        ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                        ScrollAxis::Vertical => occupied_size.height,
+                        ScrollAxis::Horizontal => occupied_size.width,
                     };
                     pending_entry_measurements
                         .borrow_mut()
@@ -616,10 +616,12 @@ pub fn virtualize<T, K>(
             observe_layout(
                 handle,
                 Box::new(move |observation| {
-                    let layout_geometry = observation.geometry;
+                    // Synthetic grid tracks use an outer margin for the gap;
+                    // ListLayoutIndex already adds that gap separately.
+                    let track_box = observation.geometry.border_box;
                     let size = match axis {
-                        ScrollAxis::Vertical => layout_geometry.border_box.height,
-                        ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                        ScrollAxis::Vertical => track_box.height,
+                        ScrollAxis::Horizontal => track_box.width,
                     };
                     pending_track_measurements
                         .borrow_mut()
@@ -643,10 +645,10 @@ pub fn virtualize<T, K>(
             observe_layout(
                 handle,
                 Box::new(move |observation| {
-                    let layout_geometry = observation.geometry;
+                    let occupied_size = observation.margin_box_size;
                     let size = match axis {
-                        ScrollAxis::Vertical => layout_geometry.border_box.height,
-                        ScrollAxis::Horizontal => layout_geometry.border_box.width,
+                        ScrollAxis::Vertical => occupied_size.height,
+                        ScrollAxis::Horizontal => occupied_size.width,
                     };
                     pending_aux_measurements
                         .borrow_mut()

--- a/crates/whisker/tests/list_giga_diagnostics.rs
+++ b/crates/whisker/tests/list_giga_diagnostics.rs
@@ -1,0 +1,404 @@
+//! Headless regression tests for GIGA's List and reader symptoms.
+//! These exercise the public List -> Rust layout -> FramePacket boundary;
+//! they do not emulate native drawing or scroll physics.
+
+use std::{cell::RefCell, collections::HashMap, convert::Infallible, rc::Rc};
+use whisker::SurfaceRuntime;
+use whisker::prelude::*;
+use whisker::runtime::reactive::{__reset_for_tests, Owner};
+use whisker::runtime::view::{observe_layout, set_root, with_installed_renderer};
+use whisker_engine::whisker_layout::LayoutSize;
+use whisker_engine::whisker_protocol::{
+    InputEvent, InputEventKind, MeasurementRequest, MeasurementResponse, Operation, SurfaceId,
+    WhiskerValue,
+};
+use whisker_engine::whisker_style::StyleEnvironment;
+use whisker_engine::{LayoutOptions, MeasurementProvider, RecordingRenderer};
+
+struct NoText;
+impl MeasurementProvider for NoText {
+    type Error = Infallible;
+    fn measure_batch(
+        &mut self,
+        _: SurfaceId,
+        requests: &[MeasurementRequest],
+        _: &mut Vec<MeasurementResponse>,
+    ) -> Result<(), Self::Error> {
+        assert!(requests.is_empty());
+        Ok(())
+    }
+}
+
+fn frame(surface: &SurfaceRuntime, renderer: &mut RecordingRenderer, epoch: u32) {
+    surface
+        .render_frame(
+            LayoutSize::new(390.0, 600.0),
+            1,
+            epoch,
+            &mut NoText,
+            renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+}
+
+#[test]
+fn giga_row_margin_does_not_move_a_retained_row() {
+    for (axis, leading, margin) in [
+        (ScrollAxis::Vertical, 0, 0),
+        (ScrollAxis::Vertical, 0, 8),
+        (ScrollAxis::Vertical, 4, 8),
+        (ScrollAxis::Horizontal, 0, 8),
+        (ScrollAxis::Horizontal, 4, 8),
+    ] {
+        __reset_for_tests();
+        let owner = Owner::new(None);
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(94).unwrap(),
+            StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+        );
+        let positions = Rc::new(RefCell::new(HashMap::new()));
+        with_installed_renderer(surface.renderer(), || {
+            let root = owner.with(|| {
+                let positions = positions.clone();
+                render! {
+                    List(
+                        axis: axis,
+                        style: css!(width: percent(100), height: px(600)),
+                        each: || (0_u32..800).collect::<Vec<_>>(),
+                        key: |row: &u32| *row,
+                        children: move |row: ReadSignal<u32>| {
+                            let index = row.get_untracked();
+                            let positions = positions.clone();
+                            let style = match axis {
+                                ScrollAxis::Vertical => css!(height: px(60), margin_top: px(leading), margin_bottom: px(margin), flex_shrink: 0.0),
+                                ScrollAxis::Horizontal => css!(width: px(60), margin_left: px(leading), margin_right: px(margin), flex_shrink: 0.0),
+                            };
+                            let node = render! { View(style: style) };
+                            observe_layout(node, Box::new(move |observation| {
+                                let position = match axis {
+                                    ScrollAxis::Vertical => observation.geometry.border_box.y,
+                                    ScrollAxis::Horizontal => observation.geometry.border_box.x,
+                                };
+                                positions.borrow_mut().insert(index, position);
+                            }));
+                            node
+                        },
+                    )
+                }
+            });
+            set_root(root);
+        });
+        let mut renderer = RecordingRenderer::new(surface.surface());
+        frame(&surface, &mut renderer, 1);
+        frame(&surface, &mut renderer, 2);
+        let scroll_type = surface
+            .element_registrations()
+            .iter()
+            .find(|r| r.name == whisker::SCROLL_VIEW_ELEMENT_NAME)
+            .unwrap()
+            .element_type;
+        let scroll_node = renderer.frames()[0]
+            .packet
+            .operations
+            .iter()
+            .find_map(|op| match op {
+                Operation::CreateNode {
+                    node, element_type, ..
+                } if *element_type == scroll_type => Some(*node),
+                _ => None,
+            })
+            .unwrap();
+        let scroll = |offset: f64| {
+            with_installed_renderer(surface.renderer(), || {
+                surface
+                    .dispatch_input(&InputEvent {
+                        surface: surface.surface(),
+                        timestamp_ms: offset,
+                        kind: InputEventKind::Named("scroll".into()),
+                        pointer: None,
+                        target: Some(scroll_node),
+                        detail: WhiskerValue::map([
+                            (
+                                if axis == ScrollAxis::Vertical {
+                                    "scrollTop"
+                                } else {
+                                    "scrollLeft"
+                                },
+                                WhiskerValue::Float(offset),
+                            ),
+                            (
+                                if axis == ScrollAxis::Vertical {
+                                    "viewportHeight"
+                                } else {
+                                    "viewportWidth"
+                                },
+                                WhiskerValue::Float(if axis == ScrollAxis::Vertical {
+                                    600.0
+                                } else {
+                                    390.0
+                                }),
+                            ),
+                            (
+                                if axis == ScrollAxis::Vertical {
+                                    "scrollHeight"
+                                } else {
+                                    "scrollWidth"
+                                },
+                                WhiskerValue::Float(800.0 * f64::from(60 + leading + margin)),
+                            ),
+                        ]),
+                    })
+                    .unwrap();
+                whisker::flush();
+            })
+        };
+        scroll(1200.0);
+        frame(&surface, &mut renderer, 3);
+        frame(&surface, &mut renderer, 4);
+        let before = positions.borrow()[&25];
+        scroll(1260.0);
+        frame(&surface, &mut renderer, 5);
+        frame(&surface, &mut renderer, 6);
+        let after = positions.borrow()[&25];
+        eprintln!(
+            "axis={axis:?}, leading={leading}, margin={margin}: retained row 25 content y {before} -> {after}; drift={}",
+            after - before
+        );
+        with_installed_renderer(surface.renderer(), || owner.dispose());
+        assert!(
+            (after - before).abs() < 0.5,
+            "scrolling must not move an unchanged retained row in content coordinates"
+        );
+    }
+}
+
+#[test]
+fn giga_loading_replacement_keeps_header_visible() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(95).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let loaded = owner.with(|| signal(false));
+    let handle = owner.with(ListHandle::<u32>::new);
+    let header_heights = Rc::new(RefCell::new(Vec::new()));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            let header_heights = header_heights.clone();
+            render! {
+                List(
+                    list_ref: handle.r(),
+                    style: css!(width: percent(100), height: px(600)),
+                    header: move || {
+                        let heights = header_heights.clone();
+                        let header = render! { View(style: css!(height: px(360))) };
+                        observe_layout(header, Box::new(move |o| heights.borrow_mut().push(o.geometry.border_box.height)));
+                        header
+                    },
+                    each: move || if loaded.get() { (0..800).collect::<Vec<_>>() } else { vec![999] },
+                    key: |row: &u32| *row,
+                    children: |row: ReadSignal<u32>| render! { View(style: css!(height: px(if row.get_untracked() == 999 { 640 } else { 60 }), margin_bottom: px(8))) },
+                )
+            }
+        });
+        set_root(root);
+    });
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    for epoch in 1..=3 {
+        frame(&surface, &mut renderer, epoch);
+    }
+    with_installed_renderer(surface.renderer(), || {
+        loaded.set(true);
+        whisker::flush();
+    });
+    for epoch in 4..=8 {
+        frame(&surface, &mut renderer, epoch);
+        let snapshot = handle.snapshot().unwrap();
+        eprintln!(
+            "loaded frame {epoch}: offset={}, extent={}",
+            snapshot.offset, snapshot.content_extent
+        );
+        assert_eq!(
+            snapshot.offset, 0.0,
+            "loading chapters must not scroll the header out of view"
+        );
+    }
+    eprintln!("header heights={:?}", header_heights.borrow());
+    assert!(
+        header_heights
+            .borrow()
+            .iter()
+            .all(|height| (*height - 360.0).abs() < 0.5)
+    );
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn giga_rtl_initial_page_settles_before_runtime_goes_idle() {
+    __reset_for_tests();
+    let handle = Rc::new(RefCell::new(None::<ListHandle<u32>>));
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(96).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let wake = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let wake_callback = wake.clone();
+    let mut runtime = whisker::RuntimeInstance::new(
+        surface.clone(),
+        whisker::runtime::RuntimeWakeHandle::new(move || {
+            wake_callback.store(true, std::sync::atomic::Ordering::Relaxed);
+        }),
+    );
+    runtime
+        .mount(|| {
+            let list = ListHandle::<u32>::new();
+            *handle.borrow_mut() = Some(list.clone());
+            render! {
+                List(
+                    list_ref: list.r(),
+                    axis: ScrollAxis::Horizontal,
+                    initial_scroll: ListScrollTarget::index(9, ScrollAlignment::Start),
+                    style: css!(width: px(390), height: px(600)),
+                    content_style: css!(height: percent(100)),
+                    each: || (0_u32..10).rev().collect::<Vec<_>>(),
+                    key: |row: &u32| *row,
+                    children: |_row: ReadSignal<u32>| render! {
+                        View(style: css!(width: px(390), height: percent(100), flex_shrink: 0.0))
+                    },
+                )
+            }
+        })
+        .unwrap();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    for epoch in 1..=8 {
+        wake.store(false, std::sync::atomic::Ordering::Relaxed);
+        let drive = runtime
+            .drive_frame(
+                f64::from(epoch) * 16.0,
+                StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+                1,
+                epoch,
+                &mut NoText,
+                &mut renderer,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+        let snapshot = handle.borrow().as_ref().unwrap().snapshot().unwrap();
+        eprintln!(
+            "RTL frame {epoch}: needs_frame={}, offset={}, first_key={:?}",
+            drive.needs_frame, snapshot.offset, snapshot.first_visible_key
+        );
+        if !drive.needs_frame && !wake.load(std::sync::atomic::Ordering::Relaxed) {
+            break;
+        }
+    }
+    let snapshot = handle.borrow().as_ref().unwrap().snapshot().unwrap();
+    runtime.unmount().unwrap();
+    assert_eq!(
+        snapshot.offset, 3510.0,
+        "RTL logical page 0 must be reached before the Host stops scheduling frames"
+    );
+}
+
+#[test]
+fn giga_reader_hold_emits_longpress() {
+    use std::cell::Cell;
+    use whisker_engine::whisker_protocol::{InputPoint, PointerId, PointerInput, PointerKind};
+    __reset_for_tests();
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(97).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let holds = Rc::new(Cell::new(0));
+    let held = holds.clone();
+    let mut runtime = whisker::RuntimeInstance::new(
+        surface.clone(),
+        whisker::runtime::RuntimeWakeHandle::new(|| {}),
+    );
+    runtime.mount(|| {
+        let builder = List::builder()
+            .style(css!(width: px(390), height: px(600)))
+            .axis(ScrollAxis::Horizontal)
+            .each(|| vec![0_u32])
+            .key(|row: &u32| *row)
+            .children(|_: ReadSignal<u32>| render! { View(style: css!(width: px(390), height: px(600))) });
+        whisker::runtime::event::bind_typed(builder.__element(), "longpress", whisker::event::BindType::Bind, move |_: whisker::event::TouchEvent| held.set(held.get() + 1));
+        builder.build()
+    }).unwrap();
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    for epoch in 1..=3 {
+        runtime
+            .drive_frame(
+                f64::from(epoch),
+                StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+                1,
+                epoch,
+                &mut NoText,
+                &mut renderer,
+                LayoutOptions::default(),
+            )
+            .unwrap();
+    }
+    let pointer = |timestamp_ms, kind, buttons| InputEvent {
+        surface: surface.surface(),
+        timestamp_ms,
+        kind,
+        pointer: Some(PointerInput {
+            id: PointerId::new(1).unwrap(),
+            kind: PointerKind::Touch,
+            position: InputPoint { x: 100.0, y: 100.0 },
+            buttons,
+            changed_button: -1,
+        }),
+        target: None,
+        detail: WhiskerValue::Null,
+    };
+    let down = runtime
+        .dispatch_input(&pointer(10.0, InputEventKind::PointerDown, 1))
+        .unwrap();
+    assert!(down.target.is_some(), "the page must be hit-testable");
+    runtime
+        .drive_frame(
+            1010.0,
+            StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+            1,
+            4,
+            &mut NoText,
+            &mut renderer,
+            LayoutOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        holds.get(),
+        1,
+        "longpress must fire before the finger is released"
+    );
+    runtime
+        .dispatch_input(&pointer(1110.0, InputEventKind::PointerUp, 0))
+        .unwrap();
+    let from_pointer = holds.get();
+    // Control: the named-event listener and bubbling must work independently
+    // of held-pointer recognition.
+    runtime
+        .dispatch_input(&InputEvent {
+            surface: surface.surface(),
+            timestamp_ms: 1200.0,
+            kind: InputEventKind::Named("longpress".into()),
+            pointer: pointer(1200.0, InputEventKind::PointerUp, 0).pointer,
+            target: down.target,
+            detail: WhiskerValue::Null,
+        })
+        .unwrap();
+    let from_named_event = holds.get() - from_pointer;
+    runtime.unmount().unwrap();
+    eprintln!(
+        "held pointer: {from_pointer} longpress events; direct named event: {from_named_event}"
+    );
+    assert_eq!(from_named_event, 1);
+    assert_eq!(
+        from_pointer, 1,
+        "holding the reader must reach the UI toggle callback"
+    );
+}

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -2054,3 +2054,219 @@ fn deferred_measurement_event_wakes_and_completes_the_next_frame() {
     assert!(complete.frame.layout.has_layout());
     assert!(complete.frame.presentation.is_some());
 }
+
+mod longpress {
+    use super::*;
+
+    struct Reader {
+        runtime: RuntimeInstance,
+        surface: SurfaceRuntime,
+        sink: RecordingRenderer,
+        holds: Rc<RefCell<Vec<f64>>>,
+        taps: Rc<Cell<usize>>,
+        wakes: Arc<AtomicUsize>,
+    }
+
+    impl Reader {
+        fn new(listen: bool) -> Self {
+            let surface = surface(90);
+            let holds = Rc::new(RefCell::new(Vec::new()));
+            let held = holds.clone();
+            let taps = Rc::new(Cell::new(0));
+            let tapped = taps.clone();
+            let wakes = Arc::new(AtomicUsize::new(0));
+            let wake_count = wakes.clone();
+            let mut runtime = RuntimeInstance::new(
+                surface.clone(),
+                RuntimeWakeHandle::new(move || {
+                    wake_count.fetch_add(1, Ordering::Relaxed);
+                }),
+            );
+            runtime
+                .mount(move || {
+                    let view = render! {
+                        View(style: css!(width: px(100), height: px(100)),
+                            on_tap: move |_| tapped.set(tapped.get() + 1)) {
+                            View(style: css!(width: px(100), height: px(100)))
+                        }
+                    };
+                    if listen {
+                        whisker::runtime::event::bind_typed(
+                            view,
+                            "longpress",
+                            whisker::event::BindType::Bind,
+                            move |event: whisker::event::TouchEvent| {
+                                held.borrow_mut().push(event.detail.x)
+                            },
+                        );
+                    }
+                    view
+                })
+                .unwrap();
+            let sink = RecordingRenderer::new(surface.surface());
+            let mut reader = Self {
+                runtime,
+                surface,
+                sink,
+                holds,
+                taps,
+                wakes,
+            };
+            reader.frame(1.0);
+            reader.wakes.store(0, Ordering::Relaxed);
+            reader
+        }
+
+        fn frame(&mut self, time: f64) -> bool {
+            self.runtime
+                .drive_frame(
+                    time,
+                    StyleEnvironment::new(200.0, 100.0, 1.0, 14.0),
+                    1,
+                    1,
+                    &mut NoMeasurement,
+                    &mut self.sink,
+                    LayoutOptions::default(),
+                )
+                .unwrap()
+                .needs_frame
+        }
+
+        fn pointer(
+            &self,
+            time: f64,
+            kind: InputEventKind,
+            id: u64,
+            x: f32,
+            pointer_kind: PointerKind,
+        ) {
+            self.runtime
+                .dispatch_input(&InputEvent {
+                    surface: self.surface.surface(),
+                    timestamp_ms: time,
+                    pointer: Some(PointerInput {
+                        id: PointerId::new(id).unwrap(),
+                        kind: pointer_kind,
+                        position: InputPoint { x, y: 10.0 },
+                        buttons: if kind == InputEventKind::PointerUp {
+                            0
+                        } else {
+                            1
+                        },
+                        changed_button: -1,
+                    }),
+                    kind,
+                    target: None,
+                    detail: WhiskerValue::Null,
+                })
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn stationary_contact_wakes_fires_once_bubbles_and_does_not_tap_on_release() {
+        for pointer_kind in [PointerKind::Touch, PointerKind::Pen] {
+            let mut reader = Reader::new(true);
+            reader.pointer(10.0, InputEventKind::PointerDown, 1, 10.0, pointer_kind);
+            assert!(reader.wakes.load(Ordering::Relaxed) > 0);
+            assert!(
+                reader.frame(509.0),
+                "hold deadline must keep the host scheduled"
+            );
+            assert!(reader.holds.borrow().is_empty());
+            assert!(
+                !reader.frame(510.0),
+                "recognition must stop requesting frames"
+            );
+            assert_eq!(&*reader.holds.borrow(), &[10.0]);
+            reader.frame(900.0);
+            reader.pointer(1000.0, InputEventKind::PointerUp, 1, 10.0, pointer_kind);
+            assert_eq!(reader.holds.borrow().len(), 1);
+            assert_eq!(reader.taps.get(), 0);
+            reader.pointer(1100.0, InputEventKind::PointerDown, 1, 10.0, pointer_kind);
+            reader.pointer(1110.0, InputEventKind::PointerUp, 1, 10.0, pointer_kind);
+            assert_eq!(reader.taps.get(), 1, "the next independent tap must work");
+        }
+    }
+
+    #[test]
+    fn movement_cancel_second_contact_and_pause_cancel_a_hold() {
+        for scenario in ["move", "cancel", "second contact", "pause", "remount"] {
+            let mut reader = Reader::new(true);
+            reader.pointer(
+                10.0,
+                InputEventKind::PointerDown,
+                1,
+                10.0,
+                PointerKind::Touch,
+            );
+            match scenario {
+                "move" => reader.pointer(
+                    20.0,
+                    InputEventKind::PointerMove,
+                    1,
+                    30.0,
+                    PointerKind::Touch,
+                ),
+                "cancel" => reader.pointer(
+                    20.0,
+                    InputEventKind::PointerCancel,
+                    1,
+                    10.0,
+                    PointerKind::Touch,
+                ),
+                "second contact" => reader.pointer(
+                    20.0,
+                    InputEventKind::PointerDown,
+                    2,
+                    20.0,
+                    PointerKind::Touch,
+                ),
+                "pause" => {
+                    reader.runtime.pause().unwrap();
+                    reader.runtime.resume().unwrap();
+                }
+                "remount" => {
+                    reader.runtime.remount_root(|| render! { View() }).unwrap();
+                }
+                _ => unreachable!(),
+            }
+            reader.frame(1000.0);
+            assert!(reader.holds.borrow().is_empty(), "{scenario}");
+            reader.pointer(
+                1010.0,
+                InputEventKind::PointerUp,
+                1,
+                10.0,
+                PointerKind::Touch,
+            );
+            assert_eq!(reader.taps.get(), 0, "{scenario}");
+        }
+    }
+
+    #[test]
+    fn ordinary_taps_and_mouse_contacts_do_not_keep_frames_running() {
+        let mut reader = Reader::new(false);
+        reader.pointer(
+            10.0,
+            InputEventKind::PointerDown,
+            1,
+            10.0,
+            PointerKind::Touch,
+        );
+        assert!(!reader.frame(20.0));
+        reader.pointer(30.0, InputEventKind::PointerUp, 1, 10.0, PointerKind::Touch);
+        assert_eq!(reader.taps.get(), 1);
+        let mut reader = Reader::new(true);
+        reader.pointer(
+            10.0,
+            InputEventKind::PointerDown,
+            1,
+            10.0,
+            PointerKind::Mouse,
+        );
+        assert!(!reader.frame(20.0));
+        reader.frame(1000.0);
+        assert!(reader.holds.borrow().is_empty());
+    }
+}


### PR DESCRIPTION
Reader holds never reached `longpress` listeners, and List rows with margins shifted when virtualization replaced offscreen rows with spacers.

- Recognize a stationary touch or pen after 500 ms using the Host frame clock, emit once while held, and suppress the release tap. Cancel on movement, multiple contacts, pointer cancellation, pause, unmount, or remount. Only contacts with a reachable longpress listener keep frames scheduled while waiting.
- Include resolved margins in List row and auxiliary-content measurements without changing Host paint geometry. Keep synthetic grid-track measurements separate from their already-accounted-for gaps.
- Add regression coverage for hold recognition and cancellation, frame scheduling, vertical/horizontal margins, loading replacement, and initial RTL positioning.

Validation: 297 related tests passed across `whisker-layout`, `whisker-runtime`, `runtime_instance`, `surface_render_pipeline`, and `list_giga_diagnostics`; formatting and diff checks passed. The package-only `whisker-layout` coverage gate passes at 100% lines, functions, and regions, including resolved-margin measurement and parent-width changes. Rust 1.88 Clippy passed for `whisker-layout`, `whisker-runtime`, and `whisker` libraries and tests with CI warning settings.

Android app validation with the updated runtime remains pending. The companion GIGA change removes its next-tap suppression workaround because longpress release no longer produces a tap. SDK publishing and scroll-performance optimization will follow separately.

