### PR TITLE
fix(ios): include descendant overflow in native scroll ranges

### DIFF
--- a/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
+++ b/platforms/ios/Sources/WhiskerModule/WhiskerBuiltInElements.swift
@@ -17,6 +17,10 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
     public let contentView = WhiskerContainerView(frame: .zero)
     private var eventSink: ((String, WhiskerValue) -> Void)?
     private var presentationSink: ((CGPoint) -> Void)?
+    private var contentExtentSource: (() -> CGSize)?
+    private var cachedContentExtent = CGSize.zero
+    private var contentExtentNeedsUpdate = true
+    private var previousChildExtent = CGRect.null
     private var horizontal = false
     private var chromeVisible = true
     private var snapFactor: CGFloat?
@@ -56,6 +60,17 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
     /** Installs the Host-internal scroll mirror, independent of app listeners. */
     public func installWhiskerPresentationSink(_ sink: ((CGPoint) -> Void)?) {
         presentationSink = sink
+    }
+
+    /// Installs the Host's overflow measurement without exposing its scene wrappers to native modules.
+    public func installWhiskerContentExtentSource(_ source: (() -> CGSize)?) {
+        contentExtentSource = source
+        invalidateWhiskerContentExtent()
+    }
+
+    public func invalidateWhiskerContentExtent() {
+        contentExtentNeedsUpdate = true
+        setNeedsLayout()
     }
 
     public func setScrollOrientation(_ value: String) {
@@ -187,12 +202,26 @@ public final class WhiskerScrollContainerView: UIScrollView, UIScrollViewDelegat
 
     public override func layoutSubviews() {
         super.layoutSubviews()
-        let extent = contentView.subviews.reduce(CGRect.zero) { result, child in
+        let directExtent = contentView.subviews.reduce(CGRect.zero) { result, child in
             result.union(child.frame)
         }
+        if directExtent != previousChildExtent {
+            previousChildExtent = directExtent
+            contentExtentNeedsUpdate = true
+        }
+        let extent: CGSize
+        if let contentExtentSource {
+            if contentExtentNeedsUpdate {
+                contentExtentNeedsUpdate = false
+                cachedContentExtent = contentExtentSource()
+            }
+            extent = cachedContentExtent
+        } else {
+            extent = CGSize(width: directExtent.maxX, height: directExtent.maxY)
+        }
         let size = CGSize(
-            width: max(bounds.width, extent.maxX),
-            height: max(bounds.height, extent.maxY)
+            width: max(bounds.width, extent.width),
+            height: max(bounds.height, extent.height)
         )
         contentSize = size
         contentView.frame = CGRect(origin: .zero, size: size)

--- a/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/scene/HostNodeView.swift
@@ -104,8 +104,14 @@ final class WhiskerNodeView: UIView {
         }
     }
 
+    override func willMove(toSuperview newSuperview: UIView?) {
+        invalidateAncestorScrollExtent()
+        super.willMove(toSuperview: newSuperview)
+    }
+
     override func didMoveToSuperview() {
         super.didMoveToSuperview()
+        invalidateAncestorScrollExtent()
         updateAncestorScrollObservations()
         updateOverflowMask()
     }
@@ -143,6 +149,7 @@ final class WhiskerNodeView: UIView {
         updateBackdropBlurGeometry()
         updateOverflowMask()
         updateClipPathMask()
+        invalidateAncestorScrollExtent()
     }
 
     func setPresentationTransform(_ values: UnsafeBufferPointer<Float>) {
@@ -165,6 +172,7 @@ final class WhiskerNodeView: UIView {
         transform.m43 = CGFloat(values[14])
         transform.m44 = CGFloat(values[15])
         layer.transform = transform
+        invalidateAncestorScrollExtent()
     }
 
     func setOverflowClip(horizontal: Bool, vertical: Bool) {
@@ -173,6 +181,7 @@ final class WhiskerNodeView: UIView {
         clipsToBounds = false
         updateAncestorScrollObservations()
         updateOverflowMask()
+        invalidateAncestorScrollExtent()
     }
 
     func sceneChildrenHost() -> UIView {
@@ -182,6 +191,10 @@ final class WhiskerNodeView: UIView {
     func mountedContentDidInstall() {
         mountedElement?.view.layer.zPosition = 2
         bringSubviewToFront(defaultChildrenHost)
+        (mountedElement?.view as? WhiskerScrollContainerView)?
+            .installWhiskerContentExtentSource { [weak self] in
+                self?.scrollableChildrenExtent() ?? .zero
+            }
         scrollOffsetObservation = (mountedElement?.view as? UIScrollView)?.observe(
             \.contentOffset,
             options: [.new]
@@ -189,6 +202,46 @@ final class WhiskerNodeView: UIView {
             self?.updateOverflowMaskPosition(scrollView)
         }
         updateOverflowMask()
+    }
+
+    private func invalidateAncestorScrollExtent() {
+        var ancestor = superview
+        while let current = ancestor {
+            if let scroll = current as? WhiskerScrollContainerView {
+                scroll.invalidateWhiskerContentExtent()
+                return
+            }
+            ancestor = current.superview
+        }
+    }
+
+    private func scrollableChildrenExtent() -> CGSize {
+        let host = sceneChildrenHost()
+        var right: CGFloat = 0
+        var bottom: CGFloat = 0
+        for child in host.subviews {
+            let childBounds = (child as? WhiskerNodeView)?.scrollableOverflowBounds() ?? child.bounds
+            let extent = child.convert(childBounds, to: host)
+            right = max(right, extent.maxX)
+            bottom = max(bottom, extent.maxY)
+        }
+        return CGSize(width: right, height: bottom)
+    }
+
+    private func scrollableOverflowBounds() -> CGRect {
+        // Nested scroll contents belong to their own viewport, not the outer scroll range.
+        guard !(mountedElement?.view is UIScrollView) else { return bounds }
+        layoutIfNeeded()
+        let extent = scrollableChildrenExtent()
+        let host = sceneChildrenHost()
+        let rect = host.convert(CGRect(origin: .zero, size: extent), to: self)
+        return CGRect(
+            origin: bounds.origin,
+            size: CGSize(
+                width: clipsOverflowHorizontally ? bounds.width : max(bounds.width, rect.maxX - bounds.minX),
+                height: clipsOverflowVertically ? bounds.height : max(bounds.height, rect.maxY - bounds.minY)
+            )
+        )
     }
 
     func boxPaintDidChange() {

--- a/platforms/ios/Tests/WhiskerHostConformance/ScrollOverflowTests.swift
+++ b/platforms/ios/Tests/WhiskerHostConformance/ScrollOverflowTests.swift
@@ -1,0 +1,109 @@
+import UIKit
+import XCTest
+@testable import WhiskerModule
+@testable import WhiskerRuntime
+
+extension HostConformanceTests {
+    private func scrollNode() throws -> (WhiskerNodeView, WhiskerScrollContainerView) {
+        let registration = WhiskerElementRegistration(
+            elementType: 3,
+            name: WhiskerBuiltInElements.scrollViewName,
+            childPolicy: .elements,
+            measurement: .none,
+            properties: [
+                WhiskerPropertyBinding(id: 1, name: "scroll-orientation", value: .string),
+                WhiskerPropertyBinding(id: 2, name: "item-snap", value: .map),
+                WhiskerPropertyBinding(id: 3, name: "scroll-snap-stop", value: .string),
+                WhiskerPropertyBinding(id: 4, name: "enable-scroll", value: .bool),
+            ],
+            events: [WhiskerEventBinding(id: 1, name: "scroll", detail: .map)],
+            commands: [
+                WhiskerCommandBinding(id: 1, name: "scrollTo", arguments: .map),
+                WhiskerCommandBinding(id: 2, name: "scrollBy", arguments: .map),
+            ]
+        )
+        XCTAssertTrue(WhiskerElementRegistry.bind([registration]))
+        let mounted = try XCTUnwrap(WhiskerElementRegistry.mount(3) { _, _ in })
+        let scroll = try XCTUnwrap(mounted.view as? WhiskerScrollContainerView)
+        let node = WhiskerNodeView(element: registration.name)
+        node.mountedElement = mounted
+        node.addSubview(scroll)
+        node.contentFrame = CGRect(x: 0, y: 0, width: 300, height: 200)
+        node.setLayoutFrame(node.contentFrame)
+        node.mountedContentDidInstall()
+        node.layoutIfNeeded()
+        scroll.setScrollOrientation("horizontal")
+        return (node, scroll)
+    }
+
+    private func row(in scroll: WhiskerScrollContainerView) -> (WhiskerNodeView, WhiskerNodeView) {
+        let row = WhiskerNodeView(element: WhiskerBuiltInElements.viewName)
+        row.setLayoutFrame(CGRect(x: 0, y: 0, width: 300, height: 200))
+        scroll.contentView.addSubview(row)
+        let card = WhiskerNodeView(element: WhiskerBuiltInElements.viewName)
+        row.sceneChildrenHost().addSubview(card)
+        card.setLayoutFrame(CGRect(x: 240, y: 0, width: 200, height: 200))
+        return (row, card)
+    }
+
+    @objc func testHorizontalRangeIncludesCardsOverflowingViewportSizedRow() throws {
+        let (node, scroll) = try scrollNode()
+        let (_, card) = row(in: scroll)
+        withExtendedLifetime(node) {
+            scroll.layoutIfNeeded()
+            XCTAssertEqual(scroll.contentSize.width, 440)
+            card.setLayoutFrame(CGRect(x: 400, y: 0, width: 200, height: 200))
+            scroll.layoutIfNeeded()
+            XCTAssertEqual(scroll.contentSize.width, 600)
+            card.removeFromSuperview()
+            scroll.layoutIfNeeded()
+            XCTAssertEqual(scroll.contentSize.width, 300)
+        }
+    }
+
+    @objc func testOverflowClipLimitsOnlyItsOwnAxis() throws {
+        let (node, scroll) = try scrollNode()
+        let (row, _) = row(in: scroll)
+        withExtendedLifetime(node) {
+            row.setOverflowClip(horizontal: false, vertical: true)
+            scroll.layoutIfNeeded()
+            XCTAssertEqual(scroll.contentSize.width, 440)
+            row.setOverflowClip(horizontal: true, vertical: false)
+            scroll.layoutIfNeeded()
+            XCTAssertEqual(scroll.contentSize.width, 300)
+        }
+    }
+
+    @objc func testNativeScrollingDoesNotRemeasureDescendantGeometry() {
+        let scroll = WhiskerScrollContainerView(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
+        var measurements = 0
+        scroll.installWhiskerContentExtentSource {
+            measurements += 1
+            return CGSize(width: 1000, height: 200)
+        }
+        scroll.layoutIfNeeded()
+        let initial = measurements
+        XCTAssertGreaterThan(initial, 0)
+        for x in stride(from: 10, through: 200, by: 10) {
+            scroll.contentOffset.x = CGFloat(x)
+            scroll.layoutIfNeeded()
+        }
+        XCTAssertEqual(measurements, initial)
+    }
+
+    @objc func testNestedScrollContentDoesNotExpandOuterViewport() throws {
+        let (outerNode, outerScroll) = try scrollNode()
+        let (innerNode, innerScroll) = try scrollNode()
+        outerScroll.contentView.addSubview(innerNode)
+        _ = row(in: innerScroll)
+        withExtendedLifetime(outerNode) {
+            innerScroll.layoutIfNeeded()
+            outerScroll.layoutIfNeeded()
+            XCTAssertEqual(innerScroll.contentSize.width, 440)
+            XCTAssertEqual(outerScroll.contentSize.width, 300)
+            innerScroll.contentOffset.x = 100
+            outerScroll.layoutIfNeeded()
+            XCTAssertEqual(outerScroll.contentSize.width, 300)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fix horizontal scrolling on iOS when fixed-width cards overflow a viewport-width wrapper, as in GIGA's Home reading history. The native scroll view previously measured only direct child frames, leaving its content width equal to the viewport and preventing scrolling.

Measure visible descendant overflow through the runtime host, respecting per-axis clipping and nested scroll view boundaries. Cache the measured extent and invalidate it when scene geometry or children change, so scrolling itself does not repeatedly traverse descendants.

## Validation

- Reproduced the failure in GIGA with an iOS Simulator UI test: a horizontal drag left the history card at the same position before the fix.
- The same test passes with the fix; the card moves horizontally and the native content width increases from 402 pt to approximately 1276 pt.
- All 40 iOS Host conformance tests pass, including regressions for descendant overflow, geometry/removal invalidation, per-axis clipping, nested scrolling, and cached measurement during scrolling.
- `git diff --check` passes.

The GIGA verification build also included the separate viewport mask animation fix from #688. This PR contains only the scroll content extent fix.
