### PR TITLE
ci: resume crate releases after crates.io rate limits

### DIFF
--- a/.agents/skills/release-whisker/SKILL.md
+++ b/.agents/skills/release-whisker/SKILL.md
@@ -37,13 +37,18 @@ happens on the merge commit of a release PR**.
    Confirm its changelog mentions your change.
 3. Merge that PR. The push to `main` publishes and tags.
 
-Expect **HTTP 429** partway through: crates.io limits how many existing
-crates you may update in a burst, and the workspace is large. It is not
-a failure of the release — re-run the failed job and it resumes from the
-first unpublished crate.
+The publish job automatically recovers from **crates.io HTTP 429** using
+`.github/scripts/release_with_retry.py`. It waits until the reset time
+in cargo's diagnostic (with a small margin), then runs release-plz again
+on the same checkout. Published crates are skipped. Missing or stale
+reset times use a fallback delay; attempts and job duration are bounded.
+Other errors fail immediately.
+
+If retries are exhausted, inspect the final error before re-running.
+A manual re-run resumes the same release without bumping versions:
 
 ```sh
-gh run rerun <run-id> --failed   # wait ~2-3 min between attempts
+gh run rerun <run-id> --failed
 ```
 
 Watch a specific crate rather than the run alone, since the run can be

--- a/.github/scripts/release_with_retry.py
+++ b/.github/scripts/release_with_retry.py
@@ -1,0 +1,77 @@
+"""Resume release-plz after crates.io's publish rate limit, on the same checkout."""
+
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from email.utils import parsedate_to_datetime
+
+
+MAX_ATTEMPTS = 40
+FALLBACK_DELAY_SECONDS = 120
+RATE_LIMIT = re.compile(
+    r"status 429 Too Many Requests[^\n]*https://crates\.io/docs/rate-limits"
+)
+RETRY_AT = re.compile(r"Please try again after (.+? GMT)")
+
+
+def retry_delay(output, now):
+    """Only retry crates.io publish throttling; honor its advertised reset time."""
+    responses = RATE_LIMIT.findall(output)
+    if not responses:
+        return None
+    delays = []
+    for response in responses:
+        match = RETRY_AT.search(response)
+        try:
+            reset = parsedate_to_datetime(match[1]).timestamp() if match else None
+        except (TypeError, ValueError, OverflowError):
+            reset = None
+        # Give the server a little slack for clock skew / rounding. If the
+        # advertised time is stale or absent, avoid a tight retry loop.
+        delays.append(
+            max(10, math.ceil(reset - now) + 10)
+            if reset is not None and reset > now
+            else FALLBACK_DELAY_SECONDS
+        )
+    return max(delays)
+
+
+def run_release(command):
+    # Stream diagnostics to Actions while retaining this attempt's output for
+    # classification. Never log command arguments: they contain the GitHub token.
+    with subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, errors="replace", bufsize=1,
+    ) as process:
+        output = []
+        for line in process.stdout:
+            print(line, end="", flush=True)
+            output.append(line)
+        return process.wait(), "".join(output)
+
+
+def release_with_retry(command):
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        print(f"release-plz attempt {attempt}/{MAX_ATTEMPTS}", flush=True)
+        status, output = run_release(command)
+        if status == 0:
+            return 0
+        delay = retry_delay(output, time.time())
+        if delay is None or attempt == MAX_ATTEMPTS:
+            print("Release failed; no further automatic retries.", file=sys.stderr)
+            return status if status > 0 else 1
+        print(
+            f"crates.io rate limit: waiting {delay}s before resuming unpublished crates.",
+            flush=True,
+        )
+        time.sleep(delay)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(release_with_retry([
+        "release-plz", "release", "--git-token", os.environ["GITHUB_TOKEN"],
+    ]))

