### PR TITLE
fix(scroll): support app-driven paging on Android and iOS

### DIFF
--- a/crates/whisker-runtime/src/event.rs
+++ b/crates/whisker-runtime/src/event.rs
@@ -388,20 +388,24 @@ pub struct ScrollEvent {
 }
 
 /// Scroll geometry carried by a [`ScrollEvent`]'s `detail` map.
+///
+/// Android/iOS also emit when dragging begins or ends without an offset change.
+/// A `true` → `false` transition in `is_dragging` identifies release/cancellation;
+/// release velocity is a one-event snapshot, not a continuous velocity stream.
 #[derive(Debug, Clone, Copy, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct ScrollDetail {
-    /// Horizontal content offset (px).
+    /// Horizontal content offset (logical pixels).
     #[serde(default)]
     pub scroll_left: f64,
-    /// Vertical content offset (px).
+    /// Vertical content offset (logical pixels).
     #[serde(default)]
     pub scroll_top: f64,
-    /// Total scrollable content width (px).
+    /// Total scrollable content width (logical pixels).
     #[serde(default)]
     pub scroll_width: f64,
-    /// Total scrollable content height (px).
+    /// Total scrollable content height (logical pixels).
     #[serde(default)]
     pub scroll_height: f64,
     /// Visible content width in logical pixels.
@@ -410,15 +414,28 @@ pub struct ScrollDetail {
     /// Visible content height in logical pixels.
     #[serde(default)]
     pub viewport_height: f64,
-    /// Horizontal delta since the previous scroll event (px).
+    /// Horizontal delta since the previous scroll event (logical pixels).
     #[serde(default)]
     pub delta_x: f64,
-    /// Vertical delta since the previous scroll event (px).
+    /// Vertical delta since the previous scroll event (logical pixels).
     #[serde(default)]
     pub delta_y: f64,
     /// Whether the user's finger is currently dragging the scroll view.
     #[serde(default)]
     pub is_dragging: bool,
+    /// Content velocity at drag release, in logical pixels per second.
+    /// Positive values increase `scroll_left`. Android/iOS supply this only on
+    /// the event ending a drag; other events and unsupported hosts use zero.
+    #[serde(default)]
+    pub velocity_x: f64,
+    /// Vertical release velocity, with the same contract as [`Self::velocity_x`].
+    /// Positive values increase `scroll_top`.
+    #[serde(default)]
+    pub velocity_y: f64,
+    /// True on an Android/iOS drag cancellation (with zero release velocity).
+    /// False on a normal release and on all other scroll events.
+    #[serde(default)]
+    pub is_drag_cancelled: bool,
 }
 
 // list events (beyond the shared `ScrollEvent` used for
@@ -757,6 +774,39 @@ mod tests {
         assert_eq!(e.detail.scroll_left, 640.0);
         assert_eq!(e.detail.scroll_width, 832.0);
         assert!(e.detail.is_dragging);
+    }
+
+    #[test]
+    fn native_scroll_release_payload_and_legacy_defaults() {
+        let detail: ScrollDetail = WhiskerValue::map([
+            ("scrollLeft", WhiskerValue::Float(120.0)),
+            ("deltaX", WhiskerValue::Float(-20.0)),
+            ("isDragging", WhiskerValue::Bool(false)),
+            ("velocityX", WhiskerValue::Float(-1200.0)),
+            ("velocityY", WhiskerValue::Float(0.0)),
+            ("isDragCancelled", WhiskerValue::Bool(false)),
+        ])
+        .deserialize_into()
+        .unwrap();
+        assert_eq!(detail.scroll_left, 120.0);
+        assert_eq!(detail.delta_x, -20.0);
+        assert_eq!(detail.velocity_x, -1200.0);
+        assert_eq!(detail.velocity_y, 0.0);
+        assert!(!detail.is_dragging);
+        assert!(!detail.is_drag_cancelled);
+        let legacy: ScrollDetail = WhiskerValue::map([("scrollTop", WhiskerValue::Float(40.0))])
+            .deserialize_into()
+            .unwrap();
+        assert_eq!(legacy.scroll_top, 40.0);
+        assert_eq!(legacy.velocity_x, 0.0);
+        assert_eq!(legacy.velocity_y, 0.0);
+        assert!(!legacy.is_drag_cancelled);
+        let cancelled: ScrollDetail =
+            WhiskerValue::map([("isDragCancelled", WhiskerValue::Bool(true))])
+                .deserialize_into()
+                .unwrap();
+        assert!(cancelled.is_drag_cancelled);
+        assert_eq!(cancelled.velocity_x, 0.0);
     }
 
     #[test]

--- a/crates/whisker/src/builtins/list.rs
+++ b/crates/whisker/src/builtins/list.rs
@@ -183,7 +183,8 @@ impl<EachF, KeyF, ChildF, RefF, InitialF> List<EachF, KeyF, ChildF, RefF, Initia
     }
 
     /// Fired continuously while scrolling. Geometry is normalized by the
-    /// standard ScrollView event contract on every Host.
+    /// standard ScrollView event contract on every Host. Android/iOS also report
+    /// drag transitions and release velocity; see [`crate::event::ScrollDetail`].
     pub fn on_scroll<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
         bind_typed(self.handle, "scroll", BindType::Bind, f);
         self

