### PR TITLE
fix(ios): allow compiler macros in headless dev builds

### DIFF
--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -548,11 +548,9 @@ async fn ios_install_and_launch(
         .args(["-destination", "generic/platform=iOS Simulator"])
         .arg("-derivedDataPath")
         .arg(&derived)
-        // The WhiskerModuleCodegenPlugin is a SwiftPM build-tool plugin;
-        // Xcode gates plugins behind an interactive trust prompt a
-        // headless build can't answer, so skip validation (it ships from
-        // Whisker's own `whisker` SPM package).
+        // Whisker's codegen plugin and compiler macros have separate trust prompts that headless builds cannot answer.
         .arg("-skipPackagePluginValidation")
+        .arg("-skipMacroValidation")
         .args(["-quiet", "build"]);
     // No `WHISKER_IOS_RUNTIME` / `WHISKER_IOS_MACROS` injection:
     // WhiskerRuntime and the codegen plugin resolve from the remote


### PR DESCRIPTION
`cargo whisker run ios` fails before compilation when Xcode has not approved `WhiskerModuleMacros`: “Macro ‘WhiskerModuleMacros’ from package ‘Whisker’ must be enabled before it can be used.” The dev installer already skips package-plugin validation, but compiler macros have a separate approval gate.

Pass `-skipMacroValidation` to the dev installer's `xcodebuild` invocation, matching the existing `whisker build` behavior. This applies to that build invocation; it does not change global Xcode preferences.

Validation:
- Reproduced the macro approval failure with GIGA's generated iOS project.
- Installed the patched CLI and ran `cargo whisker run ios --no-tui`: both Rust simulator architectures compiled, Xcode built the app, and installation and launch succeeded on the iPhone 17 Pro simulator. The dev client connected successfully.
- `cargo fmt --all --check` and `git diff --check` passed.