--- a/.github/scripts/test_release_with_retry.py
+++ b/.github/scripts/test_release_with_retry.py
@@ -1,0 +1,121 @@
+import contextlib
+import io
+import os
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import release_with_retry as release
+
+
+# Actual cargo diagnostic from the failed v0.13.3 release (run 33906332276).
+THROTTLED = (
+    "the remote server responded with an error (status 429 Too Many Requests): "
+    "You have published too many updates to existing crates in a short period "
+    "of time. Please try again after Fri, 04 Sep 2026 18:40:23 GMT and see "
+    "https://crates.io/docs/rate-limits for more details."
+)
+RESET = 1788547223
+
+
+class RetryTests(unittest.TestCase):
+    def test_server_reset_time_including_slack(self):
+        self.assertEqual(release.retry_delay(THROTTLED, RESET - 38), 48)
+
+    def test_duplicate_cargo_diagnostics_do_not_double_wait(self):
+        self.assertEqual(release.retry_delay(THROTTLED + "\n" + THROTTLED, RESET - 38), 48)
+
+    def test_stale_missing_or_invalid_time_uses_fallback(self):
+        for diagnostic, now in [
+            (THROTTLED, RESET + 1),
+            (THROTTLED.replace("Fri, 04 Sep 2026 18:40:23 GMT", "invalid GMT"), RESET),
+            (THROTTLED.replace("Please try again after Fri, 04 Sep 2026 18:40:23 GMT", ""), RESET),
+        ]:
+            with self.subTest(diagnostic=diagnostic):
+                self.assertEqual(release.retry_delay(diagnostic, now), 120)
+
+    def test_other_errors_are_not_retryable(self):
+        for diagnostic in [
+            "error[E0432]: unresolved import",
+            "registry at https://crates.io returned status 403 Forbidden",
+            "GitHub returned status 429 Too Many Requests",
+            "published crate version 0.4.29; compilation failed",
+        ]:
+            with self.subTest(diagnostic=diagnostic):
+                self.assertIsNone(release.retry_delay(diagnostic, RESET))
+
+    def run_attempts(self, results):
+        with (
+            patch.object(release, "run_release", side_effect=results) as run,
+            patch.object(release.time, "sleep") as sleep,
+            patch.object(release.time, "time", return_value=RESET - 38),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            status = release.release_with_retry(["release-plz", "release"])
+        return status, run, sleep
+
+    def test_success_does_not_retry(self):
+        status, run, sleep = self.run_attempts([(0, "already published")])
+        self.assertEqual(status, 0)
+        self.assertEqual(run.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_repeated_throttling_resumes_until_success(self):
+        status, run, sleep = self.run_attempts([(1, THROTTLED), (1, THROTTLED), (0, "published")])
+        self.assertEqual(status, 0)
+        self.assertEqual(run.call_count, 3)
+        self.assertEqual([call.args for call in sleep.call_args_list], [(48,), (48,)])
+
+    def test_error_after_throttling_stops_using_only_current_output(self):
+        status, run, sleep = self.run_attempts([(1, THROTTLED), (101, "compilation failed")])
+        self.assertEqual(status, 101)
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once()
+
+    def test_retry_budget_exhaustion_is_failure(self):
+        status, run, sleep = self.run_attempts([(1, THROTTLED)] * release.MAX_ATTEMPTS)
+        self.assertEqual(status, 1)
+        self.assertEqual(run.call_count, release.MAX_ATTEMPTS)
+        self.assertEqual(sleep.call_count, release.MAX_ATTEMPTS - 1)
+
+    def test_signal_termination_is_failure_without_retry(self):
+        status, run, sleep = self.run_attempts([(-15, "")])
+        self.assertEqual(status, 1)
+        self.assertEqual(run.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_real_subprocess_resumes_partial_release_and_streams_both_outputs(self):
+        # A fake publisher persists the first published crate before throttling.
+        # The second invocation must retain cwd/env/state and finish the remainder.
+        with tempfile.TemporaryDirectory() as directory:
+            publisher = Path(directory) / "publisher.py"
+            publisher.write_text(
+                "import os, pathlib, sys\n"
+                "state = pathlib.Path(os.environ['RETRY_TEST_STATE'])\n"
+                "if not state.exists():\n"
+                "    state.write_text(os.getcwd())\n"
+                "    print('published crate-a', flush=True)\n"
+                f"    print({THROTTLED!r}, file=sys.stderr)\n"
+                "    sys.exit(1)\n"
+                "assert state.read_text() == os.getcwd()\n"
+                "print('crate-a: already published; published crate-b')\n"
+            )
+            output = io.StringIO()
+            with (
+                patch.dict(os.environ, {"RETRY_TEST_STATE": str(Path(directory) / "state")}),
+                patch.object(release.time, "sleep") as sleep,
+                patch.object(release.time, "time", return_value=RESET - 38),
+                contextlib.redirect_stdout(output),
+            ):
+                status = release.release_with_retry([sys.executable, str(publisher)])
+            self.assertEqual(status, 0)
+            sleep.assert_called_once_with(48)
+            self.assertIn(THROTTLED, output.getvalue())
+            self.assertIn("crate-a: already published; published crate-b", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
+  release-retry-tests:
+    name: Release retry tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python3 -m unittest discover -s .github/scripts -p 'test_*.py' -v
+
   test:
     name: cargo test
     runs-on: ubuntu-latest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -52,6 +52,7 @@ jobs:
     # commit that triggered this run isn't a release PR merge.
     name: release-plz / release (publish + tag)
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     # Skip on forks — only the canonical repo can publish.
     if: github.repository_owner == 'whiskerrs'
     steps:
@@ -62,10 +63,16 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run release-plz release
-        uses: release-plz/action@v0.5
+      - name: Install release-plz
+        uses: taiki-e/install-action@v2
         with:
-          command: release
+          tool: release-plz@0.3.161
+      - name: Configure release tag author
+        uses: release-plz/git-config@59144859caf016f8b817a2ac9b051578729173c4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run release-plz with crates.io rate-limit recovery
+        run: python3 .github/scripts/release_with_retry.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The v0.13.3 publish job failed twice because crates.io returned HTTP 429: the first attempt stopped four seconds before the advertised reset time, and the manual rerun stopped 38 seconds before it. Neither job waited, leaving the workspace partially published.

Run `release-plz release` through a wrapper that waits until crates.io's advertised reset time plus ten seconds, then resumes on the same checkout. Already published crates are skipped by release-plz. Missing or stale reset times use a two-minute fallback. Retry only the crates.io publish rate-limit diagnostic; compilation, authentication, and other errors remain failures. Bound recovery to 40 attempts and a 120-minute job timeout.

Keep the existing release-plz version (0.3.161), tag-author setup, registry credentials, and release-PR-only publishing policy. The release PR job is unchanged. Update the release skill to describe automatic recovery.

Validation:
- Ten Python tests pass, including the actual failure diagnostic, repeated throttling, retry exhaustion, unrelated errors, and a real subprocess that resumes a partial publish using persisted state.
- Add these tests to pull-request CI.
- actionlint 1.7.12 passes for both changed workflows.
- Verify the actual job log yields a 48-second retry delay at the failure timestamp.

No crates or platform SDKs have been published by this PR. Merge this before the next release PR. The pending Android fixes also need a new SDK AAR and the CLI SDK pin updated before releasing crates.