--- a/crates/whisker/src/builtins/mod.rs
+++ b/crates/whisker/src/builtins/mod.rs
@@ -536,7 +536,10 @@ impl ScrollView {
 
     /// `scroll` — fired continuously while scrolling. The
     /// [`ScrollEvent`] `detail` carries the current offset, content
-    /// size, per-event delta, and drag state.
+    /// size, per-event delta, and drag state. Android/iOS also notify at drag
+    /// begin/end without offset movement, with release velocity and cancellation
+    /// in [`crate::event::ScrollDetail`]. This allows app-owned paging using instant
+    /// [`crate::ScrollViewHandle::scroll_to`] commands.
     pub fn on_scroll<F: Fn(ScrollEvent) + 'static>(self, f: F) -> Self {
         bind_typed(self.handle, "scroll", BindType::Bind, f);
         self

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -5,6 +5,8 @@ import android.graphics.Canvas
 import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.View
+import android.view.VelocityTracker
+import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
@@ -161,6 +163,12 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
     private var userScrollEnabled = true
     private var scrollSequenceStart: Int? = null
     private var settleGeneration = 0
+    private var dragging = false
+    private var lastScrollX = 0.0
+    private var lastScrollY = 0.0
+    private var velocityTracker: VelocityTracker? = null
+    private var activePointerId = MotionEvent.INVALID_POINTER_ID
+    private var touchAction = -1
 
     private val verticalScroller = object : ScrollView(context) {
         fun scrollInstantlyTo(x: Int, y: Int) {
@@ -171,8 +179,18 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
             super.onOverScrolled(scrollX, scrollY, false, true)
         }
 
-        override fun onInterceptTouchEvent(event: MotionEvent): Boolean =
-            userScrollEnabled && super.onInterceptTouchEvent(event)
+        override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+            val intercepted = userScrollEnabled && super.onInterceptTouchEvent(event)
+            if (intercepted) beginDrag()
+            return intercepted
+        }
+
+        override fun onOverScrolled(x: Int, y: Int, clampedX: Boolean, clampedY: Boolean) {
+            // The native scroller calls this only after its own touch slop and
+            // nested-scroll arbitration have accepted movement, including edges.
+            if (touchAction == MotionEvent.ACTION_MOVE) beginDrag()
+            super.onOverScrolled(x, y, clampedX, clampedY)
+        }
 
         override fun onTouchEvent(event: MotionEvent): Boolean {
             if (!userScrollEnabled) return false
@@ -205,8 +223,18 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
             super.onOverScrolled(scrollX, scrollY, true, false)
         }
 
-        override fun onInterceptTouchEvent(event: MotionEvent): Boolean =
-            userScrollEnabled && super.onInterceptTouchEvent(event)
+        override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+            val intercepted = userScrollEnabled && super.onInterceptTouchEvent(event)
+            if (intercepted) beginDrag()
+            return intercepted
+        }
+
+        override fun onOverScrolled(x: Int, y: Int, clampedX: Boolean, clampedY: Boolean) {
+            // The native scroller calls this only after its own touch slop and
+            // nested-scroll arbitration have accepted movement, including edges.
+            if (touchAction == MotionEvent.ACTION_MOVE) beginDrag()
+            super.onOverScrolled(x, y, clampedX, clampedY)
+        }
 
         override fun onTouchEvent(event: MotionEvent): Boolean {
             if (!userScrollEnabled) return false
@@ -300,6 +328,7 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
     public fun setUserScrollEnabled(value: Boolean) {
         userScrollEnabled = value
         if (!value) {
+            finishDrag(cancelled = true)
             verticalScroller.stopNestedScroll()
             horizontalScroller.stopNestedScroll()
         }
@@ -350,11 +379,76 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
         }
     }
 
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+            finishDrag(cancelled = true)
+            velocityTracker = VelocityTracker.obtain()
+            activePointerId = event.getPointerId(0)
+        }
+        velocityTracker?.addMovement(event)
+        if (event.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+            activePointerId = event.getPointerId(event.actionIndex)
+        } else if (event.actionMasked == MotionEvent.ACTION_POINTER_UP &&
+            event.getPointerId(event.actionIndex) == activePointerId
+        ) {
+            activePointerId = event.getPointerId(if (event.actionIndex == 0) 1 else 0)
+            velocityTracker?.clear()
+        }
+        touchAction = event.actionMasked
+        val handled = try {
+            super.dispatchTouchEvent(event)
+        } finally {
+            touchAction = -1
+        }
+        // Emit after native UP processing, so an app's Instant command cancels
+        // the fling that native handling just started, rather than preceding it.
+        if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_CANCEL) {
+            finishDrag(cancelled = event.actionMasked == MotionEvent.ACTION_CANCEL)
+        }
+        return handled
+    }
+
+    private fun beginDrag() {
+        if (dragging || !userScrollEnabled || velocityTracker == null) return
+        dragging = true
+        scrollSequenceStart = if (horizontal) horizontalScroller.scrollX else verticalScroller.scrollY
+        emitScroll()
+    }
+
+    private fun finishDrag(cancelled: Boolean) {
+        var velocity = 0.0
+        if (dragging && !cancelled) {
+            velocityTracker?.let { tracker ->
+                tracker.computeCurrentVelocity(1000, ViewConfiguration.get(context).scaledMaximumFlingVelocity.toFloat())
+                // Pointer motion and content offset have opposite signs.
+                velocity = -(if (horizontal) tracker.getXVelocity(activePointerId)
+                    else tracker.getYVelocity(activePointerId)) / resources.displayMetrics.density.toDouble()
+            }
+        }
+        velocityTracker?.recycle()
+        velocityTracker = null
+        activePointerId = MotionEvent.INVALID_POINTER_ID
+        if (!dragging) return
+        dragging = false
+        emitScroll(velocity, cancelled)
+    }
+
+    override fun onDetachedFromWindow() {
+        finishDrag(cancelled = true)
+        super.onDetachedFromWindow()
+    }
+
     private fun activeScroller(): View = if (horizontal) horizontalScroller else verticalScroller
 
