### PR TITLE
feat: expose longpress handlers on element builders

### DIFF
--- a/crates/whisker-macros/src/module_element.rs
+++ b/crates/whisker-macros/src/module_element.rs
@@ -983,6 +983,10 @@ const COMMON_ELEMENT_PROP_NAMES: &[&str] = &[
     "on_tap_catch",
     "on_capture_tap",
     "on_capture_tap_catch",
+    "on_longpress",
+    "on_longpress_catch",
+    "on_capture_longpress",
+    "on_capture_longpress_catch",
     "on_click",
     "on_click_catch",
     "on_capture_click",
@@ -1368,6 +1372,10 @@ mod tests {
             "dataset",
             "accessibility",
             "on_tap",
+            "on_longpress",
+            "on_longpress_catch",
+            "on_capture_longpress",
+            "on_capture_longpress_catch",
             "on_animationend",
         ] {
             let ident: Ident = syn::parse_str(name).unwrap();

--- a/crates/whisker/src/builtins/mod.rs
+++ b/crates/whisker/src/builtins/mod.rs
@@ -120,6 +120,34 @@ pub trait ElementBuilder: Sized {
         self
     }
 
+    /// `longpress` — fires while the pointer remains held past the hold
+    /// threshold without moving far. Receives the touch coordinates and
+    /// target metadata. Bubble phase, lets the event continue up the chain.
+    ///
+    /// ```ignore
+    /// View(on_longpress: move |e| println!("held at {:?}", e.detail))
+    /// ```
+    fn on_longpress<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+        bind_typed(self.__element(), "longpress", BindType::Bind, f);
+        self
+    }
+    /// `longpress`, bubble phase — **stops** propagation at this element.
+    fn on_longpress_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+        bind_typed(self.__element(), "longpress", BindType::Catch, f);
+        self
+    }
+    /// `longpress`, capture phase — doesn't stop propagation.
+    fn on_capture_longpress<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+        bind_typed(self.__element(), "longpress", BindType::CaptureBind, f);
+        self
+    }
+    /// `longpress`, capture phase — **stops** propagation before it reaches
+    /// the target.
+    fn on_capture_longpress_catch<F: Fn(TouchEvent) + 'static>(self, f: F) -> Self {
+        bind_typed(self.__element(), "longpress", BindType::CaptureCatch, f);
+        self
+    }
+
     /// `click` — mouse-compatible activation on the nearest listening node.
     /// A mouse activation emits `tap` first and then `click`; touch and pen
     /// activation emit only `tap`.

--- a/crates/whisker/tests/list_giga_diagnostics.rs
+++ b/crates/whisker/tests/list_giga_diagnostics.rs
@@ -324,8 +324,9 @@ fn giga_reader_hold_emits_longpress() {
             .each(|| vec![0_u32])
             .key(|row: &u32| *row)
             .children(|_: ReadSignal<u32>| render! { View(style: css!(width: px(390), height: px(600))) });
-        whisker::runtime::event::bind_typed(builder.__element(), "longpress", whisker::event::BindType::Bind, move |_: whisker::event::TouchEvent| held.set(held.get() + 1));
-        builder.build()
+        builder
+            .on_longpress(move |_| held.set(held.get() + 1))
+            .build()
     }).unwrap();
     let mut renderer = RecordingRenderer::new(surface.surface());
     for epoch in 1..=3 {

--- a/crates/whisker/tests/render_macro.rs
+++ b/crates/whisker/tests/render_macro.rs
@@ -466,6 +466,39 @@ fn tap_propagation_variants_route_to_bind_types() {
 }
 
 #[test]
+fn longpress_propagation_variants_route_to_bind_types() {
+    with_recorder(|log| {
+        let _ = render! {
+            View {
+                View(on_longpress: |_| {})
+                View(on_longpress_catch: |_| {})
+                View(on_capture_longpress: |_| {})
+                View(on_capture_longpress_catch: |_| {})
+            }
+        };
+        let kinds: Vec<BindType> = log
+            .borrow()
+            .iter()
+            .filter_map(|op| match op {
+                Op::Event {
+                    name, bind_type, ..
+                } if name == "longpress" => Some(*bind_type),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            [
+                BindType::Bind,
+                BindType::Catch,
+                BindType::CaptureBind,
+                BindType::CaptureCatch,
+            ]
+        );
+    });
+}
+
+#[test]
 fn component_specific_events_route_bind_only() {
     // Tag-specific events use the binding declared by their public builder.
     with_recorder(|log| {

--- a/crates/whisker/tests/runtime_instance.rs
+++ b/crates/whisker/tests/runtime_instance.rs
@@ -2084,23 +2084,18 @@ mod longpress {
             );
             runtime
                 .mount(move || {
-                    let view = render! {
-                        View(style: css!(width: px(100), height: px(100)),
-                            on_tap: move |_| tapped.set(tapped.get() + 1)) {
+                    let builder = View::builder()
+                        .style(css!(width: px(100), height: px(100)))
+                        .on_tap(move |_| tapped.set(tapped.get() + 1))
+                        .child(render! {
                             View(style: css!(width: px(100), height: px(100)))
-                        }
+                        });
+                    let builder = if listen {
+                        builder.on_longpress(move |event| held.borrow_mut().push(event.detail.x))
+                    } else {
+                        builder
                     };
-                    if listen {
-                        whisker::runtime::event::bind_typed(
-                            view,
-                            "longpress",
-                            whisker::event::BindType::Bind,
-                            move |event: whisker::event::TouchEvent| {
-                                held.borrow_mut().push(event.detail.x)
-                            },
-                        );
-                    }
-                    view
+                    builder.build()
                 })
                 .unwrap();
             let sink = RecordingRenderer::new(surface.surface());


### PR DESCRIPTION
The runtime already recognizes long presses, but applications such as GIGA must use `builder.__element()` and `runtime::event::bind_typed` to register a handler. Expose `on_longpress` on the shared `ElementBuilder` so built-in and module elements can use `.on_longpress(...)` or `View(on_longpress: ...)`.

Add the matching catch and capture variants with the same propagation semantics as tap handlers. Reserve all four names in module element schemas to prevent component props from shadowing the common API.

Validation is delegated to CI; local builds and tests were skipped as requested. Added render-macro coverage for all four binding types and schema-name rejection coverage. Updated the existing runtime hold-detection and GIGA List reader tests to exercise the public builder API instead of direct event binding.
