### PR TITLE
fix(ios): keep overflow clipping aligned during native scrolling

### DIFF
--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -1,6 +1,11 @@
 import UIKit
 import WhiskerModule
 
+private final class OverflowMaskLayer: CAShapeLayer {
+    // The clipping viewport must track native scrolling without implicit interpolation.
+    override func action(forKey event: String) -> CAAction? { nil }
+}
+
 /// Common iOS wrapper for every built-in or custom Whisker element.
 ///
 /// The scene owner controls hierarchy and geometry. Element modules only own
@@ -13,7 +18,7 @@ final class WhiskerNodeView: UIView {
     var mountedElement: WhiskerMountedElement?
     private let defaultChildrenHost = WhiskerChildrenHostView(frame: .zero)
     private lazy var paintView = HostNodePaintView(painter: boxPainter)
-    private let overflowMask = CAShapeLayer()
+    private let overflowMask = OverflowMaskLayer()
     private var overflowMaskScrollOrigin = CGPoint.zero
     private var overflowMaskCompositionBounds = CGRect.zero
     private var ancestorScrollObservations: [NSKeyValueObservation] = []

--- a/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/HostConformanceTests.swift
@@ -6,6 +6,13 @@ import WhiskerCBridge
 @testable import WhiskerModule
 import XCTest
 
+private final class ClipAnimationProbe: NSObject, CAAction {
+    var events: [String] = []
+    func run(forKey event: String, object: Any, arguments: [AnyHashable: Any]?) {
+        events.append(event)
+    }
+}
+
 private final class EventLifecycleTestModule: Module {
     var starts = 0
     var stops = 0
@@ -840,8 +847,15 @@ final class HostConformanceTests: XCTestCase {
         XCTAssertNil(scrollView.contentView.layer.mask)
         XCTAssertGreaterThan(scrollView.contentSize.height, scrollView.bounds.height)
 
+        let mask = try XCTUnwrap(scrollView.layer.mask)
+        let animation = ClipAnimationProbe()
+        mask.actions = ["position": animation, "bounds": animation, "path": animation]
+        CATransaction.begin()
+        CATransaction.setDisableActions(false)
         scrollView.contentOffset = CGPoint(x: 0, y: 100)
         scrollView.layoutIfNeeded()
+        CATransaction.commit()
+        XCTAssertTrue(animation.events.isEmpty, "viewport clipping must follow scrolling immediately: \(animation.events)")
         XCTAssertTrue(scrollView.layer.mask != nil)
         XCTAssertNil(scrollView.contentView.layer.mask)
         XCTAssertEqual(scrollView.layer.mask?.frame.minY, scrollView.bounds.minY)
@@ -860,8 +874,14 @@ final class HostConformanceTests: XCTestCase {
         let mask = try XCTUnwrap(node.sceneChildrenHost().layer.mask)
         let initialY = mask.frame.minY
 
+        let animation = ClipAnimationProbe()
+        mask.actions = ["position": animation, "bounds": animation, "path": animation]
+        CATransaction.begin()
+        CATransaction.setDisableActions(false)
         scrollView.contentOffset = CGPoint(x: 0, y: 60)
+        CATransaction.commit()
 
+        XCTAssertTrue(animation.events.isEmpty, "ancestor scrolling must not animate the clipping viewport: \(animation.events)")
         XCTAssertEqual(mask.frame.minY, initialY + 60, accuracy: 0.001)
     }
 


### PR DESCRIPTION
Scrolling an iOS ScrollView/List can temporarily hide content at the newly exposed edge, then gradually reveal it. The content moves correctly, but implicit Core Animation actions on the overflow mask's position make the clipping viewport lag behind the native scroll offset.

Use a dedicated overflow mask layer that suppresses implicit actions so its geometry follows scrolling immediately. This covers both the scroll view's own offset and ancestor scrolling for single-axis overflow clipping. Scroll physics and list virtualization are unchanged.

Extend the existing clipping tests with action probes to verify that real scroll-offset updates do not trigger implicit animations while preserving the expected mask coordinates.

Validation:
- Both regression cases failed before the fix with an unexpected `position` action: direct scrolling and ancestor scrolling.
- All 36 iOS Host conformance tests passed after the fix on the simulator.
- Reproduced the visual clipping lag in GIGA using XCTest-driven scroll gestures and recorded video. Built and installed GIGA with the fix and confirmed that the clipping viewport no longer trails the content using the same gestures.
- Restored the dependency checkout used for temporary GIGA verification and stopped the verification runner.
- `git diff --check` passed.