-    private fun emitScroll() {
+    private fun emitScroll(releaseVelocity: Double = 0.0, cancelled: Boolean = false) {
         val density = resources.displayMetrics.density.toDouble()
         val scroller = activeScroller()
+        val x = scroller.scrollX / density
+        val y = scroller.scrollY / density
+        val dx = x - lastScrollX
+        val dy = y - lastScrollY
+        lastScrollX = x
+        lastScrollY = y
         presentationSink?.invoke(
             (scroller.scrollX / density).toFloat(),
             (scroller.scrollY / density).toFloat(),
@@ -363,6 +457,12 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
             "scroll",
             WhiskerValue.Map(
                 mapOf(
+                    "deltaX" to WhiskerValue.Float(dx),
+                    "deltaY" to WhiskerValue.Float(dy),
+                    "isDragging" to WhiskerValue.Bool(dragging),
+                    "velocityX" to WhiskerValue.Float(if (horizontal) releaseVelocity else 0.0),
+                    "velocityY" to WhiskerValue.Float(if (horizontal) 0.0 else releaseVelocity),
+                    "isDragCancelled" to WhiskerValue.Bool(cancelled),
                     "scrollLeft" to WhiskerValue.Float(scroller.scrollX / density),
                     "scrollTop" to WhiskerValue.Float(scroller.scrollY / density),
                     "scrollWidth" to WhiskerValue.Float(contentView.width / density),

--- a/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
+++ b/platforms/android/module/src/main/kotlin/rs/whisker/runtime/WhiskerContainerView.kt
@@ -163,6 +163,14 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
     private var settleGeneration = 0
 
     private val verticalScroller = object : ScrollView(context) {
+        fun scrollInstantlyTo(x: Int, y: Int) {
+            super.scrollTo(x, y)
+            // scrollTo clamps the position but leaves the framework scroller running.
+            // A clamped overscroll finishes its springBack immediately when already
+            // in bounds, cancelling both flings and smooth scrolls at this position.
+            super.onOverScrolled(scrollX, scrollY, false, true)
+        }
+
         override fun onInterceptTouchEvent(event: MotionEvent): Boolean =
             userScrollEnabled && super.onInterceptTouchEvent(event)
 
@@ -189,6 +197,14 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
     }
 
     private val horizontalScroller = object : HorizontalScrollView(context) {
+        fun scrollInstantlyTo(x: Int, y: Int) {
+            super.scrollTo(x, y)
+            // Finish the framework scroller even when scrollTo did not change the
+            // offset. Using the clamped position prevents a later spring-back frame
+            // from overwriting the requested position.
+            super.onOverScrolled(scrollX, scrollY, true, false)
+        }
+
         override fun onInterceptTouchEvent(event: MotionEvent): Boolean =
             userScrollEnabled && super.onInterceptTouchEvent(event)
 
@@ -293,12 +309,18 @@ public class WhiskerScrollContainerView(context: Context) : FrameLayout(context)
         val pixels = (offset * resources.displayMetrics.density).roundToInt()
         val isHorizontal = horizontal
         val apply = {
+            if (!smooth) {
+                // A settle check from the interrupted gesture must not start
+                // another animation after the explicit position has been applied.
+                settleGeneration += 1
+                scrollSequenceStart = null
+            }
             if (isHorizontal) {
                 if (smooth) horizontalScroller.smoothScrollTo(pixels, 0)
-                else horizontalScroller.scrollTo(pixels, 0)
+                else horizontalScroller.scrollInstantlyTo(pixels, 0)
             } else {
                 if (smooth) verticalScroller.smoothScrollTo(0, pixels)
-                else verticalScroller.scrollTo(0, pixels)
+                else verticalScroller.scrollInstantlyTo(0, pixels)
             }
         }
         // A FramePacket can resize the scroll content and issue scrollTo in

--- a/platforms/android/runtime/src/androidTest/AndroidManifest.xml
+++ b/platforms/android/runtime/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="rs.whisker.runtime.ScrollCancellationActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar" />
+    </application>
+</manifest>

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/PendingContinuousEventsTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/PendingContinuousEventsTest.kt
@@ -24,4 +24,40 @@ class PendingContinuousEventsTest {
         )
         assertEquals(emptyList<PendingElementEvent>(), events.drain())
     }
+    @Test
+    fun preservesDragTransitionsAndReleaseVelocityWhileSummingMovement() {
+        val pending = PendingContinuousEvents()
+        fun sample(drag: Boolean, delta: Double, velocity: Double = 0.0) = PendingElementEvent(
+            7L, "scroll", WhiskerValue.Map(mapOf(
+                "isDragging" to WhiskerValue.Bool(drag),
+                "deltaY" to WhiskerValue.Float(delta),
+                "velocityY" to WhiskerValue.Float(velocity),
+            )), 0.0,
+        )
+        pending.offer(sample(true, 0.0))
+        pending.offer(sample(true, 10.0))
+        pending.offer(sample(true, 20.0))
+        pending.offer(sample(false, 0.0, 800.0))
+        pending.offer(sample(false, 5.0))
+        pending.offer(sample(false, 10.0))
+        val result = pending.drain()
+        assertEquals(listOf(sample(true, 30.0), sample(false, 0.0, 800.0), sample(false, 15.0)), result)
+    }
+
+    @Test
+    fun preservesZeroVelocityReleaseAndCancellation() {
+        val pending = PendingContinuousEvents()
+        fun sample(drag: Boolean, cancelled: Boolean = false) = PendingElementEvent(
+            7L, "scroll", WhiskerValue.Map(mapOf(
+                "isDragging" to WhiskerValue.Bool(drag),
+                "isDragCancelled" to WhiskerValue.Bool(cancelled),
+            )), 0.0,
+        )
+        val samples = listOf(sample(true), sample(false), sample(true), sample(false, true), sample(false))
+        samples.forEach(pending::offer)
+        assertEquals(samples, pending.drain())
+        pending.offer(sample(true))
+        pending.clear()
+        assertEquals(emptyList<PendingElementEvent>(), pending.drain())
+    }
 }

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollCancellationTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollCancellationTest.kt
@@ -7,6 +7,7 @@ import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.HorizontalScrollView
 import android.widget.ScrollView
 import androidx.test.core.app.ActivityScenario
@@ -64,6 +65,7 @@ class ScrollCancellationTest {
         smooth: Boolean = false,
         requestedOffset: Int? = null,
         nativeSnap: Boolean = false,
+        delayFirstDraw: Boolean = false,
     ) {
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val intent = Intent(instrumentation.context, ScrollCancellationActivity::class.java)
@@ -77,8 +79,17 @@ class ScrollCancellationTest {
             var target = 0
             scenario.onActivity { activity ->
                 if (nativeSnap) activity.scroll.setItemSnap(0.0, 0.0)
-                activity.startMotion(smooth)
-                activity.scroll.postDelayed({
+                if (delayFirstDraw) {
+                    // Model a busy CI renderer: timers run before the first
+                    // frame that advances the native scroller.
+                    val gate = ViewTreeObserver.OnPreDrawListener { false }
+                    activity.scroll.viewTreeObserver.addOnPreDrawListener(gate)
+                    activity.scroll.postDelayed({
+                        activity.scroll.viewTreeObserver.removeOnPreDrawListener(gate)
+                        activity.scroll.invalidate()
+                    }, 160)
+                }
+                val interrupt = Runnable {
                     before = activity.offset
                     val requested = requestedOffset ?: if (sameOffset) before else 500
                     val maximum = if (horizontal) {
@@ -103,7 +114,17 @@ class ScrollCancellationTest {
                         }
                         activity.scroll.postOnAnimation(sample)
                     }
-                }, 80)
+                }
+                // A timer can run before any draw on a busy emulator. Wait for
+                // actual native movement, then interrupt outside its callback
+                // so the framework has finished updating its current frame.
+                activity.scroll.installWhiskerPresentationSink { _, _ ->
+                    if (activity.offset > 1_000) {
+                        activity.scroll.installWhiskerPresentationSink(null)
+                        activity.scroll.post(interrupt)
+                    }
+                }
+                activity.startMotion(smooth)
             }
             assertTrue("native frames must complete", completed.await(10, TimeUnit.SECONDS))
             assertTrue("fixture must interrupt moving content: before=$before", before > 1_000)
@@ -130,6 +151,8 @@ class ScrollCancellationTest {
         }
     }
 
+    @Test fun horizontalFlingWaitsForDelayedFirstDraw() = verify(true, true, delayFirstDraw = true)
+    @Test fun verticalFlingWaitsForDelayedFirstDraw() = verify(false, true, delayFirstDraw = true)
     @Test fun horizontalFlingStopsAtDifferentOffset() = verify(true, false)
     @Test fun horizontalFlingStopsAtSameOffset() = verify(true, true)
     @Test fun verticalFlingStopsAtDifferentOffset() = verify(false, false)

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollCancellationTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollCancellationTest.kt
@@ -1,0 +1,145 @@
+package rs.whisker.runtime
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.HorizontalScrollView
+import android.widget.ScrollView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Real traversal is required to exercise scrollToLogicalOffset's posted command. */
+class ScrollCancellationActivity : Activity() {
+    lateinit var scroll: WhiskerScrollContainerView
+    var horizontal = false
+
+    val nativeScroller: View
+        get() = scroll.getChildAt(if (horizontal) 1 else 0)
+
+    val offset: Int
+        get() = if (horizontal) nativeScroller.scrollX else nativeScroller.scrollY
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        horizontal = intent.getBooleanExtra("horizontal", false)
+        scroll = WhiskerScrollContainerView(this)
+        scroll.setScrollOrientation(if (horizontal) "horizontal" else "vertical")
+        scroll.contentView.addView(
+            View(this),
+            ViewGroup.LayoutParams(if (horizontal) 20_000 else 300, if (horizontal) 300 else 20_000),
+        )
+        setContentView(scroll, ViewGroup.LayoutParams(300, 300))
+    }
+
+    fun startMotion(smooth: Boolean) {
+        if (horizontal) {
+            val view = nativeScroller as HorizontalScrollView
+            view.scrollTo(1_000, 0)
+            if (smooth) view.smoothScrollTo(4_000, 0) else view.fling(8_000)
+        } else {
+            val view = nativeScroller as ScrollView
+            view.scrollTo(0, 1_000)
+            if (smooth) view.smoothScrollTo(0, 4_000) else view.fling(8_000)
+        }
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class ScrollCancellationTest {
+    private fun verify(
+        horizontal: Boolean,
+        sameOffset: Boolean,
+        smooth: Boolean = false,
+        requestedOffset: Int? = null,
+        nativeSnap: Boolean = false,
+    ) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val intent = Intent(instrumentation.context, ScrollCancellationActivity::class.java)
+            .putExtra("horizontal", horizontal)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        ActivityScenario.launch<ScrollCancellationActivity>(intent).use { scenario ->
+            instrumentation.waitForIdleSync()
+            val completed = CountDownLatch(1)
+            val samples = mutableListOf<Int>()
+            var before = 0
+            var target = 0
+            scenario.onActivity { activity ->
+                if (nativeSnap) activity.scroll.setItemSnap(0.0, 0.0)
+                activity.startMotion(smooth)
+                activity.scroll.postDelayed({
+                    before = activity.offset
+                    val requested = requestedOffset ?: if (sameOffset) before else 500
+                    val maximum = if (horizontal) {
+                        activity.scroll.contentView.width - activity.nativeScroller.width
+                    } else {
+                        activity.scroll.contentView.height - activity.nativeScroller.height
+                    }
+                    target = requested.coerceIn(0, maximum)
+                    activity.scroll.scrollToLogicalOffset(
+                        requested.toDouble() / activity.resources.displayMetrics.density,
+                        false,
+                    )
+                    // Queued after the real command, then sample subsequent native frames.
+                    activity.scroll.post {
+                        samples.add(activity.offset)
+                        val sample = object : Runnable {
+                            override fun run() {
+                                samples.add(activity.offset)
+                                if (samples.size == 31) completed.countDown()
+                                else activity.scroll.postOnAnimation(this)
+                            }
+                        }
+                        activity.scroll.postOnAnimation(sample)
+                    }
+                }, 80)
+            }
+            assertTrue("native frames must complete", completed.await(10, TimeUnit.SECONDS))
+            assertTrue("fixture must interrupt moving content: before=$before", before > 1_000)
+            assertEquals("Instant must apply the target", target, samples.first())
+            assertTrue(
+                "old motion must not overwrite Instant: target=$target, samples=$samples",
+                samples.all { it == target },
+            )
+            // A visually stationary but still-running scroller would steal the
+            // next DOWN as an animation-interruption gesture instead of a tap.
+            scenario.onActivity { activity ->
+                val now = SystemClock.uptimeMillis()
+                val down = MotionEvent.obtain(now, now, MotionEvent.ACTION_DOWN, 100f, 100f, 0)
+                val cancel = MotionEvent.obtain(now, now, MotionEvent.ACTION_CANCEL, 100f, 100f, 0)
+                try {
+                    val native = activity.nativeScroller as ViewGroup
+                    assertFalse("completed scroll must not intercept a new tap", native.onInterceptTouchEvent(down))
+                    native.onInterceptTouchEvent(cancel)
+                } finally {
+                    down.recycle()
+                    cancel.recycle()
+                }
+            }
+        }
+    }
+
+    @Test fun horizontalFlingStopsAtDifferentOffset() = verify(true, false)
+    @Test fun horizontalFlingStopsAtSameOffset() = verify(true, true)
+    @Test fun verticalFlingStopsAtDifferentOffset() = verify(false, false)
+    @Test fun verticalFlingStopsAtSameOffset() = verify(false, true)
+    @Test fun horizontalSmoothStopsAtSameOffset() = verify(true, true, true)
+    @Test fun verticalSmoothStopsAtSameOffset() = verify(false, true, true)
+    @Test fun horizontalFlingStopsAtClampedStart() = verify(true, false, requestedOffset = -1_000)
+    @Test fun horizontalFlingStopsAtClampedEnd() = verify(true, false, requestedOffset = 30_000)
+    @Test fun verticalFlingStopsAtClampedStart() = verify(false, false, requestedOffset = -1_000)
+    @Test fun verticalFlingStopsAtClampedEnd() = verify(false, false, requestedOffset = 30_000)
+    @Test fun horizontalInstantCancelsPendingSnap() = verify(true, false, nativeSnap = true)
+    @Test fun verticalInstantCancelsPendingSnap() = verify(false, false, nativeSnap = true)
+}

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollEventTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/ScrollEventTest.kt
@@ -1,0 +1,106 @@
+package rs.whisker.runtime
+
+import android.content.Intent
+import android.os.SystemClock
+import android.view.MotionEvent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ScrollEventTest {
+    private fun gesture(horizontal: Boolean, cancel: Boolean = false, clickable: Boolean = false, tap: Boolean = false, atEdge: Boolean = false) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val intent = Intent(instrumentation.context, ScrollCancellationActivity::class.java)
+            .putExtra("horizontal", horizontal).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        ActivityScenario.launch<ScrollCancellationActivity>(intent).use { scenario ->
+            instrumentation.waitForIdleSync()
+            scenario.onActivity { activity ->
+                val events = mutableListOf<Map<String, WhiskerValue>>()
+                activity.scroll.contentView.getChildAt(0).isClickable = clickable
+                activity.scroll.installWhiskerEventSink { name, value ->
+                    if (name == "scroll") events.add((value as WhiskerValue.Map).value)
+                }
+                val now = SystemClock.uptimeMillis()
+                fun send(action: Int, time: Long, position: Float) {
+                    val coordinate = if (atEdge) 300f - position else position
+                    val event = MotionEvent.obtain(now, now + time, action,
+                        if (horizontal) coordinate else 100f, if (horizontal) 100f else coordinate, 0)
+                    activity.scroll.dispatchTouchEvent(event)
+                    event.recycle()
+                }
+                send(MotionEvent.ACTION_DOWN, 0, 250f)
+                if (!tap) {
+                    send(MotionEvent.ACTION_MOVE, 20, 200f)
+                    send(MotionEvent.ACTION_MOVE, 40, 150f)
+                    send(MotionEvent.ACTION_MOVE, 60, 100f)
+                }
+                val countBeforeEnd = events.size
+                send(if (cancel) MotionEvent.ACTION_CANCEL else MotionEvent.ACTION_UP, 70, if (tap) 250f else 75f)
+                if (tap) {
+                    assertTrue("a tap is not a drag", events.isEmpty())
+                } else {
+                    assertEquals("release must notify even without offset movement", countBeforeEnd + 1, events.size)
+                    assertEquals(WhiskerValue.Bool(true), events.first()["isDragging"])
+                    val end = events.last()
+                    assertEquals(WhiskerValue.Bool(false), end["isDragging"])
+                    assertEquals(WhiskerValue.Bool(cancel), end["isDragCancelled"])
+                    assertEquals(WhiskerValue.Float(0.0), end[if (horizontal) "deltaX" else "deltaY"])
+                    val velocity = (end[if (horizontal) "velocityX" else "velocityY"] as WhiskerValue.Float).value
+                    if (cancel) assertEquals(0.0, velocity, 0.0)
+                    else assertEquals((if (atEdge) -2500.0 else 2500.0) / activity.resources.displayMetrics.density, velocity, 150.0)
+                    val positionKey = if (horizontal) "scrollLeft" else "scrollTop"
+                    val deltaKey = if (horizontal) "deltaX" else "deltaY"
+                    var previous = 0.0
+                    for (detail in events) {
+                        val position = (detail[positionKey] as WhiskerValue.Float).value
+                        assertEquals(position - previous, (detail[deltaKey] as WhiskerValue.Float).value, 0.001)
+                        previous = position
+                        if (atEdge) assertEquals("edge gesture must not move content", 0.0, position, 0.001)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test fun verticalEdgeDrag() = gesture(false, atEdge = true)
+    @Test fun horizontalEdgeDrag() = gesture(true, atEdge = true)
+
+    @Test fun programmaticScrollReportsDeltaWithoutDragging() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val intent = Intent(instrumentation.context, ScrollCancellationActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        ActivityScenario.launch<ScrollCancellationActivity>(intent).use { scenario ->
+            instrumentation.waitForIdleSync()
+            val events = mutableListOf<Map<String, WhiskerValue>>()
+            scenario.onActivity { activity ->
+                activity.scroll.installWhiskerEventSink { _, value -> events.add((value as WhiskerValue.Map).value) }
+                activity.scroll.scrollToLogicalOffset(100.0, false)
+            }
+            instrumentation.waitForIdleSync()
+            scenario.onActivity { activity -> activity.scroll.scrollToLogicalOffset(60.0, false) }
+            instrumentation.waitForIdleSync()
+            scenario.onActivity {
+                assertEquals(2, events.size)
+                assertEquals(100.0, (events[0]["deltaY"] as WhiskerValue.Float).value, 1.0)
+                assertEquals(-40.0, (events[1]["deltaY"] as WhiskerValue.Float).value, 1.0)
+                for (event in events) {
+                    assertEquals(WhiskerValue.Bool(false), event["isDragging"])
+                    assertEquals(WhiskerValue.Float(0.0), event["velocityY"])
+                }
+            }
+        }
+    }
+
+    @Test fun verticalDrag() = gesture(false)
+    @Test fun horizontalDrag() = gesture(true)
+    @Test fun interceptClickableChild() = gesture(false, clickable = true)
+    @Test fun interceptHorizontalClickableChild() = gesture(true, clickable = true)
+    @Test fun verticalCancel() = gesture(false, cancel = true)
+    @Test fun horizontalCancel() = gesture(true, cancel = true)
+    @Test fun tapDoesNotEmitDrag() = gesture(false, tap = true)
+}

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/PendingContinuousEvents.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/PendingContinuousEvents.kt
@@ -9,28 +9,61 @@ internal data class PendingElementEvent(
 )
 
 /**
- * Keeps only the newest continuous-event sample for each element.
+ * Coalesces movement samples per element without losing drag transitions.
  *
- * Android can report several scroll offsets while the UI thread is preparing
- * one frame. Rust only needs the newest offset to select the next List window;
- * synchronously reconciling every intermediate sample stalls ScrollView's own
- * input handling.
+ * Android can report several scroll offsets while preparing one frame.
+ * Keeping the newest position avoids reconciling List for every native sample,
+ * but release velocity and drag boundaries must reach Rust in order.
  */
 internal class PendingContinuousEvents {
-    private val events = LinkedHashMap<Pair<Long, String>, PendingElementEvent>()
+    private val events = mutableListOf<PendingElementEvent>()
+    private val latest = mutableMapOf<Pair<Long, String>, Int>()
 
     fun offer(event: PendingElementEvent) {
-        events[event.node to event.name] = event
+        val key = event.node to event.name
+        val index = latest[key]
+        val previous = index?.let { events[it] }
+        val old = (previous?.detail as? WhiskerValue.Map)?.value
+        val next = (event.detail as? WhiskerValue.Map)?.value
+        fun isRelease(detail: Map<String, WhiskerValue>?): Boolean =
+            detail?.get("isDragCancelled") == WhiskerValue.Bool(true) ||
+                listOf("velocityX", "velocityY").any {
+                    ((detail?.get(it) as? WhiskerValue.Float)?.value ?: 0.0) != 0.0
+                }
+
+        if (index != null && old?.get("isDragging") == next?.get("isDragging") &&
+            !isRelease(old) && !isRelease(next)
+        ) {
+            // Deltas describe movement since the last event Rust received, not
+            // just the last native sample retained in this frame.
+            val detail = if (old != null && next != null) {
+                val merged = next.toMutableMap()
+                for (axis in listOf("deltaX", "deltaY")) {
+                    if (axis in old || axis in next) {
+                        merged[axis] = WhiskerValue.Float(
+                            ((old[axis] as? WhiskerValue.Float)?.value ?: 0.0) +
+                                ((next[axis] as? WhiskerValue.Float)?.value ?: 0.0),
+                        )
+                    }
+                }
+                WhiskerValue.Map(merged)
+            } else event.detail
+            events[index] = event.copy(detail = detail)
+        } else {
+            latest[key] = events.size
+            events.add(event)
+        }
     }
 
     fun drain(): List<PendingElementEvent> {
         if (events.isEmpty()) return emptyList()
-        val drained = events.values.toList()
-        events.clear()
+        val drained = events.toList()
+        clear()
         return drained
     }
 
     fun clear() {
         events.clear()
+        latest.clear()
     }
 }

--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -23,6 +23,15 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
     private var snapOffset: CGFloat = 0
     private var snapStopAlways = false
     private var scrollSequenceStart: CGPoint?
+    private var reportingDrag = false
+    private var lastScrollOffset = CGPoint.zero
+    private var releaseVelocity = CGPoint.zero
+
+    public override var isScrollEnabled: Bool {
+        didSet {
+            if !isScrollEnabled { finishDrag(cancelled: true) }
+        }
+    }
 
     public override init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,6 +44,7 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
         automaticallyAdjustsScrollIndicatorInsets = false
         addSubview(contentView)
         delegate = self
+        panGestureRecognizer.addTarget(self, action: #selector(panStateChanged))
     }
 
     public required init?(coder: NSCoder) { nil }
@@ -91,11 +101,44 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
 
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         scrollSequenceStart = contentOffset
+        releaseVelocity = .zero
+        reportingDrag = true
+        emitScroll()
+    }
+
+    @objc private func panStateChanged() {
+        if panGestureRecognizer.state == .cancelled || panGestureRecognizer.state == .failed {
+            finishDrag(cancelled: true)
+        }
+    }
+
+    public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        finishDrag(cancelled: panGestureRecognizer.state == .cancelled || !isScrollEnabled)
+    }
+
+    private func finishDrag(cancelled: Bool) {
+        guard reportingDrag else { return }
+        reportingDrag = false
+        let velocity = cancelled ? CGPoint.zero : releaseVelocity
+        releaseVelocity = .zero
+        emitScroll(velocity: velocity, cancelled: cancelled)
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        emitScroll()
+    }
+
+    private func emitScroll(velocity: CGPoint = .zero, cancelled: Bool = false) {
+        let delta = CGPoint(x: contentOffset.x - lastScrollOffset.x, y: contentOffset.y - lastScrollOffset.y)
+        lastScrollOffset = contentOffset
         presentationSink?(contentOffset)
         eventSink?("scroll", .map([
+            "deltaX": .float(Double(delta.x)),
+            "deltaY": .float(Double(delta.y)),
+            "isDragging": .bool(reportingDrag),
+            "velocityX": .float(Double(velocity.x)),
+            "velocityY": .float(Double(velocity.y)),
+            "isDragCancelled": .bool(cancelled),
             "scrollLeft": .float(Double(contentOffset.x)),
             "scrollTop": .float(Double(contentOffset.y)),
             "scrollWidth": .float(Double(contentSize.width)),
@@ -110,6 +153,9 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
         withVelocity velocity: CGPoint,
         targetContentOffset: UnsafeMutablePointer<CGPoint>
     ) {
+        // UIKit supplies content velocity in points/ms; Whisker uses logical px/s.
+        releaseVelocity = CGPoint(x: horizontal ? velocity.x * 1000 : 0,
+                                  y: horizontal ? 0 : velocity.y * 1000)
         guard let factor = snapFactor, !contentView.subviews.isEmpty else { return }
         let viewport = horizontal ? bounds.width : bounds.height
         let contentExtent = horizontal ? contentSize.width : contentSize.height

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -665,9 +665,78 @@ final class HostConformanceTests: XCTestCase {
             return XCTFail("scroll must emit a map payload")
         }
         XCTAssertEqual(values["scrollTop"], .float(120))
+        XCTAssertEqual(values["deltaY"], .float(120))
+        XCTAssertEqual(values["deltaX"], .float(0))
+        XCTAssertEqual(values["isDragging"], .bool(false))
         XCTAssertEqual(values["viewportHeight"], .float(80))
         XCTAssertEqual(values["scrollHeight"], .float(300))
         XCTAssertEqual(presentedOffset, CGPoint(x: 0, y: 120))
+    }
+
+    func testScrollDragLifecycleAndReleaseVelocityWithoutOffsetChange() {
+        let scroll = WhiskerScrollContainerView(frame: CGRect(x: 0, y: 0, width: 100, height: 80))
+        var events: [[String: WhiskerValue]] = []
+        scroll.installWhiskerEventSink { name, value in
+            if name == "scroll", case let .map(detail) = value { events.append(detail) }
+        }
+        scroll.scrollViewWillBeginDragging(scroll)
+        var target = CGPoint.zero
+        scroll.scrollViewWillEndDragging(scroll, withVelocity: CGPoint(x: 0, y: 0.8), targetContentOffset: &target)
+        scroll.delegate?.scrollViewDidEndDragging?(scroll, willDecelerate: true)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events.first?["isDragging"], .bool(true))
+        XCTAssertEqual(events.last?["isDragging"], .bool(false))
+        XCTAssertEqual(events.last?["deltaY"], .float(0))
+        XCTAssertEqual(events.last?["velocityY"], .float(800))
+        XCTAssertEqual(events.last?["velocityX"], .float(0))
+        XCTAssertEqual(events.last?["isDragCancelled"], .bool(false))
+        scroll.scrollViewDidScroll(scroll)
+        XCTAssertEqual(events.last?["velocityY"], .float(0), "release velocity must not leak into later events")
+    }
+
+    func testHorizontalScrollReleaseAndProgrammaticDelta() {
+        let scroll = WhiskerScrollContainerView(frame: CGRect(x: 0, y: 0, width: 100, height: 80))
+        scroll.setScrollOrientation("horizontal")
+        scroll.contentView.addSubview(UIView(frame: CGRect(x: 0, y: 0, width: 1000, height: 80)))
+        scroll.layoutIfNeeded()
+        var events: [[String: WhiskerValue]] = []
+        scroll.installWhiskerEventSink { _, value in
+            if case let .map(detail) = value { events.append(detail) }
+        }
+        scroll.scrollToLogicalOffset(200, smooth: false)
+        XCTAssertEqual(events.last?["deltaX"], .float(200))
+        XCTAssertEqual(events.last?["isDragging"], .bool(false))
+        scroll.scrollViewWillBeginDragging(scroll)
+        var target = CGPoint(x: 100, y: 0)
+        scroll.scrollViewWillEndDragging(scroll, withVelocity: CGPoint(x: -1.2, y: 0.4), targetContentOffset: &target)
+        scroll.scrollViewDidEndDragging(scroll, willDecelerate: false)
+        XCTAssertEqual(events.last?["velocityX"], .float(-1200))
+        XCTAssertEqual(events.last?["velocityY"], .float(0))
+        scroll.scrollToLogicalOffset(180, smooth: false)
+        XCTAssertEqual(events.last?["deltaX"], .float(-20))
+        XCTAssertEqual(events.last?["velocityX"], .float(0))
+    }
+
+    func testDisablingScrollCancelsDragOnlyOnceAndClearsReleaseVelocity() {
+        let scroll = WhiskerScrollContainerView(frame: .zero)
+        var events: [[String: WhiskerValue]] = []
+        scroll.installWhiskerEventSink { _, value in
+            if case let .map(detail) = value { events.append(detail) }
+        }
+        scroll.scrollViewWillBeginDragging(scroll)
+        var target = CGPoint.zero
+        scroll.scrollViewWillEndDragging(scroll, withVelocity: CGPoint(x: 0, y: 1), targetContentOffset: &target)
+        scroll.isScrollEnabled = false
+        scroll.scrollViewDidEndDragging(scroll, willDecelerate: false)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events.last?["isDragCancelled"], .bool(true))
+        XCTAssertEqual(events.last?["isDragging"], .bool(false))
+        XCTAssertEqual(events.last?["velocityY"], .float(0))
+        scroll.isScrollEnabled = true
+        scroll.scrollViewWillBeginDragging(scroll)
+        scroll.scrollViewDidEndDragging(scroll, willDecelerate: false)
+        XCTAssertEqual(events.last?["isDragCancelled"], .bool(false))
+        XCTAssertEqual(events.last?["velocityY"], .float(0))
     }
 
     func testHiddenScrollViewSuppressesOnlyItsNativeIndicators() throws {


### PR DESCRIPTION
Android's instant `scroll_to` changes the offset while its native scroller can keep running, so an app-driven pager gets overwritten by the old fling. Native `on_scroll` also omits drag state and deltas, and emits nothing when a drag ends without movement. Together these prevent an app from reliably taking over scrolling at release.

This change makes instant Android scroll commands finish the native fling/smooth scroll, including same-offset and clamped targets, and invalidate pending snap checks. It completes Android/iOS `on_scroll` with logical-pixel deltas, drag begin/end notifications, release velocity in logical pixels per second (positive toward increasing content offset), and a cancellation flag. `ScrollDetail` gains defaulted `velocity_x`, `velocity_y`, and `is_drag_cancelled` fields, preserving deserialization of older payloads.

Android keeps frame-level movement coalescing, but preserves drag transitions and release samples and accumulates the deltas of merged samples. Drag recognition follows native interception/scrolling rather than treating every touch as a drag. UIKit release velocity is converted from points/ms to logical pixels/s.

GIGA can implement its own Pager using the existing public scroll handles and `on_scroll`. No Pager or scroll-control API is introduced in Whisker, and Web/Desktop behavior is unchanged.

Validation:
- Android host instrumentation: all 56 tests passed, including 12 instant-scroll regressions, two delayed-first-draw regressions, both axes, edge gestures, clickable-child interception, cancellation, programmatic deltas, and event coalescing.
- iOS host conformance: all 36 tests passed, covering geometry/deltas, stationary release, velocity sign/units, cancellation and stale-velocity reset.
- Rust event tests: all 8 passed, including new payload decoding and legacy defaults.
- `cargo fmt --all --check`, `git diff --check`, and `cargo doc -p whisker --no-deps` with broken intra-doc links denied passed.
- The cancellation fixture waits for actual native movement instead of assuming an 80ms timer follows the first draw. A 160ms draw gate reproduces the CI failure before this fixture fix.
- Regression tests were observed failing before their corresponding fixes. GIGA Pager UX is not exercised by these host tests; its app-side implementation remains separate.

