### PR TITLE
fix(cng): support Android API 36 build tools

### DIFF
--- a/crates/whisker-cng/src/android.rs
+++ b/crates/whisker-cng/src/android.rs
@@ -758,7 +758,7 @@ pub fn inputs_from_with_engine(
         extra_gradle_plugins,
         extra_gradle_dependencies,
         extra_files,
-        template_version: 35,
+        template_version: 36,
     })
 }
 
@@ -1106,11 +1106,56 @@ mod tests {
         let out = tmp.join("gen/android");
         sync(&out, &sample_inputs()).unwrap();
         let mut next = sample_inputs();
-        next.target_sdk = 35;
+        next.target_sdk = 36;
         let regenerated = sync(&out, &next).unwrap();
         assert!(regenerated);
         let app_gradle = std::fs::read_to_string(out.join("app/build.gradle.kts")).unwrap();
-        assert!(app_gradle.contains("compileSdk = 35"));
+        assert!(app_gradle.contains("compileSdk = 36"));
+        assert!(app_gradle.contains("targetSdk = 36"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sync_upgrades_cached_android_build_tools() {
+        let mut config = Config::default();
+        config.name("HelloWorld").bundle_id("rs.whisker.hello");
+        let inputs = inputs_from(
+            &config,
+            "hello_world".into(),
+            PathBuf::from("../.."),
+            "hello-world".into(),
+            "0.1.0".into(),
+            "0.1.0".into(),
+            "https://example.invalid/maven".into(),
+        )
+        .unwrap();
+        let mut previous = inputs.clone();
+        previous.template_version = 35;
+        let tmp = unique_tempdir();
+        let out = tmp.join("gen/android");
+        sync(&out, &previous).unwrap();
+        let build = out.join("build.gradle.kts");
+        let wrapper = out.join("gradle/wrapper/gradle-wrapper.properties");
+        std::fs::write(&build, ROOT_BUILD_GRADLE_KTS.replace("8.10.1", "8.6.1")).unwrap();
+        std::fs::write(
+            &wrapper,
+            std::fs::read_to_string(&wrapper)
+                .unwrap()
+                .replace("8.11.1", "8.10.2"),
+        )
+        .unwrap();
+
+        assert!(sync(&out, &inputs).unwrap());
+        let build = std::fs::read_to_string(build).unwrap();
+        assert!(build.contains("id(\"com.android.application\") version \"8.10.1\""));
+        assert!(build.contains("id(\"com.android.library\") version \"8.10.1\""));
+        assert!(
+            std::fs::read_to_string(wrapper)
+                .unwrap()
+                .contains("gradle-8.11.1-bin.zip")
+        );
+        assert!(!sync(&out, &inputs).unwrap());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/whisker-cng/src/templates/android/build.gradle.kts
+++ b/crates/whisker-cng/src/templates/android/build.gradle.kts
@@ -1,8 +1,8 @@
 // Root build file. Module-specific configuration in app/build.gradle.kts.
 
 plugins {
-    id("com.android.application") version "8.6.1" apply false
-    id("com.android.library") version "8.6.1" apply false
+    id("com.android.application") version "8.10.1" apply false
+    id("com.android.library") version "8.10.1" apply false
     id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }
 

--- a/crates/whisker-cng/src/templates/android/gradle/wrapper/gradle-wrapper.properties
+++ b/crates/whisker-cng/src/templates/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Generated Android projects still use AGP 8.6.1, which supports API 35. Apps targeting API 36 need a supported build toolchain to satisfy the current Play target SDK requirement.

Update the CNG template to AGP 8.10.1 and Gradle 8.11.1, retaining Kotlin 2.0.21 and the published Whisker Gradle plugin/SDK pins. Bump the Android template version so cached projects regenerate even when the app configuration has not changed.

Validation:
- Regression coverage upgrades a cached template-version-35 project and verifies subsequent sync is a no-op. Generation coverage verifies API 36 is applied to both compileSdk and targetSdk.
- Local CNG unit tests: 143 passed; CLI build passed.
- All CI jobs passed, including test, fmt, clippy, coverage and Android/iOS host conformance.
- GIGA consumer: this CLI regenerated template version 36, built/installed/launched Android debug with hot patching enabled, and built a release AAB using published Gradle plugin 0.5.0 / Android SDK 0.1.23.
- bundletool validation passed. The actual AAB manifest contains compile/target SDK 36, versionCode 26, minSdk 24 and Billing 8.0.0 (RevenueCat 9.29.1).
- The consumer AAB is unsigned because the local signing identity is unavailable; Play purchase/restore validation remains for internal testing.

Consumer change: https://github.com/chantoinc/giga/pull/3. Only the Rust/CLI release stream is needed for these template changes.
