### PR TITLE
fix: enforce Owner lifetimes for tasks, callbacks, and runtime caches

### DIFF
--- a/crates/whisker-animation/src/controller.rs
+++ b/crates/whisker-animation/src/controller.rs
@@ -53,6 +53,8 @@ enum Dir {
     Backward,
 }
 
+type FinishCallback = whisker_runtime::lifetime::Scoped<Box<dyn FnMut(bool)>>;
+
 /// Mutable controller state, shared between the [`AnimationController`]
 /// handle, the scheduler's active list, and the registered cleanup.
 struct ControllerState {
@@ -97,7 +99,7 @@ struct ControllerState {
     /// when it was stopped or interrupted by a new run (Reanimated's
     /// completion callback). Callbacks are `FnMut` and stay registered
     /// across runs.
-    on_finish: Vec<Box<dyn FnMut(bool)>>,
+    on_finish: Vec<FinishCallback>,
 }
 
 impl ControllerState {
@@ -239,8 +241,9 @@ impl ControllerState {
     fn fire_on_finish(&mut self, finished: bool) {
         let mut cbs = std::mem::take(&mut self.on_finish);
         for cb in cbs.iter_mut() {
-            cb(finished);
+            cb.with_mut(|cb| cb(finished));
         }
+        cbs.retain(|cb| cb.is_active());
         // Preserve any callbacks a re-entrant run may have registered.
         if self.on_finish.is_empty() {
             self.on_finish = cbs;
@@ -671,10 +674,12 @@ impl AnimationController {
     /// reached its target naturally, `false` when it was cancelled by
     /// [`stop`](Self::stop) or interrupted by a new run (Reanimated's
     /// completion callback). Callbacks are `FnMut`, accumulate, and stay
-    /// registered across runs. Owner-dispose does **not** fire them (it is
-    /// teardown, not a logical cancel).
+    /// registered across runs until the registering Owner is disposed, which cancels them silently.
     pub fn on_finish(&self, cb: impl FnMut(bool) + 'static) {
-        self.state.borrow_mut().on_finish.push(Box::new(cb));
+        self.state
+            .borrow_mut()
+            .on_finish
+            .push(whisker_runtime::lifetime::Scoped::new(Box::new(cb)));
     }
 
     /// Run forward to `1.0`, then restart from `0.0` and run forward

--- a/crates/whisker-animation/src/tests.rs
+++ b/crates/whisker-animation/src/tests.rs
@@ -920,3 +920,23 @@ fn step_survives_active_controller_with_freed_value_node() {
     let _ = ctrl;
     owner.dispose();
 }
+
+#[test]
+fn on_finish_does_not_outlive_its_registering_owner() {
+    fresh();
+    let parent = Owner::new(None);
+    let child = Owner::new(Some(parent));
+    let controller = parent.with(|| AnimationController::new(AnimConfig::linear(100)));
+    child.with(|| {
+        let signal = whisker_runtime::reactive::RwSignal::new(42);
+        controller.on_finish(move |_| {
+            let _ = signal.get();
+        });
+    });
+    child.dispose();
+    controller.forward();
+    __step_for_tests(0.0);
+    __step_for_tests(100.0);
+    assert_eq!(controller.value().get(), 1.0);
+    parent.dispose();
+}

--- a/crates/whisker-runtime/src/lib.rs
+++ b/crates/whisker-runtime/src/lib.rs
@@ -20,6 +20,8 @@ mod dispatch;
 pub mod element;
 mod element_registry;
 pub mod event;
+#[doc(hidden)]
+pub mod lifetime;
 pub mod module;
 pub mod reactive;
 mod runtime_context;

--- a/crates/whisker-runtime/src/lifetime.rs
+++ b/crates/whisker-runtime/src/lifetime.rs
@@ -1,0 +1,272 @@
+use crate::reactive::{Owner, try_with_runtime, with_runtime};
+use slotmap::DefaultKey;
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
+
+pub struct Scoped<T: 'static> {
+    inner: Rc<Registered<T>>,
+}
+struct Registered<T> {
+    owner: Owner,
+    runtime: Weak<()>,
+    key: Cell<Option<DefaultKey>>,
+    active: Cell<bool>,
+    value: RefCell<Option<T>>,
+}
+
+trait Cancel {
+    fn cancel(&self);
+    fn is_active(&self) -> bool;
+}
+#[derive(Clone)]
+pub struct Cancellation(Weak<dyn Cancel>);
+impl Cancellation {
+    pub fn is_active(&self) -> bool {
+        self.0.upgrade().is_some_and(|value| value.is_active())
+    }
+    pub fn cancel(&self) {
+        if let Some(value) = self.0.upgrade() {
+            value.cancel();
+        }
+    }
+    pub fn is_live(&self) -> bool {
+        self.0.strong_count() != 0
+    }
+}
+impl<T> Registered<T> {
+    fn unregister(&self) {
+        try_with_runtime(|rt| {
+            if self.runtime.ptr_eq(&Rc::downgrade(&rt.identity)) {
+                if let (Some(owner), Some(key)) = (rt.owners.get_mut(self.owner), self.key.take()) {
+                    owner.registrations.remove(key);
+                }
+            }
+        });
+    }
+    fn release_cancelled(&self) {
+        if !self.active.get() {
+            let removed = self
+                .value
+                .try_borrow_mut()
+                .ok()
+                .and_then(|mut value| value.take());
+            drop(removed);
+        }
+    }
+}
+impl<T> Cancel for Registered<T> {
+    fn is_active(&self) -> bool {
+        self.active.get()
+            && with_runtime(|rt| {
+                !rt.shutting_down
+                    && self.runtime.ptr_eq(&Rc::downgrade(&rt.identity))
+                    && rt
+                        .owners
+                        .get(self.owner)
+                        .is_some_and(|scope| !scope.closing)
+            })
+    }
+
+    fn cancel(&self) {
+        self.active.set(false);
+        self.unregister();
+        self.release_cancelled();
+    }
+}
+impl<T> Drop for Registered<T> {
+    fn drop(&mut self) {
+        self.unregister();
+    }
+}
+impl<T: 'static> Clone for Scoped<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+impl<T: 'static> Scoped<T> {
+    pub fn new(value: T) -> Self {
+        let owner = Owner::current().unwrap_or_else(Owner::service);
+        let inner = Rc::new(Registered {
+            owner,
+            runtime: with_runtime(|rt| Rc::downgrade(&rt.identity)),
+            key: Cell::new(None),
+            active: Cell::new(true),
+            value: RefCell::new(Some(value)),
+        });
+        let weak = Rc::downgrade(&inner);
+        let key = with_runtime(|rt| {
+            assert!(
+                !rt.shutting_down,
+                "cannot register work during runtime shutdown"
+            );
+            let scope = rt
+                .owners
+                .get_mut(owner)
+                .expect("cannot register work in a disposed owner");
+            assert!(!scope.closing, "cannot register work in a closing owner");
+            scope.registrations.insert(Box::new(move || {
+                if let Some(value) = weak.upgrade() {
+                    value.cancel();
+                }
+            }))
+        });
+        inner.key.set(Some(key));
+        Self { inner }
+    }
+    pub fn is_active(&self) -> bool {
+        self.inner.is_active()
+    }
+    pub fn cancel(&self) {
+        self.inner.cancel();
+    }
+    pub fn cancellation(&self) -> Cancellation {
+        let inner: Rc<dyn Cancel> = self.inner.clone();
+        Cancellation(Rc::downgrade(&inner))
+    }
+    pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
+        if !self.is_active() {
+            return None;
+        }
+        let _execution = Execution::enter();
+        let _release = ReleaseCancelled(&self.inner);
+        self.inner
+            .owner
+            .with(|| self.inner.value.borrow().as_ref().map(f))
+    }
+    pub fn with_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> Option<R> {
+        if !self.is_active() {
+            return None;
+        }
+        let _execution = Execution::enter();
+        let _release = ReleaseCancelled(&self.inner);
+        self.inner
+            .owner
+            .with(|| self.inner.value.borrow_mut().as_mut().map(f))
+    }
+}
+struct ReleaseCancelled<'a, T>(&'a Registered<T>);
+impl<T> Drop for ReleaseCancelled<'_, T> {
+    fn drop(&mut self) {
+        self.0.release_cancelled();
+    }
+}
+
+pub(crate) struct Execution;
+impl Execution {
+    pub(crate) fn enter() -> Self {
+        with_runtime(|rt| rt.execution_depth += 1);
+        Self
+    }
+}
+impl Drop for Execution {
+    fn drop(&mut self) {
+        let ready = with_runtime(|rt| {
+            rt.execution_depth -= 1;
+            rt.execution_depth == 0
+        });
+        if ready {
+            Owner::drain_disposals();
+        }
+    }
+}
+
+pub struct OwnedOwner {
+    owner: Owner,
+    runtime: Weak<()>,
+    dispatcher: Option<crate::RuntimeDispatcher>,
+}
+
+impl OwnedOwner {
+    pub fn new() -> Self {
+        Self {
+            owner: Owner::detached_root(),
+            runtime: with_runtime(|rt| Rc::downgrade(&rt.identity)),
+            dispatcher: crate::runtime_dispatcher(),
+        }
+    }
+
+    pub fn with<R>(&self, f: impl FnOnce() -> R) -> R {
+        self.owner.with(f)
+    }
+}
+
+impl Default for OwnedOwner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for OwnedOwner {
+    fn drop(&mut self) {
+        let current = try_with_runtime(|rt| self.runtime.ptr_eq(&Rc::downgrade(&rt.identity)))
+            .unwrap_or(false);
+        if current {
+            self.owner.dispose();
+        } else if self.runtime.upgrade().is_some() {
+            if let Some(dispatcher) = &self.dispatcher {
+                let owner = self.owner;
+                dispatcher.post(move || owner.dispose());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RuntimeContext, RuntimeWakeHandle};
+
+    #[test]
+    fn completed_and_cancelled_registrations_do_not_accumulate() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let owner = Owner::new(None);
+            owner.with(|| {
+                for _ in 0..1000 {
+                    crate::tasks::spawn_local(async {});
+                }
+            });
+            crate::tasks::run_until_stalled();
+            assert_eq!(with_runtime(|rt| rt.owners[owner].registrations.len()), 0);
+            owner.with(|| {
+                for _ in 0..1000 {
+                    let callback = Scoped::new(|| {});
+                    callback.cancel();
+                }
+            });
+            assert_eq!(with_runtime(|rt| rt.owners[owner].registrations.len()), 0);
+        });
+    }
+
+    #[test]
+    fn cancelling_a_pending_task_releases_its_pool_entry_without_an_external_wake() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let owner = Owner::new(None);
+            let task = owner.with(|| crate::tasks::spawn_cancelable(std::future::pending()));
+            crate::tasks::run_until_stalled();
+            owner.dispose();
+            crate::tasks::run_until_stalled();
+            assert!(!task.is_live());
+        });
+    }
+
+    #[test]
+    fn explicit_cancellation_inside_a_callback_releases_it_after_return() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let owner = Owner::new(None);
+            let value = Rc::new(());
+            let callback = owner.with(|| Scoped::new(value.clone()));
+            let cancel = callback.cancellation();
+            callback.with(|_| {
+                cancel.cancel();
+                assert!(!callback.is_active());
+                assert_eq!(Rc::strong_count(&value), 2);
+            });
+            assert_eq!(Rc::strong_count(&value), 1);
+        });
+    }
+}

--- a/crates/whisker-runtime/src/module.rs
+++ b/crates/whisker-runtime/src/module.rs
@@ -73,6 +73,15 @@ impl ModuleHost {
     {
         let id = self.next_listener.get();
         self.next_listener.set(id.saturating_add(1));
+        let cleanup = ModuleSubscription {
+            id,
+            host: Rc::downgrade(self),
+            error: None,
+        };
+        let scoped = crate::lifetime::Scoped::new((callback, cleanup));
+        let callback = move |value| {
+            scoped.with(|(callback, _)| callback(value));
+        };
         let first = {
             let mut listeners = self.listeners.borrow_mut();
             let first = !listeners
@@ -99,19 +108,18 @@ impl ModuleHost {
     }
 
     fn remove_listener(&self, id: i32) {
-        let last = {
-            let mut listeners = self.listeners.borrow_mut();
-            let Some(removed) = listeners.remove(&id) else {
-                return;
-            };
-            (!listeners.values().any(|listener| {
-                listener.module == removed.module && listener.event == removed.event
-            }))
-            .then_some((removed.module, removed.event))
+        let removed = self.listeners.borrow_mut().remove(&id);
+        let Some(removed) = removed else {
+            return;
         };
-        if let Some((module, event)) = last {
-            (self.observe)(&module, &event, false);
+        let last =
+            !self.listeners.borrow().values().any(|listener| {
+                listener.module == removed.module && listener.event == removed.event
+            });
+        if last {
+            (self.observe)(&removed.module, &removed.event, false);
         }
+        drop(removed);
     }
 
     /// Delivers a Host event to matching Rust subscriptions.
@@ -119,12 +127,14 @@ impl ModuleHost {
         let callbacks: Vec<_> = self
             .listeners
             .borrow()
-            .values()
-            .filter(|listener| listener.module == module && listener.event == event)
-            .map(|listener| Rc::clone(&listener.callback))
+            .iter()
+            .filter(|(_, listener)| listener.module == module && listener.event == event)
+            .map(|(id, listener)| (*id, Rc::clone(&listener.callback)))
             .collect();
-        for callback in &callbacks {
-            callback(payload.clone());
+        for (id, callback) in &callbacks {
+            if self.listeners.borrow().contains_key(id) {
+                callback(payload.clone());
+            }
         }
         !callbacks.is_empty()
     }
@@ -250,7 +260,7 @@ impl PlatformModule {
     }
 }
 
-/// RAII handle for a module event subscription.
+/// Retains an event subscription until this handle drops or its registering Owner is disposed.
 pub struct ModuleSubscription {
     id: i32,
     host: Weak<ModuleHost>,

--- a/crates/whisker-runtime/src/reactive/component.rs
+++ b/crates/whisker-runtime/src/reactive/component.rs
@@ -73,19 +73,20 @@ pub fn unmount_component(owner: Owner) {
 /// Register `f` as a post-mount callback for the current owner. Fires
 /// once on the next [`flush_mounts`] call, which runs after the
 /// component's view is appended to its parent.
+/// Disposing the Owner before delivery cancels the callback.
 ///
 /// No-op (with debug-build warning) if there is no current owner.
 pub fn on_mount(f: impl FnOnce() + 'static) {
-    let registered = with_runtime(|rt| {
-        if rt.current_owner().is_none() {
-            return false;
-        }
-        rt.pending_mounts.push(Box::new(f));
-        true
-    });
-    if !registered {
+    if Owner::current().is_none() {
         super::warn_no_owner("on_mount");
+        return;
     }
+    let callback = crate::lifetime::Scoped::new(Some(f));
+    with_runtime(|rt| {
+        rt.pending_mounts.push(Box::new(move || {
+            callback.with_mut(|f| f.take().expect("mount callback runs once")());
+        }))
+    });
 }
 
 /// Run all queued on_mount callbacks in registration order. Called

--- a/crates/whisker-runtime/src/reactive/mod.rs
+++ b/crates/whisker-runtime/src/reactive/mod.rs
@@ -95,6 +95,13 @@ pub(crate) fn with_runtime<R>(f: impl FnOnce(&mut ReactiveRuntime) -> R) -> R {
     RUNTIME.with_borrow_mut(f)
 }
 
+pub(crate) fn try_with_runtime<R>(f: impl FnOnce(&mut ReactiveRuntime) -> R) -> Option<R> {
+    RUNTIME
+        .try_with(|runtime| runtime.try_borrow_mut().ok().map(|mut rt| f(&mut rt)))
+        .ok()
+        .flatten()
+}
+
 pub(crate) fn swap_runtime(runtime: &mut ReactiveRuntime) {
     RUNTIME.with_borrow_mut(|active| std::mem::swap(active, runtime));
 }

--- a/crates/whisker-runtime/src/reactive/owner.rs
+++ b/crates/whisker-runtime/src/reactive/owner.rs
@@ -42,7 +42,16 @@ impl Owner {
     /// the route resumes.
     pub fn new(parent: Option<Owner>) -> Owner {
         with_runtime(|rt| {
+            assert!(
+                !rt.shutting_down,
+                "cannot create an owner during runtime shutdown"
+            );
             let parent = parent.or_else(|| rt.current_owner());
+            assert!(
+                parent
+                    .is_none_or(|parent| rt.owners.get(parent).is_some_and(|owner| !owner.closing)),
+                "cannot create a child of a disposed owner"
+            );
             let parent_paused = parent
                 .and_then(|p| rt.owners.get(p))
                 .map(|o| o.paused)
@@ -59,29 +68,16 @@ impl Owner {
         })
     }
 
-    /// Create a parentless **root** owner, ignoring whatever owner is
-    /// currently on the stack.
-    ///
-    /// Unlike [`Owner::new(None)`](Owner::new) — which adopts the
-    /// current top-of-stack owner as parent — this always produces a
-    /// detached root. Use it for **runtime-local singletons** whose
-    /// lifetime must not be tied to the (possibly short-lived) owner
-    /// that happens to be active when the singleton is first touched.
-    ///
-    /// The canonical case is a module that lazily mints an
-    /// arena-backed handle on first access (e.g.
-    /// `whisker-safe-area`): if that first access lands inside a
-    /// per-route / per-component owner, minting under `new(None)` would
-    /// free the handle when that scope disposes, and a later read would
-    /// hit a disposed node. Minting under a `detached_root()` (then
-    /// never disposing it) keeps the handle alive until the runtime ends.
-    /// It does not make an arena handle portable between runtime instances.
-    ///
-    /// The returned owner is never auto-disposed; the caller is
-    /// expected to retain it until explicit disposal or let the runtime release
-    /// its arena on shutdown. Dropping the handle alone does not dispose it.
+    /// Creates a parentless owner whose Copy handle does not dispose it on drop.
+    /// Call `dispose` explicitly; use [`crate::runtime_local!`] for Runtime-owned caches.
     pub fn detached_root() -> Owner {
-        with_runtime(|rt| rt.owners.insert(Scope::new(None)))
+        with_runtime(|rt| {
+            assert!(
+                !rt.shutting_down,
+                "cannot create an owner during runtime shutdown"
+            );
+            rt.owners.insert(Scope::new(None))
+        })
     }
 
     /// Push `self` as the current scope, run `f`, pop back.
@@ -90,16 +86,32 @@ impl Owner {
     /// will belong to this owner.
     pub fn with<R>(self, f: impl FnOnce() -> R) -> R {
         with_runtime(|rt| rt.owner_stack.push(self));
-        let result = f();
-        with_runtime(|rt| {
-            let popped = rt.owner_stack.pop();
-            debug_assert_eq!(
-                popped,
-                Some(self),
-                "Owner::with: stack imbalance — owner pop didn't match push"
-            );
-        });
-        result
+        struct Restore(Owner);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                with_runtime(|rt| {
+                    let popped = rt.owner_stack.pop();
+                    debug_assert_eq!(popped, Some(self.0));
+                });
+            }
+        }
+        let _restore = Restore(self);
+        f()
+    }
+
+    pub(crate) fn service() -> Self {
+        if let Some(owner) = with_runtime(|rt| rt.service_owner) {
+            return owner;
+        }
+        let owner = Self::detached_root();
+        with_runtime(|rt| rt.service_owner = Some(owner));
+        owner
+    }
+
+    /// Whether this owner still accepts new work.
+    #[doc(hidden)]
+    pub fn is_alive(self) -> bool {
+        with_runtime(|rt| rt.owners.get(self).is_some_and(|scope| !scope.closing))
     }
 
     /// Dispose `self`, freeing all its descendants, nodes, and
@@ -108,6 +120,38 @@ impl Owner {
     /// Recursive — disposes children first, then this owner. Safe
     /// to call even if the owner has already been disposed (no-op).
     pub fn dispose(self) {
+        let drain = with_runtime(|rt| {
+            if rt.owners.get(self).is_none_or(|scope| scope.closing) {
+                return false;
+            }
+            let mut pending = vec![self];
+            while let Some(owner) = pending.pop() {
+                if let Some(scope) = rt.owners.get_mut(owner) {
+                    scope.closing = true;
+                    pending.extend(scope.children.iter().copied());
+                }
+            }
+            rt.disposing.push(self);
+            rt.execution_depth == 0
+        });
+        if drain {
+            Self::drain_disposals();
+        }
+    }
+
+    pub(crate) fn drain_disposals() {
+        loop {
+            let owners = with_runtime(|rt| std::mem::take(&mut rt.disposing));
+            if owners.is_empty() {
+                break;
+            }
+            for owner in owners {
+                owner.dispose_now();
+            }
+        }
+    }
+
+    fn dispose_now(self) {
         // Everything is pulled out under a short borrow rather than
         // held across the recursion — deeper levels re-enter the
         // runtime.
@@ -117,6 +161,7 @@ impl Owner {
         let parent;
         let mount_fn;
         let elements;
+        let registrations;
         {
             let removed = with_runtime(|rt| rt.owners.remove(self));
             let Some(o) = removed else { return };
@@ -126,6 +171,7 @@ impl Owner {
             parent = o.parent;
             mount_fn = o.mount_fn;
             elements = o.elements;
+            registrations = o.registrations;
         }
 
         // A component owner must leave the hot-reload registry, or
@@ -181,7 +227,7 @@ impl Owner {
         }
 
         for child in children {
-            child.dispose();
+            child.dispose_now();
         }
 
         // Cleanups run before this owner's nodes are freed, so an
@@ -190,6 +236,10 @@ impl Owner {
         // already disposed above, so a *child's* signal still reads as
         // gone. LIFO, and with no runtime borrow held — a cleanup may
         // re-enter the runtime.
+        for (_, cancel) in registrations {
+            cancel();
+        }
+
         for cleanup in cleanups.into_iter().rev() {
             cleanup();
         }
@@ -199,28 +249,30 @@ impl Owner {
         // Arc-signal back-refs are collected here and unsubscribed
         // below, outside the borrow — those callees re-enter the
         // runtime.
+        let mut removed_nodes = Vec::new();
         let arc_unsubscribes: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> =
             with_runtime(|rt| {
                 let mut out: Vec<(Rc<dyn super::runtime::ArcSubscription>, NodeId)> = Vec::new();
                 for node_id in &nodes {
-                    let Some(node) = rt.nodes.remove(*node_id) else {
+                    let Some(mut node) = rt.nodes.remove(*node_id) else {
                         continue;
                     };
-                    for source in node.sources {
+                    for source in std::mem::take(&mut node.sources) {
                         if let Some(src_node) = rt.nodes.get_mut(source) {
                             src_node.subscribers.remove(node_id);
                         }
                     }
                     // A signal this owner held may have been read by an
                     // outer effect, so clear the reverse edge too.
-                    for sub in node.subscribers {
+                    for sub in std::mem::take(&mut node.subscribers) {
                         if let Some(sub_node) = rt.nodes.get_mut(sub) {
                             sub_node.sources.remove(node_id);
                         }
                     }
-                    for arc_src in node.arc_sources {
+                    for arc_src in std::mem::take(&mut node.arc_sources) {
                         out.push((arc_src, *node_id));
                     }
+                    removed_nodes.push(node);
                 }
                 // A scheduled node left in these queues would be re-run
                 // from its freed slot on the next flush / resume.
@@ -232,6 +284,7 @@ impl Owner {
         // An Arc-backed signal outlives its subscribers, so pruning
         // here is what keeps its list from accumulating dead
         // `NodeId`s across transient subscribers.
+        drop(removed_nodes);
         for (arc_src, subscriber) in arc_unsubscribes {
             arc_src.unsubscribe(subscriber);
         }

--- a/crates/whisker-runtime/src/reactive/prop.rs
+++ b/crates/whisker-runtime/src/reactive/prop.rs
@@ -124,6 +124,19 @@ impl<T: 'static> Clone for Signal<T> {
 impl<T: 'static> Copy for Signal<T> {}
 
 impl<T: 'static + Clone> Signal<T> {
+    pub fn try_get(&self) -> Option<T> {
+        match self {
+            Self::Stored(value) => value.try_get(),
+            Self::Dynamic(signal) => signal.try_get(),
+        }
+    }
+    pub fn try_get_untracked(&self) -> Option<T> {
+        match self {
+            Self::Stored(value) => value.try_get(),
+            Self::Dynamic(signal) => signal.try_get_untracked(),
+        }
+    }
+
     /// Read the current value.
     ///
     /// - For [`Signal::Stored`]: returns a clone of the held value.

--- a/crates/whisker-runtime/src/reactive/resource.rs
+++ b/crates/whisker-runtime/src/reactive/resource.rs
@@ -36,7 +36,7 @@ use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
 
-use crate::tasks::spawn_local;
+use crate::tasks::spawn_cancelable;
 
 use super::runtime::NodeId;
 use super::signal::RwSignal;
@@ -169,11 +169,8 @@ impl<T: Clone + 'static> Resource<T> {
 /// [`ResourceState::Loading`]; the first fetch is spawned during the
 /// effect's synchronous initial run.
 ///
-/// Owner discipline: the underlying [`RwSignal`] and the driving effect
-/// are registered with whatever owner is current at call time. If that
-/// owner is disposed, the effect stops re-running and any eventual
-/// write is a no-op (the signal node is gone), so no stale write hits a
-/// re-mounted owner.
+/// The registering Owner cancels the fetcher on disposal; dependency changes
+/// cancel the previous fetch before starting its replacement.
 ///
 /// For tests / already-in-memory values, prefer [`resource_sync`] — it
 /// runs the fetcher inline once, untracked, and doesn't depend on the
@@ -190,6 +187,7 @@ where
     // counter still matches at completion time (generation guard).
     let generation = Rc::new(Cell::new(0u64));
     let fetcher = Rc::new(fetcher);
+    let mut pending: Option<crate::lifetime::Cancellation> = None;
 
     super::effect::effect(move || {
         // Captured so the spawned future can re-install it as the
@@ -197,6 +195,9 @@ where
         // this node too.
         let node = super::current_tracker().expect("resource effect must run under a tracker");
 
+        if let Some(previous) = pending.take() {
+            previous.cancel();
+        }
         let my_gen = generation.get().wrapping_add(1);
         generation.set(my_gen);
 
@@ -208,13 +209,13 @@ where
         // or it re-triggers itself forever.
         state.update_untracked(|s| *s = ResourceState::Loading);
 
-        spawn_local(ScopedFetch {
+        pending = Some(spawn_cancelable(ScopedFetch {
             node,
             my_gen,
             generation: generation.clone(),
             state,
             fut: Box::pin(fut),
-        });
+        }));
     });
 
     Resource { state }

--- a/crates/whisker-runtime/src/reactive/runtime.rs
+++ b/crates/whisker-runtime/src/reactive/runtime.rs
@@ -154,6 +154,8 @@ pub trait ArcSubscription {
 /// `use_context`. `cleanups` is the LIFO callback queue from
 /// `on_cleanup`.
 pub struct Scope {
+    pub(crate) closing: bool,
+    pub(crate) registrations: SlotMap<slotmap::DefaultKey, Box<dyn FnOnce()>>,
     pub parent: Option<Owner>,
     pub children: Vec<Owner>,
     pub nodes: Vec<NodeId>,
@@ -189,6 +191,8 @@ impl Scope {
     pub fn new(parent: Option<Owner>) -> Self {
         Self {
             parent,
+            closing: false,
+            registrations: SlotMap::new(),
             children: Vec::new(),
             nodes: Vec::new(),
             contexts: HashMap::new(),
@@ -217,6 +221,11 @@ impl Scope {
 /// running inside a closure can re-enter the runtime (read signals,
 /// write signals, register new effects) without panicking.
 pub struct ReactiveRuntime {
+    pub(crate) identity: Rc<()>,
+    pub(crate) service_owner: Option<Owner>,
+    pub(crate) execution_depth: usize,
+    pub(crate) disposing: Vec<Owner>,
+    pub(crate) shutting_down: bool,
     pub owners: SlotMap<Owner, Scope>,
     pub nodes: SlotMap<NodeId, ReactiveNode>,
     /// Owner stack: the topmost is the "current" owner — new signals,
@@ -269,6 +278,11 @@ pub struct ReactiveRuntime {
 impl ReactiveRuntime {
     pub fn new() -> Self {
         Self {
+            identity: Rc::new(()),
+            service_owner: None,
+            execution_depth: 0,
+            disposing: Vec::new(),
+            shutting_down: false,
             owners: SlotMap::with_key(),
             nodes: SlotMap::with_key(),
             owner_stack: Vec::new(),

--- a/crates/whisker-runtime/src/reactive/scheduler.rs
+++ b/crates/whisker-runtime/src/reactive/scheduler.rs
@@ -144,6 +144,9 @@ fn run_node_if_alive(node: NodeId) {
     let prep = with_runtime(|rt| {
         let n = rt.nodes.get(node)?;
         let owner = n.owner;
+        if rt.owners.get(owner).is_none_or(|scope| scope.closing) {
+            return None;
+        }
         // Signal nodes have no compute, so the paused-owner gate below
         // only concerns Effect / Computed.
         let compute = match &n.data {
@@ -203,6 +206,7 @@ fn run_node_if_alive(node: NodeId) {
             });
         }
     }
+    let _execution = crate::lifetime::Execution::enter();
     let _run_guard = RunGuard;
 
     // The runtime is unborrowed here, so the compute body is free to

--- a/crates/whisker-runtime/src/reactive/signal.rs
+++ b/crates/whisker-runtime/src/reactive/signal.rs
@@ -95,6 +95,16 @@ impl<T: 'static> Clone for ReadSignal<T> {
 impl<T: 'static> Copy for ReadSignal<T> {}
 
 impl<T: 'static + Clone> ReadSignal<T> {
+    /// Reads and tracks a live signal in its owning Runtime, returning `None` after disposal.
+    pub fn try_get(self) -> Option<T> {
+        read_value(self.id, true, Clone::clone)
+    }
+
+    /// Reads a live signal without tracking, returning `None` after disposal.
+    pub fn try_get_untracked(self) -> Option<T> {
+        read_value(self.id, false, Clone::clone)
+    }
+
     /// Read the current value, registering this signal as a dependency
     /// of the currently-running effect / computed (if any).
     pub fn get(self) -> T {
@@ -112,44 +122,13 @@ impl<T: 'static> ReadSignal<T> {
     /// Borrowed read with dependency tracking. Useful when `T` is
     /// expensive to clone or doesn't implement `Clone`.
     pub fn with<R>(self, f: impl FnOnce(&T) -> R) -> R {
-        let value = fetch_value(self.id);
-        // Arc-backed storage routes through `ArcRwSignal`'s
-        // tracker-aware path, which subscribes via `arc_sources`; the
-        // arena `subscribers` set stays empty for these entries.
-        let arc_handle: Option<super::arc_signal::ArcRwSignal<T>> = {
-            let borrow = value.borrow();
-            borrow
-                .downcast_ref::<super::arc_signal::ArcRwSignal<T>>()
-                .cloned()
-        };
-        if let Some(arc) = arc_handle {
-            return arc.with(f);
-        }
-        track_node(self.id);
-        let borrow = value.borrow();
-        let typed = borrow
-            .downcast_ref::<T>()
-            .expect("ReadSignal::with: type mismatch — signal storage corrupted");
-        f(typed)
+        read_value(self.id, true, f)
+            .expect("ReadSignal: signal disposed or not a value-bearing node")
     }
 
-    /// Borrowed read without tracking.
     pub fn with_untracked<R>(self, f: impl FnOnce(&T) -> R) -> R {
-        let value = fetch_value(self.id);
-        let arc_handle: Option<super::arc_signal::ArcRwSignal<T>> = {
-            let borrow = value.borrow();
-            borrow
-                .downcast_ref::<super::arc_signal::ArcRwSignal<T>>()
-                .cloned()
-        };
-        if let Some(arc) = arc_handle {
-            return arc.with_untracked(f);
-        }
-        let borrow = value.borrow();
-        let typed = borrow
-            .downcast_ref::<T>()
-            .expect("ReadSignal::with_untracked: type mismatch — signal storage corrupted");
-        f(typed)
+        read_value(self.id, false, f)
+            .expect("ReadSignal: signal disposed or not a value-bearing node")
     }
 }
 
@@ -333,6 +312,16 @@ impl<T: 'static> RwSignal<T> {
 }
 
 impl<T: 'static + Clone> RwSignal<T> {
+    /// Reads and tracks a live signal in its owning Runtime, returning `None` after disposal.
+    pub fn try_get(self) -> Option<T> {
+        self.split().0.try_get()
+    }
+
+    /// Reads a live signal without tracking, returning `None` after disposal.
+    pub fn try_get_untracked(self) -> Option<T> {
+        self.split().0.try_get_untracked()
+    }
+
     pub fn get(self) -> T {
         ReadSignal::<T> {
             id: self.id,
@@ -445,13 +434,26 @@ fn track_node(id: NodeId) {
     })
 }
 
-fn fetch_value(id: NodeId) -> Rc<RefCell<dyn Any>> {
-    with_runtime(|rt| {
-        rt.nodes
-            .get(id)
-            .and_then(|n| n.data.value().cloned())
-            .expect("ReadSignal: signal disposed or not a value-bearing node")
-    })
+fn read_value<T: 'static, R>(id: NodeId, track: bool, f: impl FnOnce(&T) -> R) -> Option<R> {
+    let value = with_runtime(|rt| rt.nodes.get(id).and_then(|node| node.data.value().cloned()))?;
+    let arc = value
+        .borrow()
+        .downcast_ref::<super::arc_signal::ArcRwSignal<T>>()
+        .cloned();
+    if let Some(arc) = arc {
+        return Some(if track {
+            arc.with(f)
+        } else {
+            arc.with_untracked(f)
+        });
+    }
+    if track {
+        track_node(id);
+    }
+    let value = value.borrow();
+    Some(f(value.downcast_ref::<T>().expect(
+        "ReadSignal: type mismatch — signal storage corrupted",
+    )))
 }
 
 /// Mutate the value of signal `id` under `f`, optionally notifying

--- a/crates/whisker-runtime/src/reactive/stored.rs
+++ b/crates/whisker-runtime/src/reactive/stored.rs
@@ -105,6 +105,14 @@ impl<T: 'static> StoredValue<T> {
 }
 
 impl<T: 'static + Clone> StoredValue<T> {
+    pub fn try_get(self) -> Option<T> {
+        super::signal::ReadSignal {
+            id: self.id,
+            _ty: PhantomData,
+        }
+        .try_get_untracked()
+    }
+
     pub fn get(self) -> T {
         self.with(|v| v.clone())
     }

--- a/crates/whisker-runtime/src/reactive/tests_resource.rs
+++ b/crates/whisker-runtime/src/reactive/tests_resource.rs
@@ -12,10 +12,13 @@ use crate::reactive::{__reset_for_tests, Owner, ResourceState, flush, resource, 
 use crate::tasks;
 
 fn with_test_owner<R>(f: impl FnOnce() -> R) -> R {
-    __reset_for_tests();
-    tasks::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(f)
+    let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        __reset_for_tests();
+        tasks::__reset_for_tests();
+        let owner = Owner::new(None);
+        owner.with(f)
+    })
 }
 
 #[test]
@@ -384,84 +387,89 @@ mod cross_thread_wake {
 
     #[test]
     fn reactive_resource_reading_signal_with_run_blocking_completes_after_refetch() {
-        use std::cell::Cell;
-        use std::rc::Rc;
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {
+            DRIVE_REQUESTED.store(true, Ordering::Release)
+        }));
+        runtime.enter(|| {
+            use std::cell::Cell;
+            use std::rc::Rc;
 
-        let _g = lock();
-        __reset_for_tests();
-        tasks::__reset_for_tests();
-        install_host();
+            let _g = lock();
+            __reset_for_tests();
+            tasks::__reset_for_tests();
+            install_host();
 
-        let runs = Rc::new(Cell::new(0u32));
-        let runs_for_fetcher = runs.clone();
+            let runs = Rc::new(Cell::new(0u32));
+            let runs_for_fetcher = runs.clone();
 
-        let owner = Owner::new(None);
-        owner.with(|| {
-            let query = RwSignal::new(1_i32);
-            let r = resource::<i32, _, _>(move || {
-                runs_for_fetcher.set(runs_for_fetcher.get() + 1);
-                // Sync-prefix read of the tracked signal (the canonical
-                // "fetch keyed by a signal" pattern).
-                let q = query.get();
-                async move {
-                    // Blocking IO offloaded to a worker thread, result
-                    // marshaled back through the host wake callback. A small
-                    // sleep makes the worker outlive the spawning frame
-                    // so the cross-thread wake (not an inline poll) is
-                    // what resumes the fetch — as on device.
-                    let v = run_blocking(move || {
-                        std::thread::sleep(Duration::from_millis(15));
-                        q * 10
-                    })
-                    .await;
-                    Ok::<i32, String>(v)
-                }
-            });
+            let owner = Owner::new(None);
+            owner.with(|| {
+                let query = RwSignal::new(1_i32);
+                let r = resource::<i32, _, _>(move || {
+                    runs_for_fetcher.set(runs_for_fetcher.get() + 1);
+                    // Sync-prefix read of the tracked signal (the canonical
+                    // "fetch keyed by a signal" pattern).
+                    let q = query.get();
+                    async move {
+                        // Blocking IO offloaded to a worker thread, result
+                        // marshaled back through the host wake callback. A small
+                        // sleep makes the worker outlive the spawning frame
+                        // so the cross-thread wake (not an inline poll) is
+                        // what resumes the fetch — as on device.
+                        let v = run_blocking(move || {
+                            std::thread::sleep(Duration::from_millis(15));
+                            q * 10
+                        })
+                        .await;
+                        Ok::<i32, String>(v)
+                    }
+                });
 
-            // A consuming effect, as a component's render would have: it
-            // reads the resource state, so each commit (`state.set`)
-            // schedules a re-run on the trailing flush.
-            let seen = Rc::new(Cell::new(0i32));
-            let seen_for_effect = seen.clone();
-            crate::reactive::effect::effect(move || {
-                if let ResourceState::Ready(v) = r.state() {
-                    seen_for_effect.set(v);
-                }
-            });
+                // A consuming effect, as a component's render would have: it
+                // reads the resource state, so each commit (`state.set`)
+                // schedules a re-run on the trailing flush.
+                let seen = Rc::new(Cell::new(0i32));
+                let seen_for_effect = seen.clone();
+                crate::reactive::effect::effect(move || {
+                    if let ResourceState::Ready(v) = r.state() {
+                        seen_for_effect.set(v);
+                    }
+                });
 
-            // Drive the INITIAL fetch to completion.
-            drive_until(|| !r.loading());
-            assert_eq!(
-                r.get(),
-                Some(10),
-                "initial reactive+run_blocking fetch must complete (query=1 → 10)"
-            );
+                // Drive the INITIAL fetch to completion.
+                drive_until(|| !r.loading());
+                assert_eq!(
+                    r.get(),
+                    Some(10),
+                    "initial reactive+run_blocking fetch must complete (query=1 → 10)"
+                );
 
-            // Deliberately no inline flush: let the tick loop pick up
-            // the frame request the write's wake made, as the host does.
-            query.set(7);
+                // Deliberately no inline flush: let the tick loop pick up
+                // the frame request the write's wake made, as the host does.
+                query.set(7);
 
-            // Drive the RE-FETCH to completion — the case where loading
-            // flips true but the result never arrives.
-            drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
-            assert_eq!(
-                r.get(),
-                Some(70),
-                "reactive resource + run_blocking must finish the re-fetch \
+                // Drive the RE-FETCH to completion — the case where loading
+                // flips true but the result never arrives.
+                drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
+                assert_eq!(
+                    r.get(),
+                    Some(70),
+                    "reactive resource + run_blocking must finish the re-fetch \
                  after the tracked signal changes (query=7 → 70), not stay Loading"
-            );
-            assert_eq!(
-                runs.get(),
-                2,
-                "fetcher must run exactly twice (initial + one re-fetch); a \
+                );
+                assert_eq!(
+                    runs.get(),
+                    2,
+                    "fetcher must run exactly twice (initial + one re-fetch); a \
                  spurious extra run would bump the generation and abandon the \
                  in-flight fetch"
-            );
-            assert_eq!(seen.get(), 70, "consumer effect observed the final value");
-        });
+                );
+                assert_eq!(seen.get(), 70, "consumer effect observed the final value");
+            });
 
-        owner.dispose();
-        reset_host();
+            owner.dispose();
+            reset_host();
+        });
     }
 
     /// After-`.await` variant: the tracked signal is read AFTER the
@@ -469,40 +477,45 @@ mod cross_thread_wake {
     /// cross-thread-woken poll, inside `with_observer`.
     #[test]
     fn reactive_resource_signal_read_after_run_blocking_await_refetches() {
-        let _g = lock();
-        __reset_for_tests();
-        tasks::__reset_for_tests();
-        install_host();
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {
+            DRIVE_REQUESTED.store(true, Ordering::Release)
+        }));
+        runtime.enter(|| {
+            let _g = lock();
+            __reset_for_tests();
+            tasks::__reset_for_tests();
+            install_host();
 
-        let owner = Owner::new(None);
-        owner.with(|| {
-            let multiplier = RwSignal::new(2_i32);
-            let r = resource::<i32, _, _>(move || async move {
-                // Blocking IO FIRST (a real cross-thread suspension),
-                // then read the tracked signal AFTER resuming.
-                let base = run_blocking(|| {
-                    std::thread::sleep(Duration::from_millis(15));
-                    10_i32
-                })
-                .await;
-                let m = multiplier.get();
-                Ok::<i32, String>(base * m)
+            let owner = Owner::new(None);
+            owner.with(|| {
+                let multiplier = RwSignal::new(2_i32);
+                let r = resource::<i32, _, _>(move || async move {
+                    // Blocking IO FIRST (a real cross-thread suspension),
+                    // then read the tracked signal AFTER resuming.
+                    let base = run_blocking(|| {
+                        std::thread::sleep(Duration::from_millis(15));
+                        10_i32
+                    })
+                    .await;
+                    let m = multiplier.get();
+                    Ok::<i32, String>(base * m)
+                });
+
+                drive_until(|| !r.loading());
+                assert_eq!(r.get(), Some(20), "initial: 10 * multiplier(2) = 20");
+
+                multiplier.set(5);
+                drive_until(|| matches!(r.state(), ResourceState::Ready(50)));
+                assert_eq!(
+                    r.get(),
+                    Some(50),
+                    "after-await tracked read + run_blocking must re-fetch (10*5=50)"
+                );
             });
 
-            drive_until(|| !r.loading());
-            assert_eq!(r.get(), Some(20), "initial: 10 * multiplier(2) = 20");
-
-            multiplier.set(5);
-            drive_until(|| matches!(r.state(), ResourceState::Ready(50)));
-            assert_eq!(
-                r.get(),
-                Some(50),
-                "after-await tracked read + run_blocking must re-fetch (10*5=50)"
-            );
+            owner.dispose();
+            reset_host();
         });
-
-        owner.dispose();
-        reset_host();
     }
 
     /// Overlapping re-fetch: the tracked signal changes WHILE the first
@@ -513,58 +526,63 @@ mod cross_thread_wake {
     /// one.
     #[test]
     fn reactive_resource_overlapping_refetch_completes_latest() {
-        use std::cell::Cell;
-        use std::rc::Rc;
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {
+            DRIVE_REQUESTED.store(true, Ordering::Release)
+        }));
+        runtime.enter(|| {
+            use std::cell::Cell;
+            use std::rc::Rc;
 
-        let _g = lock();
-        __reset_for_tests();
-        tasks::__reset_for_tests();
-        install_host();
+            let _g = lock();
+            __reset_for_tests();
+            tasks::__reset_for_tests();
+            install_host();
 
-        let owner = Owner::new(None);
-        owner.with(|| {
-            let query = RwSignal::new(1_i32);
-            let r = resource::<i32, _, _>(move || {
-                let q = query.get();
-                async move {
-                    let v = run_blocking(move || {
-                        // Long enough that the second change lands while
-                        // this worker is still asleep.
-                        std::thread::sleep(Duration::from_millis(40));
-                        q * 10
-                    })
-                    .await;
-                    Ok::<i32, String>(v)
-                }
-            });
+            let owner = Owner::new(None);
+            owner.with(|| {
+                let query = RwSignal::new(1_i32);
+                let r = resource::<i32, _, _>(move || {
+                    let q = query.get();
+                    async move {
+                        let v = run_blocking(move || {
+                            // Long enough that the second change lands while
+                            // this worker is still asleep.
+                            std::thread::sleep(Duration::from_millis(40));
+                            q * 10
+                        })
+                        .await;
+                        Ok::<i32, String>(v)
+                    }
+                });
 
-            let seen = Rc::new(Cell::new(0i32));
-            let seen_for_effect = seen.clone();
-            crate::reactive::effect::effect(move || {
-                if let ResourceState::Ready(v) = r.state() {
-                    seen_for_effect.set(v);
-                }
-            });
+                let seen = Rc::new(Cell::new(0i32));
+                let seen_for_effect = seen.clone();
+                crate::reactive::effect::effect(move || {
+                    if let ResourceState::Ready(v) = r.state() {
+                        seen_for_effect.set(v);
+                    }
+                });
 
-            // Kick the first fetch (do NOT wait for it).
-            tick();
-            assert!(r.loading());
+                // Kick the first fetch (do NOT wait for it).
+                tick();
+                assert!(r.loading());
 
-            // Change the signal while the first worker is still asleep.
-            query.set(7);
+                // Change the signal while the first worker is still asleep.
+                query.set(7);
 
-            // Drive to the LATEST result.
-            drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
-            assert_eq!(
-                r.get(),
-                Some(70),
-                "overlapping re-fetch must settle on the latest query (7 → 70), \
+                // Drive to the LATEST result.
+                drive_until(|| matches!(r.state(), ResourceState::Ready(70)));
+                assert_eq!(
+                    r.get(),
+                    Some(70),
+                    "overlapping re-fetch must settle on the latest query (7 → 70), \
                  not hang in Loading"
-            );
-        });
+                );
+            });
 
-        owner.dispose();
-        reset_host();
+            owner.dispose();
+            reset_host();
+        });
     }
 }
 

--- a/crates/whisker-runtime/src/runtime_context.rs
+++ b/crates/whisker-runtime/src/runtime_context.rs
@@ -110,27 +110,48 @@ impl RuntimeContext {
             !self.entered.get(),
             "Whisker RuntimeContext cannot shut down while entered"
         );
-        if self.closed.replace(true) {
+        if self.closed.get() {
             return;
         }
+        self.enter(|| {
+            crate::reactive::with_runtime(|rt| rt.shutting_down = true);
+            if let Some(dispatcher) = crate::runtime_dispatcher() {
+                dispatcher.close();
+            }
+            let owners = crate::reactive::with_runtime(|rt| {
+                rt.owners
+                    .iter()
+                    .filter_map(|(owner, scope)| {
+                        (scope.parent.is_none() && Some(owner) != rt.service_owner).then_some(owner)
+                    })
+                    .collect::<Vec<_>>()
+            });
+            for owner in owners {
+                owner.dispose();
+            }
+            tasks::clear();
+            crate::runtime_local::dispose_caches();
+            if let Some(owner) = crate::reactive::with_runtime(|rt| rt.service_owner) {
+                owner.dispose();
+            }
+            crate::runtime_local::clear();
+            let mut animation = AnimationState::new();
+            anim_hook::swap_state(&mut animation);
+            drop(animation);
+        });
+        self.closed.set(true);
         let mut state = self.state.borrow_mut();
-        if let Some(dispatcher) = &state.dispatcher {
-            dispatcher.close();
-        }
-        state.reactive = ReactiveRuntime::new();
         state.view = ViewRuntimeState::new();
-        state.tasks = TaskState::new();
         state.animation = AnimationState::new();
         state.runtime_local = RuntimeLocalState::new();
+        state.reactive = ReactiveRuntime::new();
         state.pending_mount = None;
     }
 }
 
 impl Drop for RuntimeContext {
     fn drop(&mut self) {
-        if let Some(dispatcher) = &self.state.get_mut().dispatcher {
-            dispatcher.close();
-        }
+        self.shutdown();
     }
 }
 

--- a/crates/whisker-runtime/src/runtime_instance.rs
+++ b/crates/whisker-runtime/src/runtime_instance.rs
@@ -729,6 +729,10 @@ const TAP_TIMEOUT_MS: f64 = 500.0;
 const LONGPRESS_TIMEOUT_MS: f64 = 500.0;
 
 impl RuntimeInstance {
+    #[cfg(test)]
+    pub(crate) fn with_context<R>(&self, f: impl FnOnce() -> R) -> R {
+        self.context.enter(f)
+    }
     /// Creates an unmounted runtime connected to one Host wake-up endpoint.
     pub fn new(surface: SurfaceRuntime, wake: RuntimeWakeHandle) -> Self {
         let wake_enabled = Arc::new(AtomicBool::new(false));

--- a/crates/whisker-runtime/src/runtime_local.rs
+++ b/crates/whisker-runtime/src/runtime_local.rs
@@ -1,4 +1,4 @@
-//! Type-indexed state owned by the currently entered runtime instance.
+//! Lazy caches and internal subsystem state owned by the entered Runtime.
 
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
@@ -7,12 +7,16 @@ use std::rc::Rc;
 
 pub(crate) struct RuntimeLocalState {
     values: HashMap<TypeId, Box<dyn Any>>,
+    caches: HashMap<TypeId, Cache>,
+    initialized: Vec<TypeId>,
 }
 
 impl RuntimeLocalState {
     pub(crate) fn new() -> Self {
         Self {
             values: HashMap::new(),
+            caches: HashMap::new(),
+            initialized: Vec::new(),
         }
     }
 }
@@ -40,4 +44,141 @@ pub fn state<T: Default + 'static>() -> Rc<RefCell<T>> {
 
 pub(crate) fn swap_state(state: &mut RuntimeLocalState) {
     ACTIVE.with_borrow_mut(|active| std::mem::swap(active, state));
+}
+
+enum Cache {
+    Initializing,
+    Ready {
+        value: Box<dyn Any>,
+        owner: crate::reactive::Owner,
+    },
+}
+
+/// A declaration-specific key for a lazily initialized value in each Runtime.
+/// Declare keys with [`crate::runtime_local!`]. Values need not be `Send` or `Sync`.
+pub struct RuntimeLocalKey<T: 'static> {
+    key: fn() -> TypeId,
+    initialize: fn() -> T,
+    name: &'static str,
+}
+
+impl<T: 'static> RuntimeLocalKey<T> {
+    #[doc(hidden)]
+    pub const fn new(key: fn() -> TypeId, initialize: fn() -> T, name: &'static str) -> Self {
+        Self {
+            key,
+            initialize,
+            name,
+        }
+    }
+
+    /// Borrows the current Runtime's value, initializing it once on first use.
+    /// Initialization is untracked and owns its signals, subscriptions and tasks.
+    /// Panics outside an entered Runtime or on recursive initialization of this key.
+    pub fn with<R>(&'static self, f: impl FnOnce(&T) -> R) -> R {
+        assert!(
+            crate::runtime_dispatcher().is_some(),
+            "runtime_local requires an entered Runtime"
+        );
+        let key = (self.key)();
+        let value = ACTIVE.with_borrow_mut(|active| match active.caches.get(&key) {
+            Some(Cache::Ready { value, .. }) => Some(
+                value
+                    .downcast_ref::<Rc<T>>()
+                    .expect("runtime-local key type")
+                    .clone(),
+            ),
+            Some(Cache::Initializing) => {
+                panic!("recursive runtime_local initialization: {}", self.name)
+            }
+            None => {
+                crate::reactive::with_runtime(|rt| {
+                    assert!(
+                        !rt.shutting_down,
+                        "cannot initialize runtime_local during shutdown"
+                    )
+                });
+                active.caches.insert(key, Cache::Initializing);
+                None
+            }
+        });
+        let value = value.unwrap_or_else(|| {
+            use crate::reactive::Owner;
+            let owner = Owner::new(Some(Owner::service()));
+            struct Rollback {
+                key: TypeId,
+                owner: Owner,
+                committed: bool,
+            }
+            impl Drop for Rollback {
+                fn drop(&mut self) {
+                    if !self.committed {
+                        ACTIVE.with_borrow_mut(|active| {
+                            active.caches.remove(&self.key);
+                        });
+                        self.owner.dispose();
+                    }
+                }
+            }
+            let mut rollback = Rollback {
+                key,
+                owner,
+                committed: false,
+            };
+            let value = Rc::new(owner.with(|| crate::reactive::untrack(self.initialize)));
+            ACTIVE.with_borrow_mut(|active| {
+                active.caches.insert(
+                    key,
+                    Cache::Ready {
+                        value: Box::new(value.clone()),
+                        owner,
+                    },
+                );
+                active.initialized.push(key);
+            });
+            rollback.committed = true;
+            value
+        });
+        f(&value)
+    }
+}
+
+/// Declares lazily initialized Runtime-local values with independent keys.
+///
+/// ```ignore
+/// whisker::runtime_local! {
+///     static INFO: DeviceInfo = load_device_info();
+/// }
+/// let name = INFO.with(|info| info.name.clone());
+/// ```
+#[macro_export]
+macro_rules! runtime_local {
+    ($( $(#[$attr:meta])* $vis:vis static $name:ident: $ty:ty = $init:expr; )+) => {
+        $(
+            $(#[$attr])*
+            $vis static $name: $crate::runtime_local::RuntimeLocalKey<$ty> = {
+                struct Key;
+                $crate::runtime_local::RuntimeLocalKey::new(
+                    || ::std::any::TypeId::of::<Key>(), || $init, stringify!($name)
+                )
+            };
+        )+
+    };
+}
+
+pub(crate) fn dispose_caches() {
+    let keys = ACTIVE.with_borrow_mut(|active| std::mem::take(&mut active.initialized));
+    for key in keys.into_iter().rev() {
+        let entry = ACTIVE.with_borrow_mut(|active| active.caches.remove(&key));
+        if let Some(Cache::Ready { value, owner }) = entry {
+            owner.with(|| drop(value));
+            owner.dispose();
+        }
+    }
+}
+
+pub(crate) fn clear() {
+    let removed =
+        ACTIVE.with_borrow_mut(|active| std::mem::replace(active, RuntimeLocalState::new()));
+    drop(removed);
 }

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -2073,6 +2073,38 @@ mod layout_observer_tests {
     }
 
     #[test]
+    fn layout_batch_skips_observer_after_its_element_is_disposed() {
+        let context = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        context.enter(|| {
+            let surface = SurfaceRuntime::new(
+                SurfaceId::new(94).unwrap(),
+                StyleEnvironment::new(320.0, 480.0, 1.0, 14.0),
+            );
+            with_installed_renderer(surface.renderer(), || {
+                let owner = crate::reactive::Owner::new(None);
+                let hits = Rc::new(Cell::new(0));
+                let captured_hits = hits.clone();
+                let root = owner.with(|| {
+                    let root = create_element(ElementTag::View);
+                    set_specified_style(root, &absolute_box(100.0, 100.0));
+                    let value = crate::reactive::RwSignal::new(1);
+                    observe_layout(root, Box::new(move |_| owner.dispose()));
+                    observe_layout(root, Box::new(move |_| captured_hits.set(value.get())));
+                    root
+                });
+                crate::view::set_root(root);
+                let _ = surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut NoMeasurements,
+                    LayoutOptions::default(),
+                );
+                assert_eq!(hits.get(), 0);
+            });
+        });
+    }
+
+    #[test]
     fn layout_notifications_commit_row_and_spacer_updates_together() {
         crate::reactive::__reset_for_tests();
         let surface = SurfaceRuntime::new(
@@ -2117,23 +2149,27 @@ mod layout_observer_tests {
             .unwrap();
 
         surface.reset_surface_snapshot_count();
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut NoMeasurements,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut NoMeasurements,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         assert_eq!(rows.borrow().len(), 24);
         assert_eq!(surface.surface_snapshot_count(), 1);
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut NoMeasurements,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut NoMeasurements,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         let state = surface.state.borrow();
         for row in rows.borrow().iter() {
@@ -2188,12 +2224,14 @@ mod layout_observer_tests {
                 }
             })
             .unwrap();
-        let result = surface.drive_layout(
-            LayoutSize::new(320.0, 480.0),
-            1,
-            &mut NoMeasurements,
-            LayoutOptions::default(),
-        );
+        let result = runtime.with_context(|| {
+            surface.drive_layout(
+                LayoutSize::new(320.0, 480.0),
+                1,
+                &mut NoMeasurements,
+                LayoutOptions::default(),
+            )
+        });
         assert!(matches!(result, Err(RuntimeLayoutError::Binding(_))));
         {
             let state = surface.state.borrow();
@@ -2209,13 +2247,15 @@ mod layout_observer_tests {
                 &absolute_box(40.0, 40.0)
             ));
         });
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut NoMeasurements,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut NoMeasurements,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
     }
 
@@ -2386,13 +2426,15 @@ mod layout_observer_tests {
             .unwrap();
 
         let mut provider = NoMeasurements;
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut provider,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut provider,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         assert_eq!(observed.get(), 1);
         assert_eq!(completed_batches.get(), 1);
@@ -2400,13 +2442,15 @@ mod layout_observer_tests {
         with_installed_renderer(surface.renderer(), || {
             set_specified_style(sibling.get().unwrap(), &absolute_box(30.0, 10.0));
         });
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut provider,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut provider,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
 
         assert_eq!(
@@ -2454,13 +2498,15 @@ mod layout_observer_tests {
             .unwrap();
 
         let mut provider = NoMeasurements;
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut provider,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut provider,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         assert_eq!(observations.borrow().len(), 1);
         assert_eq!(
@@ -2477,13 +2523,15 @@ mod layout_observer_tests {
             );
             set_specified_style(root_handle.get().unwrap(), &hidden);
         });
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut provider,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut provider,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         assert_eq!(observations.borrow().len(), 2);
         assert_eq!(
@@ -2494,13 +2542,15 @@ mod layout_observer_tests {
         with_installed_renderer(surface.renderer(), || {
             set_specified_style(root_handle.get().unwrap(), &absolute_box(100.0, 100.0));
         });
-        surface
-            .drive_layout(
-                LayoutSize::new(320.0, 480.0),
-                1,
-                &mut provider,
-                LayoutOptions::default(),
-            )
+        runtime
+            .with_context(|| {
+                surface.drive_layout(
+                    LayoutSize::new(320.0, 480.0),
+                    1,
+                    &mut provider,
+                    LayoutOptions::default(),
+                )
+            })
             .unwrap();
         assert_eq!(observations.borrow().len(), 3);
         assert_eq!(

--- a/crates/whisker-runtime/src/tasks.rs
+++ b/crates/whisker-runtime/src/tasks.rs
@@ -138,24 +138,42 @@ impl ArcWake for DriveWaker {
 /// whatever waker the user future stashes — and later wakes, possibly
 /// from a foreign thread — is the drive-bridging one rather than the
 /// bare pool waker.
-struct DriveBridged<F> {
-    future: F,
+struct DriveBridged<F: 'static> {
+    future: crate::lifetime::Scoped<TaskFuture<F>>,
 }
 
-impl<F: Future<Output = ()>> Future for DriveBridged<F> {
+struct TaskFuture<F> {
+    future: Pin<Box<F>>,
+    wake_on_cancel: Option<std::task::Waker>,
+}
+
+impl<F> Drop for TaskFuture<F> {
+    fn drop(&mut self) {
+        if let Some(waker) = self.wake_on_cancel.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl<F: Future<Output = ()> + 'static> Future for DriveBridged<F> {
     type Output = ();
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        // SAFETY: standard pin-projection — we never move `future` out
-        // of `self`, and `DriveBridged` is `!Unpin`-agnostic: we only
-        // re-pin the field in place.
-        let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
         let drive_waker = Arc::new(DriveWaker {
             inner: cx.waker().clone(),
             wake: crate::runtime_wake::current_wake_handle(),
         });
         let waker = waker_ref(&drive_waker);
         let mut cx = Context::from_waker(&waker);
-        future.poll(&mut cx)
+        self.future
+            .with_mut(|task| {
+                task.wake_on_cancel = Some(cx.waker().clone());
+                let result = task.future.as_mut().poll(&mut cx);
+                if result.is_ready() {
+                    task.wake_on_cancel = None;
+                }
+                result
+            })
+            .unwrap_or(Poll::Ready(()))
     }
 }
 
@@ -171,18 +189,32 @@ impl<F: Future<Output = ()>> Future for DriveBridged<F> {
 /// strictly single-threaded.
 ///
 /// Returns nothing because once spawned a task is owned by the pool;
-/// detach-on-drop is the default. Use [`run_blocking`] when you want
+/// its registering Owner cancels it on disposal. Use [`run_blocking`] when you want
 /// a typed result back into an `async fn` body.
 ///
 /// # Panics
 ///
-/// Panics if the local pool has somehow shut down (only possible if
-/// a test called `__reset_for_tests` mid-spawn). This is a
-/// programming error inside the runtime, never user-reachable.
+/// Panics outside an entered Runtime, during shutdown, or when the current Owner is closing.
 pub fn spawn_local<F>(future: F)
 where
     F: Future<Output = ()> + 'static,
 {
+    let _ = spawn_cancelable(future);
+}
+
+pub(crate) fn spawn_cancelable<F>(future: F) -> crate::lifetime::Cancellation
+where
+    F: Future<Output = ()> + 'static,
+{
+    assert!(
+        crate::runtime_dispatcher().is_some(),
+        "spawn_local requires an entered Runtime"
+    );
+    let future = crate::lifetime::Scoped::new(TaskFuture {
+        future: Box::pin(future),
+        wake_on_cancel: None,
+    });
+    let cancellation = future.cancellation();
     TASKS.with(|tasks| {
         tasks
             .borrow()
@@ -190,9 +222,8 @@ where
             .spawn_local(DriveBridged { future })
             .expect("whisker tasks: local pool is shut down");
     });
-    // Without this nudge a freshly spawned task sits dormant until
-    // something else happens to wake the runtime.
     crate::runtime_wake::wake_runtime();
+    cancellation
 }
 
 /// Drain pending tasks until they're all pending on external events.
@@ -264,7 +295,7 @@ impl<T> Future for BlockingResult<T> {
         use std::task::Poll;
         match std::pin::Pin::new(&mut self.rx).poll(cx) {
             Poll::Ready(Ok(v)) => Poll::Ready(v),
-            // Sender dropped → owner disposed; park forever.
+            // A worker panic leaves no result; owner cancellation still drops this receiver.
             Poll::Ready(Err(_)) => Poll::Pending,
             Poll::Pending => Poll::Pending,
         }
@@ -276,7 +307,12 @@ impl<T> Future for BlockingResult<T> {
 /// doesn't bleed across.
 #[doc(hidden)]
 pub fn __reset_for_tests() {
-    TASKS.with_borrow_mut(|tasks| *tasks = TaskState::new());
+    clear();
+}
+
+pub(crate) fn clear() {
+    let removed = TASKS.with_borrow_mut(|tasks| std::mem::replace(tasks, TaskState::new()));
+    drop(removed);
 }
 
 #[cfg(test)]
@@ -297,50 +333,59 @@ mod tests {
 
     #[test]
     fn spawn_local_does_not_block_poll_at_call_time() {
-        let _g = lock();
-        reset_all();
-        let flag = Rc::new(Cell::new(false));
-        let f = flag.clone();
-        spawn_local(async move {
-            f.set(true);
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let flag = Rc::new(Cell::new(false));
+            let f = flag.clone();
+            spawn_local(async move {
+                f.set(true);
+            });
+            assert!(!flag.get(), "spawn should not poll synchronously");
+            run_until_stalled();
+            assert!(flag.get(), "tick should drive the task to completion");
         });
-        assert!(!flag.get(), "spawn should not poll synchronously");
-        run_until_stalled();
-        assert!(flag.get(), "tick should drive the task to completion");
     }
 
     #[test]
     fn run_until_stalled_drains_multiple_independent_tasks() {
-        let _g = lock();
-        reset_all();
-        let counter = Rc::new(Cell::new(0));
-        for _ in 0..5 {
-            let c = counter.clone();
-            spawn_local(async move {
-                c.set(c.get() + 1);
-            });
-        }
-        run_until_stalled();
-        assert_eq!(counter.get(), 5);
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let counter = Rc::new(Cell::new(0));
+            for _ in 0..5 {
+                let c = counter.clone();
+                spawn_local(async move {
+                    c.set(c.get() + 1);
+                });
+            }
+            run_until_stalled();
+            assert_eq!(counter.get(), 5);
+        });
     }
 
     #[test]
     fn running_task_can_spawn_another_local_task() {
-        let _g = lock();
-        reset_all();
-        let phase = Rc::new(Cell::new(0));
-        let outer_phase = phase.clone();
-        spawn_local(async move {
-            outer_phase.set(1);
-            let inner_phase = outer_phase.clone();
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let phase = Rc::new(Cell::new(0));
+            let outer_phase = phase.clone();
             spawn_local(async move {
-                inner_phase.set(2);
+                outer_phase.set(1);
+                let inner_phase = outer_phase.clone();
+                spawn_local(async move {
+                    inner_phase.set(2);
+                });
             });
+
+            run_until_stalled();
+
+            assert_eq!(phase.get(), 2);
         });
-
-        run_until_stalled();
-
-        assert_eq!(phase.get(), 2);
     }
 
     /// Future that returns Pending on its first poll (re-waking
@@ -369,61 +414,70 @@ mod tests {
 
     #[test]
     fn run_until_stalled_resumes_self_woken_tasks_within_one_call() {
-        let _g = lock();
-        reset_all();
-        let phase = Rc::new(Cell::new(0));
-        let phase_for_task = phase.clone();
-        spawn_local(async move {
-            Yielder {
-                phase: phase_for_task,
-                polled_once: false,
-            }
-            .await;
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let phase = Rc::new(Cell::new(0));
+            let phase_for_task = phase.clone();
+            spawn_local(async move {
+                Yielder {
+                    phase: phase_for_task,
+                    polled_once: false,
+                }
+                .await;
+            });
+            run_until_stalled();
+            assert_eq!(phase.get(), 2);
         });
-        run_until_stalled();
-        assert_eq!(phase.get(), 2);
     }
 
     #[test]
     fn run_blocking_returns_value_from_worker_thread() {
-        let _g = lock();
-        reset_all();
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
 
-        let got: Rc<RefCell<Option<i32>>> = Rc::new(RefCell::new(None));
-        let got_for_task = got.clone();
-        spawn_local(async move {
-            let v = run_blocking(|| 42_i32).await;
-            *got_for_task.borrow_mut() = Some(v);
+            let got: Rc<RefCell<Option<i32>>> = Rc::new(RefCell::new(None));
+            let got_for_task = got.clone();
+            spawn_local(async move {
+                let v = run_blocking(|| 42_i32).await;
+                *got_for_task.borrow_mut() = Some(v);
+            });
+
+            // The worker may not have scheduled yet, so poll-loop with a
+            // cap until the value lands.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+            while got.borrow().is_none() && std::time::Instant::now() < deadline {
+                run_until_stalled();
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            assert_eq!(*got.borrow(), Some(42));
         });
-
-        // The worker may not have scheduled yet, so poll-loop with a
-        // cap until the value lands.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
-        while got.borrow().is_none() && std::time::Instant::now() < deadline {
-            run_until_stalled();
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
-        assert_eq!(*got.borrow(), Some(42));
     }
 
     #[test]
     fn run_blocking_completion_does_not_require_legacy_dispatcher() {
-        let _g = lock();
-        reset_all();
-        let polled = Rc::new(Cell::new(false));
-        let polled_for_task = polled.clone();
-        spawn_local(async move {
-            let _v: () = run_blocking(|| {}).await;
-            polled_for_task.set(true);
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let polled = Rc::new(Cell::new(false));
+            let polled_for_task = polled.clone();
+            spawn_local(async move {
+                let _v: () = run_blocking(|| {}).await;
+                polled_for_task.set(true);
+            });
+            for _ in 0..20 {
+                run_until_stalled();
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            assert!(
+                polled.get(),
+                "the result channel and task waker must work through the Host wake callback"
+            );
         });
-        for _ in 0..20 {
-            run_until_stalled();
-            std::thread::sleep(std::time::Duration::from_millis(5));
-        }
-        assert!(
-            polled.get(),
-            "the result channel and task waker must work through the Host wake callback"
-        );
     }
 
     /// A future that parks on its first poll, stashing its `Waker` in a
@@ -453,101 +507,110 @@ mod tests {
 
     #[test]
     fn foreign_thread_wake_invokes_drive_hook_and_resumes_task() {
-        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-        let _g = lock();
-        reset_all();
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+            let _g = lock();
+            reset_all();
 
-        // The test hook counts pokes; the re-poll the real DRIVE
-        // callback would do is done explicitly below.
-        static DRIVE_POKES: AtomicUsize = AtomicUsize::new(0);
-        DRIVE_POKES.store(0, Ordering::SeqCst);
-        fn test_hook() {
-            DRIVE_POKES.fetch_add(1, Ordering::SeqCst);
-        }
-        let prev = set_drive_hook(test_hook);
-
-        let done = Arc::new(AtomicBool::new(false));
-        let waker_slot: Arc<std::sync::Mutex<Option<std::task::Waker>>> =
-            Arc::new(std::sync::Mutex::new(None));
-        let completed = Rc::new(Cell::new(false));
-
-        let done_for_task = done.clone();
-        let slot_for_task = waker_slot.clone();
-        let completed_for_task = completed.clone();
-        spawn_local(async move {
-            ForeignSignal {
-                done: done_for_task,
-                waker_slot: slot_for_task,
+            // The test hook counts pokes; the re-poll the real DRIVE
+            // callback would do is done explicitly below.
+            static DRIVE_POKES: AtomicUsize = AtomicUsize::new(0);
+            DRIVE_POKES.store(0, Ordering::SeqCst);
+            fn test_hook() {
+                DRIVE_POKES.fetch_add(1, Ordering::SeqCst);
             }
-            .await;
-            completed_for_task.set(true);
-        });
+            let prev = set_drive_hook(test_hook);
 
-        run_until_stalled();
-        assert!(!completed.get(), "task should be parked awaiting signal");
-        assert!(
-            waker_slot.lock().unwrap().is_some(),
-            "task must have stashed its waker on the first poll"
-        );
+            let done = Arc::new(AtomicBool::new(false));
+            let waker_slot: Arc<std::sync::Mutex<Option<std::task::Waker>>> =
+                Arc::new(std::sync::Mutex::new(None));
+            let completed = Rc::new(Cell::new(false));
 
-        // Complete the future from a SEPARATE std::thread — the
-        // foreign-thread wake this test exists for.
-        let done_for_thread = done.clone();
-        let slot_for_thread = waker_slot.clone();
-        let handle = std::thread::spawn(move || {
-            done_for_thread.store(true, Ordering::SeqCst);
-            let waker = slot_for_thread.lock().unwrap().take().unwrap();
-            waker.wake();
-        });
-        handle.join().unwrap();
+            let done_for_task = done.clone();
+            let slot_for_task = waker_slot.clone();
+            let completed_for_task = completed.clone();
+            spawn_local(async move {
+                ForeignSignal {
+                    done: done_for_task,
+                    waker_slot: slot_for_task,
+                }
+                .await;
+                completed_for_task.set(true);
+            });
 
-        assert!(
-            DRIVE_POKES.load(Ordering::SeqCst) >= 1,
-            "foreign-thread wake must invoke the drive hook so the main \
+            run_until_stalled();
+            assert!(!completed.get(), "task should be parked awaiting signal");
+            assert!(
+                waker_slot.lock().unwrap().is_some(),
+                "task must have stashed its waker on the first poll"
+            );
+
+            // Complete the future from a SEPARATE std::thread — the
+            // foreign-thread wake this test exists for.
+            let done_for_thread = done.clone();
+            let slot_for_thread = waker_slot.clone();
+            let handle = std::thread::spawn(move || {
+                done_for_thread.store(true, Ordering::SeqCst);
+                let waker = slot_for_thread.lock().unwrap().take().unwrap();
+                waker.wake();
+            });
+            handle.join().unwrap();
+
+            assert!(
+                DRIVE_POKES.load(Ordering::SeqCst) >= 1,
+                "foreign-thread wake must invoke the drive hook so the main \
              loop re-polls the pool (issue #7)"
-        );
+            );
 
-        // Stand in for the DRIVE callback the hook would have triggered.
-        run_until_stalled();
-        assert!(
-            completed.get(),
-            "task must resume and complete after the foreign-thread wake \
+            // Stand in for the DRIVE callback the hook would have triggered.
+            run_until_stalled();
+            assert!(
+                completed.get(),
+                "task must resume and complete after the foreign-thread wake \
              drove a re-poll"
-        );
+            );
 
-        set_drive_hook(prev);
+            set_drive_hook(prev);
+        });
     }
 
     #[test]
     fn reset_clears_pending_tasks() {
-        let _g = lock();
-        reset_all();
-        let counter = Rc::new(Cell::new(0));
-        let c = counter.clone();
-        spawn_local(async move {
-            c.set(c.get() + 1);
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let _g = lock();
+            reset_all();
+            let counter = Rc::new(Cell::new(0));
+            let c = counter.clone();
+            spawn_local(async move {
+                c.set(c.get() + 1);
+            });
+            __reset_for_tests();
+            run_until_stalled();
+            assert_eq!(counter.get(), 0, "reset should drop pending tasks");
         });
-        __reset_for_tests();
-        run_until_stalled();
-        assert_eq!(counter.get(), 0, "reset should drop pending tasks");
     }
 
     #[test]
     fn spawn_local_after_reset_uses_fresh_spawner() {
-        // `__reset_for_tests` must rebuild SPAWNER from the fresh POOL,
-        // or later `spawn_local` calls enqueue onto the dead one.
-        let _g = lock();
-        reset_all();
-        __reset_for_tests();
-        let flag = Rc::new(Cell::new(false));
-        let f = flag.clone();
-        spawn_local(async move {
-            f.set(true);
+        let runtime = crate::RuntimeContext::new(crate::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            // `__reset_for_tests` must rebuild SPAWNER from the fresh POOL,
+            // or later `spawn_local` calls enqueue onto the dead one.
+            let _g = lock();
+            reset_all();
+            __reset_for_tests();
+            let flag = Rc::new(Cell::new(false));
+            let f = flag.clone();
+            spawn_local(async move {
+                f.set(true);
+            });
+            run_until_stalled();
+            assert!(
+                flag.get(),
+                "spawner must be re-bound to the new pool after reset"
+            );
         });
-        run_until_stalled();
-        assert!(
-            flag.get(),
-            "spawner must be re-bound to the new pool after reset"
-        );
     }
 }

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -255,6 +255,7 @@ pub trait DynRenderer {
 }
 
 thread_local! {
+    static ELEMENT_CALLBACKS: RefCell<HashMap<Element, Vec<crate::lifetime::Cancellation>>> = RefCell::new(HashMap::new());
     /// The active renderer for this thread. `None` outside any mount.
     ///
     /// Wrapped in `RefCell<Option<Box<dyn>>>` rather than holding the
@@ -299,6 +300,7 @@ thread_local! {
 }
 
 pub(crate) struct ViewRuntimeState {
+    callbacks: HashMap<Element, Vec<crate::lifetime::Cancellation>>,
     children: HashMap<Element, Vec<Element>>,
     parents: HashMap<Element, Element>,
     phantoms: HashSet<Element>,
@@ -308,6 +310,7 @@ pub(crate) struct ViewRuntimeState {
 impl ViewRuntimeState {
     pub(crate) fn new() -> Self {
         Self {
+            callbacks: HashMap::new(),
             children: HashMap::new(),
             parents: HashMap::new(),
             phantoms: HashSet::new(),
@@ -317,6 +320,7 @@ impl ViewRuntimeState {
 }
 
 pub(crate) fn swap_runtime_state(state: &mut ViewRuntimeState) {
+    ELEMENT_CALLBACKS.with_borrow_mut(|active| std::mem::swap(active, &mut state.callbacks));
     CHILDREN_OF.with_borrow_mut(|active| std::mem::swap(active, &mut state.children));
     PARENT_OF.with_borrow_mut(|active| std::mem::swap(active, &mut state.parents));
     PHANTOM_ELEMENTS.with_borrow_mut(|active| std::mem::swap(active, &mut state.phantoms));
@@ -455,6 +459,10 @@ pub fn create_element(tag: ElementTag) -> Element {
 }
 
 pub fn release_element(handle: Element) {
+    let callbacks = ELEMENT_CALLBACKS.with_borrow_mut(|callbacks| callbacks.remove(&handle));
+    for callback in callbacks.into_iter().flatten() {
+        callback.cancel();
+    }
     if is_phantom(handle) {
         // Phantom never reached Host; tear down mirror state only.
         PHANTOM_ELEMENTS.with_borrow_mut(|s| {
@@ -898,6 +906,16 @@ pub fn __reset_children_mirror_for_tests() {
     CHILDREN_OF.with_borrow_mut(|map| map.clear());
 }
 
+fn element_callback<T: 'static>(handle: Element, callback: T) -> crate::lifetime::Scoped<T> {
+    let scoped = crate::lifetime::Scoped::new(callback);
+    ELEMENT_CALLBACKS.with_borrow_mut(|callbacks| {
+        let callbacks = callbacks.entry(handle).or_default();
+        callbacks.retain(crate::lifetime::Cancellation::is_live);
+        callbacks.push(scoped.cancellation());
+    });
+    scoped
+}
+
 pub fn set_event_listener(
     handle: Element,
     event_name: &str,
@@ -909,6 +927,10 @@ pub fn set_event_listener(
         drop(callback);
         return;
     }
+    let scoped = element_callback(handle, callback);
+    let callback = Box::new(move |value| {
+        scoped.with(|f| f(value));
+    });
     with_renderer(
         |r| r.set_event_listener(handle, event_name, bind_type, callback),
         (),
@@ -921,6 +943,10 @@ pub fn observe_layout(handle: Element, callback: Box<dyn Fn(LayoutObservation) +
         drop(callback);
         return;
     }
+    let scoped = element_callback(handle, callback);
+    let callback = Box::new(move |value| {
+        scoped.with(|f| f(value));
+    });
     with_renderer(|renderer| renderer.observe_layout(handle, callback), ())
 }
 
@@ -932,6 +958,10 @@ pub fn observe_layout_batch_end(handle: Element, callback: Box<dyn Fn() + 'stati
         drop(callback);
         return;
     }
+    let scoped = element_callback(handle, callback);
+    let callback = Box::new(move || {
+        scoped.with(|f| f());
+    });
     with_renderer(
         |renderer| renderer.observe_layout_batch_end(handle, callback),
         (),

--- a/crates/whisker-runtime/tests/owner_lifetime.rs
+++ b/crates/whisker-runtime/tests/owner_lifetime.rs
@@ -1,0 +1,460 @@
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+use whisker_runtime::module::{ModuleHost, PlatformModule, with_module_host};
+use whisker_runtime::reactive::{Owner, RwSignal, on_cleanup, resource};
+use whisker_runtime::tasks::run_until_stalled;
+use whisker_runtime::value::WhiskerValue;
+use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
+
+#[test]
+fn resource_does_not_resume_fetcher_after_owner_disposal() {
+    let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let (tx, rx) = futures_channel::oneshot::channel::<()>();
+        let rx = Rc::new(RefCell::new(Some(rx)));
+        let resumed = Rc::new(Cell::new(false));
+        owner.with(|| {
+            let source = RwSignal::new(42);
+            let resumed = resumed.clone();
+            resource(move || {
+                let rx = rx.borrow_mut().take().unwrap();
+                let resumed = resumed.clone();
+                async move {
+                    rx.await.unwrap();
+                    resumed.set(true);
+                    Ok(source.get())
+                }
+            });
+        });
+        run_until_stalled();
+        owner.dispose();
+        let _ = tx.send(());
+        run_until_stalled();
+        assert!(!resumed.get());
+    });
+}
+
+#[test]
+fn module_dispatch_skips_listener_removed_during_same_event() {
+    let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        let host = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        with_module_host(&host, || {
+            let a = Owner::new(None);
+            let b = Owner::new(None);
+            let hits = Rc::new(Cell::new(0));
+            for (owner, other) in [(a, b), (b, a)] {
+                owner.with(|| {
+                    let value = RwSignal::new(1);
+                    let hits = hits.clone();
+                    let sub = PlatformModule::named("audit").on_event("change", move |_| {
+                        other.dispose();
+                        hits.set(hits.get() + value.get());
+                    });
+                    on_cleanup(move || drop(sub));
+                });
+            }
+            host.dispatch_event("audit", "change", WhiskerValue::Null);
+            assert_eq!(hits.get(), 1);
+            a.dispose();
+            b.dispose();
+        });
+    });
+}
+
+#[test]
+fn input_dispatch_skips_listener_after_capture_unmounts_target() {
+    use whisker_engine::whisker_style::StyleEnvironment;
+    use whisker_protocol::{InputEvent, InputEventKind, SurfaceId};
+    use whisker_runtime::view::{BindType, create_element, set_event_listener};
+    use whisker_runtime::{ElementTag, RuntimeInstance, SurfaceRuntime};
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(1).unwrap(),
+        StyleEnvironment::new(320.0, 480.0, 1.0, 14.0),
+    );
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    let hits = Rc::new(Cell::new(0));
+    let captured_hits = hits.clone();
+    runtime
+        .mount(move || {
+            let owner = Owner::new(None);
+            owner.with(|| {
+                let element = create_element(ElementTag::View);
+                let value = RwSignal::new(1);
+                set_event_listener(
+                    element,
+                    "click",
+                    BindType::CaptureBind,
+                    Box::new(move |_| owner.dispose()),
+                );
+                set_event_listener(
+                    element,
+                    "click",
+                    BindType::Bind,
+                    Box::new(move |_| captured_hits.set(value.get())),
+                );
+                element
+            })
+        })
+        .unwrap();
+    runtime
+        .dispatch_input(&InputEvent {
+            surface: surface.surface(),
+            timestamp_ms: 1.0,
+            kind: InputEventKind::Click,
+            pointer: None,
+            target: surface.root(),
+            detail: WhiskerValue::Null,
+        })
+        .unwrap();
+    assert_eq!(hits.get(), 0);
+}
+
+#[test]
+fn mount_callback_is_cancelled_when_owner_disposes_before_flush() {
+    let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        owner.with(|| {
+            let value = RwSignal::new(1);
+            whisker_runtime::reactive::on_mount(move || {
+                let _ = value.get();
+            });
+        });
+        owner.dispose();
+        whisker_runtime::reactive::flush_mounts();
+    });
+}
+
+struct Dropped(Rc<Cell<usize>>);
+impl Drop for Dropped {
+    fn drop(&mut self) {
+        self.0.set(self.0.get() + 1);
+    }
+}
+fn context() -> RuntimeContext {
+    RuntimeContext::new(RuntimeWakeHandle::new(|| {}))
+}
+
+#[test]
+fn pending_and_unpolled_tasks_release_captures_immediately() {
+    for poll in [false, true] {
+        let runtime = context();
+        runtime.enter(|| {
+            let owner = Owner::new(None);
+            let drops = Rc::new(Cell::new(0));
+            let capture = Dropped(drops.clone());
+            owner.with(|| {
+                whisker_runtime::tasks::spawn_local(async move {
+                    let _capture = capture;
+                    std::future::pending::<()>().await;
+                })
+            });
+            if poll {
+                run_until_stalled();
+            }
+            owner.dispose();
+            assert_eq!(drops.get(), 1);
+            run_until_stalled();
+            assert_eq!(drops.get(), 1);
+        });
+    }
+}
+
+#[test]
+fn polls_restore_owner_for_nested_tasks_and_pause_does_not_cancel_them() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let drops = Rc::new(Cell::new(0));
+        let capture = Dropped(drops.clone());
+        owner.with(|| {
+            whisker_runtime::tasks::spawn_local(async move {
+                assert_eq!(Owner::current(), Some(owner));
+                whisker_runtime::tasks::spawn_local(async move {
+                    assert_eq!(Owner::current(), Some(owner));
+                    let _capture = capture;
+                    std::future::pending::<()>().await;
+                });
+            })
+        });
+        owner.pause();
+        run_until_stalled();
+        assert_eq!(drops.get(), 0);
+        owner.dispose();
+        assert_eq!(drops.get(), 1);
+    });
+}
+
+#[test]
+fn disposal_inside_a_poll_waits_until_that_poll_returns() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let value = owner.with(|| RwSignal::new(42));
+        let finished = Rc::new(Cell::new(false));
+        let result = finished.clone();
+        owner.with(|| {
+            whisker_runtime::tasks::spawn_local(async move {
+                owner.dispose();
+                assert_eq!(value.get(), 42);
+                result.set(true);
+            })
+        });
+        run_until_stalled();
+        assert!(finished.get());
+        assert_eq!(value.try_get(), None);
+    });
+}
+
+#[test]
+fn resource_replacement_drops_a_pending_fetch_without_a_wake() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let drops = Rc::new(Cell::new(0));
+        let source = owner.with(|| {
+            let source = RwSignal::new(0);
+            let drops = drops.clone();
+            resource(move || {
+                let _ = source.get();
+                let capture = Dropped(drops.clone());
+                async move {
+                    let _capture = capture;
+                    std::future::pending::<()>().await;
+                    Ok(())
+                }
+            });
+            source
+        });
+        run_until_stalled();
+        source.set(1);
+        whisker_runtime::reactive::flush();
+        assert_eq!(drops.get(), 1);
+        owner.dispose();
+        assert_eq!(drops.get(), 2);
+    });
+}
+
+#[test]
+fn owner_cleanup_stops_native_observation_even_with_a_retained_subscription() {
+    let runtime = context();
+    let observations = Rc::new(RefCell::new(Vec::new()));
+    let log = observations.clone();
+    let host = ModuleHost::new(
+        |_, _, _, _, _| false,
+        move |_, _, observing| log.borrow_mut().push(observing),
+    );
+    let subscription = runtime.enter(|| {
+        with_module_host(&host, || {
+            let owner = Owner::new(None);
+            let subscription = owner
+                .with(|| PlatformModule::named("test").on_event("change", |_| panic!("disposed")));
+            owner.dispose();
+            assert!(!host.dispatch_event("test", "change", WhiskerValue::Null));
+            subscription
+        })
+    });
+    assert_eq!(*observations.borrow(), vec![true, false]);
+    drop(subscription);
+    assert_eq!(*observations.borrow(), vec![true, false]);
+}
+
+#[test]
+fn callback_disposal_keeps_current_reads_valid_and_skips_nested_delivery() {
+    let runtime = context();
+    runtime.enter(|| {
+        let host = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        with_module_host(&host, || {
+            let owner = Owner::new(None);
+            let calls = Rc::new(Cell::new(0));
+            let value = owner.with(|| RwSignal::new(42));
+            let nested = host.clone();
+            let result = calls.clone();
+            let _sub = owner.with(|| {
+                PlatformModule::named("test").on_event("change", move |_| {
+                    owner.dispose();
+                    nested.dispatch_event("test", "change", WhiskerValue::Null);
+                    result.set(result.get() + 1);
+                    assert_eq!(value.get(), 42);
+                })
+            });
+            host.dispatch_event("test", "change", WhiskerValue::Null);
+            assert_eq!(calls.get(), 1);
+            assert_eq!(value.try_get(), None);
+        });
+    });
+}
+
+#[test]
+fn callback_panic_restores_execution_and_owner_state() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let value = owner.with(|| RwSignal::new(42));
+        let callback = owner.with(|| {
+            whisker_runtime::lifetime::Scoped::new(move || {
+                owner.dispose();
+                panic!("callback failed");
+            })
+        });
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback.with(|f| f())))
+                .is_err()
+        );
+        assert_eq!(Owner::current(), None);
+        assert_eq!(value.try_get(), None);
+        let next = Owner::new(None);
+        let value = next.with(|| RwSignal::new(1));
+        next.dispose();
+        assert_eq!(value.try_get(), None);
+    });
+}
+
+#[test]
+fn try_reads_track_live_values_and_distinguish_a_stored_none_from_disposal() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let (value, tracked, untracked) = owner.with(|| {
+            let value = RwSignal::new(None::<usize>);
+            let tracked = Rc::new(Cell::new(0));
+            let untracked = Rc::new(Cell::new(0));
+            let t = tracked.clone();
+            whisker_runtime::reactive::effect(move || {
+                let _ = value.try_get();
+                t.set(t.get() + 1);
+            });
+            let u = untracked.clone();
+            whisker_runtime::reactive::effect(move || {
+                let _ = value.try_get_untracked();
+                u.set(u.get() + 1);
+            });
+            (value, tracked, untracked)
+        });
+        assert_eq!(value.try_get(), Some(None));
+        value.set(Some(3));
+        whisker_runtime::reactive::flush();
+        assert_eq!(tracked.get(), 2);
+        assert_eq!(untracked.get(), 1);
+        assert_eq!(value.read_only().try_get(), Some(Some(3)));
+        owner.dispose();
+        assert_eq!(value.try_get_untracked(), None);
+        assert_eq!(value.read_only().try_get(), None);
+        assert!(!value.try_set(Some(4)));
+    });
+}
+
+#[test]
+fn a_parent_task_must_use_try_reads_for_a_shorter_lived_child_signal() {
+    let runtime = context();
+    runtime.enter(|| {
+        let parent = Owner::new(None);
+        let child = Owner::new(Some(parent));
+        let value = child.with(|| RwSignal::new(42));
+        let ran = Rc::new(Cell::new(false));
+        let result = ran.clone();
+        parent.with(|| {
+            whisker_runtime::tasks::spawn_local(async move {
+                assert_eq!(value.try_get(), None);
+                result.set(true);
+            })
+        });
+        child.dispose();
+        run_until_stalled();
+        assert!(ran.get());
+        parent.dispose();
+    });
+}
+
+#[test]
+fn spawning_without_a_runtime_is_rejected() {
+    assert!(std::panic::catch_unwind(|| whisker_runtime::tasks::spawn_local(async {})).is_err());
+}
+
+#[test]
+fn closing_owners_reject_new_work_before_the_current_callback_returns() {
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let callback = owner.with(|| {
+            whisker_runtime::lifetime::Scoped::new(move || {
+                owner.dispose();
+                assert!(
+                    std::panic::catch_unwind(|| whisker_runtime::tasks::spawn_local(async {}))
+                        .is_err()
+                );
+                assert!(std::panic::catch_unwind(|| Owner::new(None)).is_err());
+            })
+        });
+        callback.with(|f| f());
+    });
+}
+
+#[test]
+fn explicit_element_release_cancels_already_planned_bubble_callbacks() {
+    use whisker_engine::whisker_style::StyleEnvironment;
+    use whisker_protocol::{InputEvent, InputEventKind, SurfaceId};
+    use whisker_runtime::view::{BindType, create_element, release_element, set_event_listener};
+    use whisker_runtime::{ElementTag, RuntimeInstance, SurfaceRuntime};
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(1).unwrap(),
+        StyleEnvironment::new(320.0, 480.0, 1.0, 14.0),
+    );
+    let mut runtime = RuntimeInstance::new(surface.clone(), RuntimeWakeHandle::new(|| {}));
+    runtime
+        .mount(|| {
+            let element = create_element(ElementTag::View);
+            set_event_listener(
+                element,
+                "click",
+                BindType::CaptureBind,
+                Box::new(move |_| release_element(element)),
+            );
+            set_event_listener(
+                element,
+                "click",
+                BindType::Bind,
+                Box::new(|_| panic!("released listener was dispatched")),
+            );
+            element
+        })
+        .unwrap();
+    runtime
+        .dispatch_input(&InputEvent {
+            surface: surface.surface(),
+            timestamp_ms: 1.0,
+            kind: InputEventKind::Click,
+            pointer: None,
+            target: surface.root(),
+            detail: WhiskerValue::Null,
+        })
+        .unwrap();
+}
+
+#[test]
+fn explicit_unsubscribe_skips_other_callbacks_in_the_same_snapshot() {
+    let runtime = context();
+    runtime.enter(|| {
+        let host = ModuleHost::new(|_, _, _, _, _| false, |_, _, _| {});
+        with_module_host(&host, || {
+            let subscriptions = Rc::new(RefCell::new(Vec::new()));
+            let hits = Rc::new(Cell::new(0));
+            for _ in 0..2 {
+                let retained = subscriptions.clone();
+                let hits = hits.clone();
+                let sub = PlatformModule::named("test").on_event("change", move |_| {
+                    let removed = std::mem::take(&mut *retained.borrow_mut());
+                    drop(removed);
+                    hits.set(hits.get() + 1);
+                });
+                subscriptions.borrow_mut().push(sub);
+            }
+            host.dispatch_event("test", "change", WhiskerValue::Null);
+            assert_eq!(hits.get(), 1);
+        });
+    });
+}

--- a/crates/whisker-runtime/tests/runtime_cache.rs
+++ b/crates/whisker-runtime/tests/runtime_cache.rs
@@ -1,0 +1,209 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use whisker_runtime::reactive::{Owner, RwSignal, effect, flush, on_cleanup};
+use whisker_runtime::{RuntimeContext, RuntimeWakeHandle, runtime_local};
+
+fn context() -> RuntimeContext {
+    RuntimeContext::new(RuntimeWakeHandle::new(|| {}))
+}
+
+#[test]
+fn declarations_are_independent_and_non_clone_values_initialize_once_per_runtime() {
+    struct State(Cell<usize>);
+    runtime_local! {
+        static FIRST: State = State(Cell::new(1));
+        static SECOND: State = State(Cell::new(2));
+    }
+    let first = context();
+    let second = context();
+    first.enter(|| FIRST.with(|state| state.0.set(42)));
+    second.enter(|| {
+        assert_eq!(FIRST.with(|state| state.0.get()), 1);
+        assert_eq!(SECOND.with(|state| state.0.get()), 2);
+    });
+    first.enter(|| assert_eq!(FIRST.with(|state| state.0.get()), 42));
+    drop(first);
+    context().enter(|| assert_eq!(FIRST.with(|state| state.0.get()), 1));
+}
+
+#[test]
+fn nested_initializers_are_untracked_and_values_outlive_the_first_component() {
+    runtime_local! {
+        static SOURCE: RwSignal<usize> = RwSignal::new(1);
+        static SNAPSHOT: usize = SOURCE.with(|signal| signal.get());
+    }
+    let runtime = context();
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let runs = Rc::new(Cell::new(0));
+        owner.with(|| {
+            let runs = runs.clone();
+            effect(move || {
+                SNAPSHOT.with(|_| runs.set(runs.get() + 1));
+            });
+        });
+        SOURCE.with(|signal| signal.set(2));
+        flush();
+        assert_eq!(runs.get(), 1);
+        owner.dispose();
+        assert_eq!(SOURCE.with(|signal| signal.get()), 2);
+        assert_eq!(SNAPSHOT.with(|value| *value), 1);
+    });
+}
+
+#[test]
+fn cache_values_can_be_borrowed_recursively_after_initialization() {
+    runtime_local! { static VALUE: usize = 3; }
+    context().enter(|| assert_eq!(VALUE.with(|a| VALUE.with(|b| a + b)), 6));
+}
+
+#[test]
+fn recursive_initialization_panics_and_rolls_back_for_a_retry() {
+    runtime_local! {
+        static RECURSE: Cell<bool> = Cell::new(true);
+        static VALUE: usize = if RECURSE.with(|flag| flag.replace(false)) { VALUE.with(|value| *value) } else { 7 };
+    }
+    context().enter(|| {
+        assert!(std::panic::catch_unwind(|| VALUE.with(|_| ())).is_err());
+        assert_eq!(VALUE.with(|value| *value), 7);
+    });
+}
+
+#[test]
+fn a_panicking_initializer_cleans_up_subscriptions_and_tasks_before_retrying() {
+    use whisker_runtime::module::{ModuleHost, PlatformModule, with_module_host};
+    runtime_local! {
+        static ATTEMPTS: Cell<usize> = Cell::new(0);
+        static VALUE: usize = {
+            let sub = PlatformModule::named("test").on_event("change", |_| {});
+            on_cleanup(move || drop(sub));
+            whisker_runtime::tasks::spawn_local(std::future::pending());
+            if ATTEMPTS.with(|attempts| { let n=attempts.get(); attempts.set(n+1); n }) == 0 { panic!("initialization failed"); }
+            42
+        };
+    }
+    let observations = Rc::new(RefCell::new(Vec::new()));
+    let log = observations.clone();
+    let host = ModuleHost::new(
+        |_, _, _, _, _| false,
+        move |_, _, active| log.borrow_mut().push(active),
+    );
+    let runtime = context();
+    runtime.enter(|| {
+        with_module_host(&host, || {
+            assert!(std::panic::catch_unwind(|| VALUE.with(|_| ())).is_err());
+            assert_eq!(*observations.borrow(), vec![true, false]);
+            assert_eq!(VALUE.with(|value| *value), 42);
+        })
+    });
+    runtime.shutdown();
+    assert_eq!(*observations.borrow(), vec![true, false, true, false]);
+}
+
+#[test]
+fn shutdown_drops_values_in_reverse_initialization_order_in_the_original_runtime() {
+    struct Value {
+        label: &'static str,
+        signal: RwSignal<usize>,
+        log: Rc<RefCell<Vec<(&'static str, usize)>>>,
+    }
+    impl Drop for Value {
+        fn drop(&mut self) {
+            self.log.borrow_mut().push((self.label, self.signal.get()));
+        }
+    }
+    runtime_local! {
+        static LOG: Rc<RefCell<Vec<(&'static str,usize)>>> = Rc::new(RefCell::new(Vec::new()));
+        static FIRST: Value = Value { label: "first", signal: RwSignal::new(1), log: LOG.with(Clone::clone) };
+        static SECOND: Value = Value { label: "second", signal: RwSignal::new(2), log: LOG.with(Clone::clone) };
+    }
+    for explicit in [true, false] {
+        let first = context();
+        let second = context();
+        let log = first.enter(|| {
+            FIRST.with(|_| ());
+            SECOND.with(|_| ());
+            LOG.with(Clone::clone)
+        });
+        second.enter(|| {
+            let _signal = RwSignal::new(999);
+            if explicit {
+                first.shutdown();
+                first.shutdown();
+            }
+            drop(first);
+        });
+        assert_eq!(*log.borrow(), vec![("second", 2), ("first", 1)]);
+    }
+}
+
+#[test]
+fn cache_rejects_use_outside_a_runtime_and_on_another_thread() {
+    runtime_local! { static VALUE: usize = 1; }
+    assert!(std::panic::catch_unwind(|| VALUE.with(|_| ())).is_err());
+    context().enter(|| {
+        assert_eq!(VALUE.with(|value| *value), 1);
+        assert!(
+            std::thread::spawn(|| std::panic::catch_unwind(|| VALUE.with(|_| ())).is_err())
+                .join()
+                .unwrap()
+        );
+    });
+}
+
+#[test]
+fn shutdown_rejects_new_cache_initialization_but_remains_idempotent() {
+    runtime_local! { static UNUSED: usize = 1; }
+    let runtime = context();
+    let rejected = Rc::new(Cell::new(false));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let rejected = rejected.clone();
+        owner.with(|| {
+            on_cleanup(move || {
+                rejected.set(std::panic::catch_unwind(|| UNUSED.with(|_| ())).is_err());
+            })
+        });
+    });
+    runtime.shutdown();
+    assert!(rejected.get());
+    runtime.shutdown();
+}
+
+#[test]
+fn detached_owner_drop_is_routed_to_its_original_runtime() {
+    use whisker_runtime::lifetime::OwnedOwner;
+    let first = context();
+    let second = context();
+    let (owner, value) = first.enter(|| {
+        let owner = OwnedOwner::new();
+        let value = owner.with(|| RwSignal::new(1));
+        (owner, value)
+    });
+    second.enter(|| {
+        let other = RwSignal::new(2);
+        drop(owner);
+        assert_eq!(other.get(), 2);
+    });
+    first.enter(|| {
+        whisker_runtime::drain_runtime_dispatches();
+        assert_eq!(value.try_get(), None);
+    });
+}
+
+#[test]
+fn component_cleanup_can_read_runtime_cached_signals_during_shutdown() {
+    runtime_local! { static VALUE: RwSignal<usize> = RwSignal::new(42); }
+    let runtime = context();
+    let seen = Rc::new(Cell::new(0));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let seen = seen.clone();
+        owner.with(|| {
+            let value = VALUE.with(|value| *value);
+            on_cleanup(move || seen.set(value.get()));
+        });
+    });
+    runtime.shutdown();
+    assert_eq!(seen.get(), 42);
+}

--- a/crates/whisker/src/back.rs
+++ b/crates/whisker/src/back.rs
@@ -35,7 +35,7 @@ struct Entry {
 
 impl Entry {
     fn is_active(&self) -> bool {
-        self.owner.is_none_or(|o| !o.is_paused())
+        self.owner.is_none_or(|o| o.is_alive() && !o.is_paused())
     }
 }
 
@@ -66,12 +66,10 @@ fn revision_signal(state: &SharedBackState) -> RwSignal<u64> {
 
 fn bump_revision(state: &SharedBackState) {
     let sig = revision_signal(state);
-    sig.set(sig.get_untracked() + 1);
+    sig.try_update(|revision| *revision += 1);
 }
 
-/// Keeps its [`on_back`] registration alive. Dropping the guard
-/// unregisters the handler; hold it in the registering component's
-/// state so unmount unregisters automatically.
+/// Retains an [`on_back`] handler until this guard drops or its registering Owner is disposed.
 #[must_use = "the handler is unregistered when the guard drops"]
 pub struct BackGuard {
     id: u64,
@@ -83,15 +81,19 @@ impl Drop for BackGuard {
         let Some(state) = self.state.upgrade() else {
             return;
         };
-        state
-            .borrow_mut()
-            .handlers
-            .retain(|entry| entry.id != self.id);
+        let removed = {
+            let mut state = state.borrow_mut();
+            let Some(index) = state.handlers.iter().position(|entry| entry.id == self.id) else {
+                return;
+            };
+            state.handlers.remove(index)
+        };
         bump_revision(&state);
+        drop(removed);
     }
 }
 
-/// Intercept the platform back action while the returned guard lives.
+/// Intercept the platform back action while both the returned guard and its Owner live.
 ///
 /// The handler fires instead of a stack pop or an app exit whenever
 /// back is triggered with this registration active. Registrations
@@ -113,6 +115,14 @@ pub fn on_back(handler: impl Fn() + 'static) -> BackGuard {
         let id = state.next_id;
         state.next_id = id.saturating_add(1);
         id
+    };
+    let cleanup = BackGuard {
+        id,
+        state: Rc::downgrade(&state),
+    };
+    let scoped = whisker_runtime::lifetime::Scoped::new((handler, cleanup));
+    let handler = move || {
+        scoped.with(|(handler, _)| handler());
     };
     state.borrow_mut().handlers.push(Entry {
         id,
@@ -141,7 +151,10 @@ pub fn exit_app() {
 /// Framework wiring: install the platform exit implementation
 /// [`exit_app`] calls. Registered by the platform gesture component.
 pub fn set_exit_impl(f: impl Fn() + 'static) {
-    state().borrow_mut().exit_impl = Some(Rc::new(f));
+    let f = whisker_runtime::lifetime::Scoped::new(f);
+    state().borrow_mut().exit_impl = Some(Rc::new(move || {
+        f.with(|f| f());
+    }));
 }
 
 /// Framework wiring: whether an active (non-paused) handler exists
@@ -197,9 +210,9 @@ mod tests {
 
     fn reset() {
         let state = state();
-        let mut state = state.borrow_mut();
-        state.handlers.clear();
-        state.exit_impl = None;
+        let handlers = std::mem::take(&mut state.borrow_mut().handlers);
+        drop(handlers);
+        state.borrow_mut().exit_impl = None;
     }
 
     #[test]

--- a/crates/whisker/src/element_ref.rs
+++ b/crates/whisker/src/element_ref.rs
@@ -103,10 +103,7 @@ impl ElementRef {
     /// (uses `get_untracked()`), so calling from inside an
     /// `effect(...)` doesn't subscribe the effect to the binding.
     pub fn element(&self) -> Option<Element> {
-        if self.inner.is_disposed() {
-            return None;
-        }
-        self.inner.get_untracked()
+        self.inner.try_get_untracked().flatten()
     }
 
     /// `true` iff bound to a live element right now. Non-reactive.

--- a/crates/whisker/src/element_ref.rs
+++ b/crates/whisker/src/element_ref.rs
@@ -99,17 +99,20 @@ impl ElementRef {
     }
 
     /// Currently-bound `Element` handle, or `None` if the ref hasn't
-    /// seen a mount yet (or has been cleared by unmount). Non-reactive
+    /// seen a mount yet, has unmounted, or its owner is disposed. Non-reactive
     /// (uses `get_untracked()`), so calling from inside an
     /// `effect(...)` doesn't subscribe the effect to the binding.
     pub fn element(&self) -> Option<Element> {
+        if self.inner.is_disposed() {
+            return None;
+        }
         self.inner.get_untracked()
     }
 
     /// `true` iff bound to a live element right now. Non-reactive.
     /// For reactive observation, use [`bound`](Self::bound).
     pub fn is_bound(&self) -> bool {
-        self.inner.get_untracked().is_some()
+        self.element().is_some()
     }
 
     /// Reactive read of "is the underlying element mounted right now?"
@@ -136,8 +139,9 @@ impl ElementRef {
     /// The command is schema-validated and ordered with the next frame. A
     /// successful return means it was enqueued; Host execution happens later
     /// and cannot synchronously return a value.
+    /// Returns [`RefError::NotBound`] after unmount or owner disposal.
     pub fn command(&self, command: &str, parameters: WhiskerValue) -> Result<(), RefError> {
-        let Some(element) = self.inner.get_untracked() else {
+        let Some(element) = self.element() else {
             return Err(RefError::NotBound);
         };
         if !parameters.is_data() {
@@ -184,6 +188,7 @@ impl ElementRef {
     /// mounted in the same owner) `try_set` no-ops gracefully.
     #[doc(hidden)]
     pub fn __unbind(&self) {
+        crate::focus::note_blurred(*self);
         let _ = self.inner.try_set(None);
     }
 }
@@ -215,7 +220,7 @@ impl Default for ElementRef {
 impl std::fmt::Debug for ElementRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ElementRef")
-            .field("element", &self.inner.get_untracked())
+            .field("element", &self.element())
             .finish()
     }
 }

--- a/crates/whisker/src/focus.rs
+++ b/crates/whisker/src/focus.rs
@@ -2,7 +2,7 @@
 //! analogue of React Native's `TextInput.State.currentlyFocusedInput()`.
 //!
 //! A focusable native element (an `<input>`) records itself here when it
-//! gains focus and clears itself when it loses focus. Navigation code
+//! gains focus and clears itself on blur or unmount. Navigation code
 //! (`whisker-router`) reads [`focused_element`] so it can blur — or later
 //! restore — the *specific* field that was focused, instead of firing a
 //! global unfocus. A global unfocus dispatched at navigation time can
@@ -13,8 +13,8 @@
 //! *that* ref rather than calling `Keyboard.dismiss()` on forward pushes.
 //!
 //! Main-thread only: the reactive/UI world is runtime-local, and the state
-//! is only ever touched from focus/blur event handlers and navigation
-//! verbs, all of which run on the runtime thread.
+//! is touched by focus/blur events, element cleanup, and navigation
+//! verbs on the runtime thread.
 
 use std::cell::Cell;
 
@@ -32,7 +32,9 @@ fn state() -> std::rc::Rc<std::cell::RefCell<FocusState>> {
 /// Record `el` as the element that currently holds focus. Call from an
 /// input's focus handler.
 pub fn note_focused(el: ElementRef) {
-    state().borrow().focused.set(Some(el));
+    if el.is_bound() {
+        state().borrow().focused.set(Some(el));
+    }
 }
 
 /// Clear the focused element **iff** it is still `el`, so a stale blur
@@ -48,7 +50,11 @@ pub fn note_blurred(el: ElementRef) {
 
 /// The element that currently holds focus, if any.
 pub fn focused_element() -> Option<ElementRef> {
-    state().borrow().focused.get()
+    let state = state();
+    let state = state.borrow();
+    let focused = state.focused.get().filter(ElementRef::is_bound);
+    state.focused.set(focused);
+    focused
 }
 
 #[cfg(test)]
@@ -56,12 +62,18 @@ mod tests {
     use super::*;
     use whisker_runtime::{RuntimeContext, RuntimeWakeHandle};
 
+    fn bound_ref() -> ElementRef {
+        let element = ElementRef::new();
+        element.__bind(whisker_runtime::view::Element::from_raw(42));
+        element
+    }
+
     #[test]
     fn focused_element_is_isolated_between_runtime_contexts() {
         let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
         let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
-        let first_ref = first.enter(ElementRef::new);
-        let second_ref = second.enter(ElementRef::new);
+        let first_ref = first.enter(bound_ref);
+        let second_ref = second.enter(bound_ref);
 
         first.enter(|| note_focused(first_ref));
         second.enter(|| note_focused(second_ref));
@@ -69,5 +81,42 @@ mod tests {
 
         assert_eq!(first.enter(focused_element), None);
         assert_eq!(second.enter(focused_element), Some(second_ref));
+    }
+
+    #[test]
+    fn unmounting_old_input_preserves_new_focus() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let owner = whisker_runtime::reactive::Owner::new(None);
+            owner.with(|| {
+                let old = bound_ref();
+                let current = bound_ref();
+                note_focused(old);
+                note_focused(current);
+                old.__unbind();
+                assert_eq!(focused_element(), Some(current));
+                note_focused(old);
+                assert_eq!(focused_element(), Some(current));
+                current.__unbind();
+                assert_eq!(state().borrow().focused.get(), None);
+                assert_eq!(focused_element(), None);
+            });
+            owner.dispose();
+        });
+    }
+
+    #[test]
+    fn disposed_input_is_removed_even_without_an_unmount_notification() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| {
+            let owner = whisker_runtime::reactive::Owner::new(None);
+            let input = owner.with(bound_ref);
+            note_focused(input);
+            owner.dispose();
+            assert_eq!(focused_element(), None);
+            assert_eq!(state().borrow().focused.get(), None);
+            note_focused(input);
+            assert_eq!(state().borrow().focused.get(), None);
+        });
     }
 }

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -471,3 +471,5 @@ pub mod prelude {
     // A separate list-item builder is intentionally absent — the `List` render-props
     // builder auto-wraps every item internally.
 }
+
+pub use whisker_runtime::runtime_local;

--- a/crates/whisker/tests/element_ref.rs
+++ b/crates/whisker/tests/element_ref.rs
@@ -236,3 +236,31 @@ fn element_ref_is_copy() {
         assert_eq!(r.element(), r2.element());
     });
 }
+
+#[test]
+fn disposed_ref_rejects_commands_and_reports_unbound() {
+    with_test_env(|| {
+        let owner = Owner::new(None);
+        let input = owner.with(|| {
+            let input = ElementRef::new();
+            let _ = render! { XRefTarget(element_ref: input, value: "x") };
+            input
+        });
+        assert!(input.is_bound());
+        whisker::focus::note_focused(input);
+        owner.dispose();
+
+        assert_eq!(
+            input.command("blur", whisker::WhiskerValue::Null),
+            Err(RefError::NotBound)
+        );
+        assert_eq!(
+            input.command("focus", whisker::WhiskerValue::Null),
+            Err(RefError::NotBound)
+        );
+        assert_eq!(input.element(), None);
+        assert!(!input.is_bound());
+        assert_eq!(whisker::focus::focused_element(), None);
+        assert_eq!(format!("{input:?}"), "ElementRef { element: None }");
+    });
+}

--- a/crates/whisker/tests/owner_lifetime.rs
+++ b/crates/whisker/tests/owner_lifetime.rs
@@ -1,0 +1,18 @@
+use whisker::runtime::{RuntimeContext, RuntimeWakeHandle};
+use whisker::{Owner, RwSignal};
+#[test]
+fn back_handler_does_not_run_after_its_owner_is_disposed() {
+    let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let guard = owner.with(|| {
+            let value = RwSignal::new(1);
+            whisker::back::on_back(move || {
+                let _ = value.get();
+            })
+        });
+        owner.dispose();
+        assert!(!whisker::back::dispatch());
+        drop(guard);
+    });
+}

--- a/packages/whisker-audio/src/runtime.rs
+++ b/packages/whisker-audio/src/runtime.rs
@@ -98,8 +98,7 @@ impl Player {
     pub fn new(source: impl Into<String>) -> Self {
         let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
         let source = source.into();
-        let runtime = whisker::runtime::runtime_local::state::<AudioRuntimeState>();
-        install_status_listener(&runtime);
+        let runtime = AUDIO.with(Clone::clone);
         let status = ArcRwSignal::new(PlaybackStatus::default());
         runtime.borrow_mut().entries.insert(id, status.clone());
         module!("WhiskerAudio").invoke(
@@ -249,6 +248,14 @@ struct AudioRuntimeState {
     subscription: Option<ModuleSubscription>,
 }
 
+whisker::runtime_local! {
+    static AUDIO: Rc<RefCell<AudioRuntimeState>> = {
+        let runtime = Rc::new(RefCell::new(AudioRuntimeState::default()));
+        install_status_listener(&runtime);
+        runtime
+    };
+}
+
 /// One-shot install of the `statusChanged` subscription. Stale
 /// events for ids that were already released drop silently.
 fn install_status_listener(runtime: &Rc<RefCell<AudioRuntimeState>>) {
@@ -292,4 +299,44 @@ fn read_f64(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> f64 {
 
 fn read_bool(fields: &BTreeMap<String, WhiskerValue>, key: &str) -> bool {
     matches!(fields.get(key), Some(WhiskerValue::Bool(true)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker::Owner;
+    use whisker::runtime::module::{ModuleHost, with_module_host};
+    use whisker::runtime::{RuntimeContext, RuntimeWakeHandle};
+
+    #[test]
+    fn status_subscription_outlives_the_first_component_and_ends_with_its_runtime() {
+        let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let observations = Rc::new(RefCell::new(Vec::new()));
+        let log = observations.clone();
+        let host = ModuleHost::new(
+            |_, _, _, _, _| false,
+            move |_, _, active| log.borrow_mut().push(active),
+        );
+        let player = runtime.enter(|| {
+            with_module_host(&host, || {
+                let owner = Owner::new(None);
+                let player = owner.with(|| Player::new("test.mp3"));
+                owner.dispose();
+                host.dispatch_event(
+                    module!("WhiskerAudio").name(),
+                    "statusChanged",
+                    WhiskerValue::Map(BTreeMap::from([
+                        ("playerId".into(), WhiskerValue::Int(player.inner.id as i64)),
+                        ("position".into(), WhiskerValue::Float(12.0)),
+                    ])),
+                );
+                assert_eq!(player.inner.status.get().position, 12.0);
+                assert_eq!(*observations.borrow(), vec![true]);
+                player
+            })
+        });
+        runtime.shutdown();
+        assert_eq!(*observations.borrow(), vec![true, false]);
+        drop(player);
+    }
 }

--- a/packages/whisker-keyboard/src/lib.rs
+++ b/packages/whisker-keyboard/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Two capabilities, both routed through one native `Keyboard` module:
 //!
-//! - [`keyboard_height`] — a process-global
+//! - [`keyboard_height`] — a runtime-local
 //!   `ReadSignal<f64>` carrying the keyboard's current overlap from the
 //!   bottom of the Screen (points on iOS, dp on Android), `0.0` when
 //!   hidden. Pad or scroll a container by this value so a focused input
@@ -59,13 +59,12 @@
 //! - iOS: `packages/whisker-keyboard/ios/Sources/WhiskerKeyboard/KeyboardModule.swift`
 //! - Android: `packages/whisker-keyboard/android/src/main/kotlin/rs/whisker/modules/keyboard/KeyboardModule.kt`
 
-use std::sync::OnceLock;
-
 #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32", test))]
 use whisker::WhiskerValue;
 #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
 use whisker::module;
-use whisker::{ArcRwSignal, ArcWriteSignal, Owner, ReadSignal};
+use whisker::runtime::module::ModuleSubscription;
+use whisker::{ReadSignal, RwSignal};
 
 /// Dismiss the keyboard by releasing focus globally.
 ///
@@ -85,69 +84,41 @@ pub fn dismiss() {
 /// the overlap from the bottom of the screen in points (iOS) / dp
 /// (Android), `0.0` when the keyboard is hidden.
 ///
-/// All calls share one process-global signal (see [`safe_area_insets`
-/// in `whisker-safe-area`] for the identical pattern and the
-/// detached-root minting rationale). The first call wires the native
-/// subscription; later calls are free. The value stays live for the
-/// process lifetime.
-///
-/// **Must be called from the main thread.** The reactive runtime is
-/// thread-local.
-///
-/// [`safe_area_insets` in `whisker-safe-area`]: https://docs.rs/whisker-safe-area
+/// Calls share a signal within the entered Runtime; its shutdown releases the subscription.
+/// The returned handle must only be used in that Runtime on its UI thread.
 pub fn keyboard_height() -> ReadSignal<f64> {
-    install();
-    SLOT.get().expect("install() ran above").read.inner
+    HEIGHT.with(|slot| slot.read)
 }
 
 struct Slot {
-    read: MainThreadOnly<ReadSignal<f64>>,
-    #[allow(dead_code)]
-    write: MainThreadOnly<ArcWriteSignal<f64>>,
+    read: ReadSignal<f64>,
+    _subscription: Option<ModuleSubscription>,
 }
 
-/// One-shot install of the global signal + native subscription.
-/// Idempotent. The `Copy` arena handle callers receive is minted once
-/// under a never-disposed [`Owner::detached_root`] so a transient
-/// per-route / per-component scope can't free it out from under a
-/// surviving reader.
-fn install() {
-    SLOT.get_or_init(|| {
-        let (read, write) = ArcRwSignal::new(0.0_f64).split();
-        subscribe_to_native(MainThreadOnly {
-            inner: write.clone(),
-        });
-        let root = Owner::detached_root();
-        let read_handle: ReadSignal<f64> = root.with(|| read.into());
-        Slot {
-            read: MainThreadOnly { inner: read_handle },
-            write: MainThreadOnly { inner: write },
-        }
-    });
+whisker::runtime_local! {
+    static HEIGHT: Slot = {
+        let signal = RwSignal::new(0.0_f64);
+        Slot { read: signal.read_only(), _subscription: subscribe_to_native(signal) }
+    };
 }
 
-/// Wire the global signal to the native module's `keyboardChanged`
-/// event. The subscription is intentionally leaked — the signal lives
-/// for the process lifetime.
-fn subscribe_to_native(writer: MainThreadOnly<ArcWriteSignal<f64>>) {
+fn subscribe_to_native(writer: RwSignal<f64>) -> Option<ModuleSubscription> {
     #[cfg(not(any(target_os = "android", target_os = "ios", target_arch = "wasm32")))]
     {
         let _ = writer;
+        None
     }
-
     #[cfg(any(target_os = "android", target_os = "ios", target_arch = "wasm32"))]
     {
-        let module = module!("Keyboard");
-        let sub = module.on_event("keyboardChanged", move |payload| {
+        let sub = module!("Keyboard").on_event("keyboardChanged", move |payload| {
             if let Some(height) = decode_payload(payload) {
-                let w = &writer;
-                w.inner.set(height);
+                writer.set(height);
             }
         });
         if let Some(err) = sub.error() {
             eprintln!("[whisker-keyboard] failed to subscribe: {err}");
         }
-        std::mem::forget(sub);
+        Some(sub)
     }
 }
 
@@ -168,8 +139,6 @@ fn decode_payload(value: WhiskerValue) -> Option<f64> {
     Some(height.max(0.0))
 }
 
-static SLOT: OnceLock<Slot> = OnceLock::new();
-
 /// Empty visual schema paired with the service-only Web keyboard Host module.
 #[doc(hidden)]
 pub fn __whisker_element_module_definition() -> whisker::ElementModuleDefinition {
@@ -178,20 +147,6 @@ pub fn __whisker_element_module_definition() -> whisker::ElementModuleDefinition
         std::iter::empty::<whisker::ElementProviderMetadata>(),
     )
 }
-
-/// Locally-scoped wrapper asserting main-thread-only access to
-/// `inner`. Same pattern (and safety contract) as
-/// `whisker-safe-area`'s `MainThreadOnly`: every access path runs on
-/// the runtime thread by contract.
-#[derive(Copy, Clone)]
-struct MainThreadOnly<T> {
-    inner: T,
-}
-// SAFETY: the signal read (`keyboard_height`) and write (the `on_event`
-// callback) both run on the runtime thread by contract. Misuse would
-// corrupt the reactive arena.
-unsafe impl<T> Send for MainThreadOnly<T> {}
-unsafe impl<T> Sync for MainThreadOnly<T> {}
 
 #[cfg(test)]
 mod tests {
@@ -232,6 +187,8 @@ mod tests {
     #[test]
     fn desktop_fallback_stays_zero() {
         dismiss();
-        assert_eq!(keyboard_height().get(), 0.0);
+        let runtime =
+            whisker::runtime::RuntimeContext::new(whisker::runtime::RuntimeWakeHandle::new(|| {}));
+        runtime.enter(|| assert_eq!(keyboard_height().get(), 0.0));
     }
 }

--- a/packages/whisker-keyboard/tests/owner_lifetime.rs
+++ b/packages/whisker-keyboard/tests/owner_lifetime.rs
@@ -1,0 +1,15 @@
+use whisker::runtime::{RuntimeContext, RuntimeWakeHandle};
+#[test]
+fn keyboard_height_can_be_read_after_runtime_recreation() {
+    let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    assert_eq!(
+        first.enter(|| whisker_keyboard::keyboard_height().get()),
+        0.0
+    );
+    first.shutdown();
+    let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+    assert_eq!(
+        second.enter(|| whisker_keyboard::keyboard_height().get()),
+        0.0
+    );
+}

--- a/packages/whisker-router/src/render/handle.rs
+++ b/packages/whisker-router/src/render/handle.rs
@@ -76,6 +76,8 @@ pub(crate) struct PoseBinding {
 /// reconcile so it always points at the current top.
 #[derive(Clone)]
 pub(crate) struct StackBridge {
+    pub owner: Owner,
+    pub registration: Option<whisker::runtime::lifetime::Cancellation>,
     /// The top wrapper's transition controller (what the gesture scrubs).
     pub top_ctrl: Option<AnimationController>,
     /// The top wrapper's pose binding.
@@ -122,16 +124,40 @@ struct Inner {
     /// Registered by [`Stack`](crate::render::Stack) reconcile; read by
     /// the swipe-back gesture to find the deepest active stack's top
     /// wrapper + controller.
-    bridges: RefCell<HashMap<NodePath, StackBridge>>,
+    bridges: RefCell<HashMap<NodePath, BridgeRegistration>>,
     /// Whether a Host history adapter was installed for this Router.
     history_enabled: bool,
     /// Retains the Host `popstate` subscription for this handle's lifetime.
     history_subscription: RefCell<Option<history::Subscription>>,
-    /// Owns the `state` signal. A detached root so the signal lives for
-    /// the handle's lifetime, not the (often transient) owner that
-    /// happened to be current at construction — the same footgun the
-    /// old `RouteStack` guards against. See `Owner::detached_root`.
-    _owner: Owner,
+    owner: whisker::runtime::lifetime::OwnedOwner,
+}
+
+struct BridgeRegistration {
+    identity: Rc<()>,
+    value: whisker::runtime::lifetime::Scoped<(StackBridge, BridgeLease)>,
+}
+
+struct BridgeLease {
+    inner: std::rc::Weak<Inner>,
+    path: NodePath,
+    identity: Rc<()>,
+}
+
+impl Drop for BridgeLease {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let current = inner
+            .bridges
+            .borrow()
+            .get(&self.path)
+            .is_some_and(|entry| Rc::ptr_eq(&entry.identity, &self.identity));
+        if current {
+            let removed = inner.bridges.borrow_mut().remove(&self.path);
+            drop(removed);
+        }
+    }
 }
 
 impl RouterHandle {
@@ -143,7 +169,7 @@ impl RouterHandle {
             registry,
             layouts,
         } = routes.into();
-        let owner = Owner::detached_root();
+        let owner = whisker::runtime::lifetime::OwnedOwner::new();
         let initial_location = history::initialize();
         let history_enabled = initial_location.is_some();
         let mut initial = RouteState::initial(&tree);
@@ -169,10 +195,13 @@ impl RouterHandle {
                 bridges: RefCell::new(HashMap::new()),
                 history_enabled,
                 history_subscription: RefCell::new(None),
-                _owner: owner,
+                owner,
             }),
         };
-        handle.install_history_subscription();
+        handle
+            .inner
+            .owner
+            .with(|| handle.install_history_subscription());
         handle
     }
 
@@ -206,7 +235,21 @@ impl RouterHandle {
     /// Called by [`Stack`](crate::render::Stack) reconcile each time its
     /// top wrapper changes.
     pub(crate) fn set_stack_bridge(&self, path: NodePath, bridge: StackBridge) {
-        self.inner.bridges.borrow_mut().insert(path, bridge);
+        let identity = Rc::new(());
+        let lease = BridgeLease {
+            inner: Rc::downgrade(&self.inner),
+            path: path.clone(),
+            identity: identity.clone(),
+        };
+        let value = whisker::runtime::lifetime::Scoped::new((bridge, lease));
+        let registration = value.cancellation();
+        value.with_mut(|(bridge, _)| bridge.registration = Some(registration));
+        let old = self
+            .inner
+            .bridges
+            .borrow_mut()
+            .insert(path, BridgeRegistration { identity, value });
+        drop(old);
     }
 
     /// (Test only) the bridge registered for the stack at `path`,
@@ -214,7 +257,11 @@ impl RouterHandle {
     /// survivor's resting pose after a coordinated pop.
     #[cfg(test)]
     pub(crate) fn active_stack_bridge_for_test(&self, path: &NodePath) -> Option<StackBridge> {
-        self.inner.bridges.borrow().get(path).cloned()
+        self.inner
+            .bridges
+            .borrow()
+            .get(path)
+            .and_then(|entry| entry.value.with(|(bridge, _)| bridge.clone()))
     }
 
     /// The gesture bridge for the **deepest active stack** — the one a
@@ -226,7 +273,10 @@ impl RouterHandle {
         let mut found: Option<StackBridge> = None;
         for node in state.active_chain() {
             if let RouteState::Stack(s) = node {
-                if let Some(b) = bridges.get(&s.path) {
+                if let Some(b) = bridges
+                    .get(&s.path)
+                    .and_then(|entry| entry.value.with(|(bridge, _)| bridge.clone()))
+                {
                     if b.can_back {
                         found = Some(b.clone());
                     }

--- a/packages/whisker-router/src/render/keyboard.rs
+++ b/packages/whisker-router/src/render/keyboard.rs
@@ -122,3 +122,36 @@ pub(crate) fn on_page_change_confirm(gesture: bool) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whisker::Owner;
+    use whisker::runtime::view::Element;
+    use whisker::runtime::{RuntimeContext, RuntimeWakeHandle};
+
+    #[test]
+    fn gesture_completion_ignores_a_disposed_input() {
+        for commit in [false, true] {
+            let runtime = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+            runtime.enter(|| {
+                let owner = Owner::new(None);
+                let input = owner.with(ElementRef::new);
+                input.__bind(Element::from_raw(42));
+                whisker::focus::note_focused(input);
+                on_page_change_start();
+                owner.dispose();
+                STARTED_AT.with(|s| s.set(Some(Instant::now() - KEYBOARD_FLASH_GUARD)));
+
+                if commit {
+                    on_page_change_confirm(true);
+                } else {
+                    on_page_change_cancel();
+                }
+
+                assert!(REMEMBERED.with(Cell::get).is_none());
+                assert!(STARTED_AT.with(Cell::get).is_none());
+            });
+        }
+    }
+}

--- a/packages/whisker-router/src/render/keyboard.rs
+++ b/packages/whisker-router/src/render/keyboard.rs
@@ -43,12 +43,13 @@ use whisker::{ElementRef, WhiskerValue, run_blocking, spawn_local};
 /// keyboard-dismiss tail. Matches RN's 100ms guard.
 const KEYBOARD_FLASH_GUARD: Duration = Duration::from_millis(100);
 
-thread_local! {
+whisker::runtime_local! {
+    static GENERATION: Cell<u64> = Cell::new(0);
     /// The field focused when the current back gesture began — restored
     /// on cancel, dropped on commit.
-    static REMEMBERED: Cell<Option<ElementRef>> = const { Cell::new(None) };
+    static REMEMBERED: Cell<Option<ElementRef>> = Cell::new(None);
     /// When that gesture began, for the flash guard.
-    static STARTED_AT: Cell<Option<Instant>> = const { Cell::new(None) };
+    static STARTED_AT: Cell<Option<Instant>> = Cell::new(None);
 }
 
 /// Blur a specific field. A no-op when the element is unmounted, which is
@@ -72,6 +73,7 @@ pub(crate) fn on_page_change_start() {
     if STARTED_AT.with(|s| s.get().is_some()) {
         return;
     }
+    GENERATION.with(|generation| generation.set(generation.get().wrapping_add(1)));
     let current = whisker::focus::focused_element();
     REMEMBERED.with(|r| r.set(current));
     STARTED_AT.with(|s| s.set(Some(Instant::now())));
@@ -84,20 +86,23 @@ pub(crate) fn on_page_change_start() {
 /// briefly for a too-fast interaction so the keyboard doesn't flash.
 /// (RN `onPageChangeCancel`.)
 pub(crate) fn on_page_change_cancel() {
-    let Some(el) = REMEMBERED.with(Cell::take) else {
-        return;
-    };
     let elapsed = STARTED_AT
         .with(Cell::take)
         .map(|t| t.elapsed())
         .unwrap_or(KEYBOARD_FLASH_GUARD);
+    let Some(el) = REMEMBERED.with(Cell::take) else {
+        return;
+    };
     if elapsed >= KEYBOARD_FLASH_GUARD {
         focus(el);
     } else {
         let wait = KEYBOARD_FLASH_GUARD - elapsed;
+        let generation = GENERATION.with(Cell::get);
         spawn_local(async move {
             run_blocking(move || std::thread::sleep(wait)).await;
-            focus(el);
+            if GENERATION.with(Cell::get) == generation {
+                focus(el);
+            }
         });
     }
 }
@@ -106,13 +111,15 @@ pub(crate) fn on_page_change_cancel() {
 /// (vs a programmatic verb). (RN `onPageChangeConfirm` with `closing`
 /// always true here — the verb already happened.)
 pub(crate) fn on_page_change_confirm(gesture: bool) {
+    GENERATION.with(|generation| generation.set(generation.get().wrapping_add(1)));
+    STARTED_AT.with(|started| started.set(None));
+    let remembered = REMEMBERED.with(Cell::take);
     if gesture {
         // The interactive back committed. The field captured at gesture
         // start stays blurred; just release it.
-        if let Some(el) = REMEMBERED.with(Cell::take) {
+        if let Some(el) = remembered {
             blur(el);
         }
-        STARTED_AT.with(|s| s.set(None));
     } else {
         // Programmatic navigation: blur the currently-focused field, if
         // any. Targeted, so a late-landing blur hits only the departing
@@ -153,5 +160,45 @@ mod tests {
                 assert!(STARTED_AT.with(Cell::get).is_none());
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod runtime_isolation_tests {
+    use super::*;
+    use whisker::runtime::view::Element;
+    use whisker::runtime::{RuntimeContext, RuntimeWakeHandle};
+    use whisker::{Owner, RwSignal};
+
+    #[test]
+    fn keyboard_gesture_state_is_isolated_between_runtimes() {
+        let first = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        let second = RuntimeContext::new(RuntimeWakeHandle::new(|| {}));
+        first.enter(|| {
+            let owner = Owner::new(None);
+            let input = owner.with(ElementRef::new);
+            input.__bind(Element::from_raw(42));
+            whisker::focus::note_focused(input);
+            on_page_change_start();
+        });
+        let second_input = second.enter(|| {
+            let owner = Owner::new(None);
+            let input = owner.with(|| {
+                let _ = RwSignal::new(0);
+                ElementRef::new()
+            });
+            input.__bind(Element::from_raw(43));
+            whisker::focus::note_focused(input);
+            on_page_change_start();
+            input
+        });
+        let remembered = second.enter(|| REMEMBERED.with(Cell::take));
+        second.enter(|| STARTED_AT.with(Cell::take));
+        second.enter(|| {
+            assert!(
+                remembered == Some(second_input),
+                "gesture captured an input from another runtime"
+            )
+        });
     }
 }

--- a/packages/whisker-router/src/render/node.rs
+++ b/packages/whisker-router/src/render/node.rs
@@ -589,6 +589,8 @@ fn reconcile_stack(
         mode: w.pose_mode,
     };
     let bridge = crate::render::handle::StackBridge {
+        owner: Owner::current().expect("stack reconcile owner"),
+        registration: None,
         top_ctrl: top_w.map(|w| w.ctrl.clone()),
         top_pose: top_w.map(pose_of),
         under_pose: under_w.map(pose_of),

--- a/packages/whisker-router/src/render/platform_navigation.rs
+++ b/packages/whisker-router/src/render/platform_navigation.rs
@@ -237,6 +237,13 @@ pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> 
 /// set the shared top controller's progress. Both wrappers re-pose and the
 /// backdrop dim follows automatically via their reactive bindings.
 pub(crate) fn scrub(bridge: &StackBridge, back_progress: f32) {
+    if !bridge
+        .registration
+        .as_ref()
+        .is_some_and(|registration| registration.is_active())
+    {
+        return;
+    }
     if let Some(ctrl) = &bridge.top_ctrl {
         ctrl.set_value(1.0 - back_progress);
     }
@@ -253,6 +260,13 @@ pub(crate) fn settle(
     commit: bool,
     velocity: Option<f32>,
 ) {
+    let Some(registration) = bridge
+        .registration
+        .clone()
+        .filter(|registration| registration.is_active())
+    else {
+        return;
+    };
     let Some(ctrl) = bridge.top_ctrl.clone() else {
         return;
     };
@@ -273,20 +287,22 @@ pub(crate) fn settle(
         // already at 0, so the reconcile's reverse settles instantly).
         let nav = nav.clone();
         let done = Rc::new(RefCell::new(false));
-        ctrl.on_finish(move |finished| {
-            if finished && !*done.borrow() {
-                *done.borrow_mut() = true;
-                // Release the dim drive (→ opacity 0) as the pop commits.
-                if let Some(d) = dim_drive {
-                    d.set(None);
+        bridge.owner.with(|| {
+            ctrl.on_finish(move |finished| {
+                if finished && registration.is_active() && !*done.borrow() {
+                    *done.borrow_mut() = true;
+                    // Release the dim drive (→ opacity 0) as the pop commits.
+                    if let Some(d) = dim_drive {
+                        d.set(None);
+                    }
+                    // Swipe-back commits like any other navigation — the
+                    // field captured at gesture start stays blurred, so a
+                    // search field on the popped screen can't keep a
+                    // hardware-keyboard target (RN `onPageChangeConfirm`).
+                    crate::render::keyboard::on_page_change_confirm(true);
+                    let _ = nav.back();
                 }
-                // Swipe-back commits like any other navigation — the
-                // field captured at gesture start stays blurred, so a
-                // search field on the popped screen can't keep a
-                // hardware-keyboard target (RN `onPageChangeConfirm`).
-                crate::render::keyboard::on_page_change_confirm(true);
-                let _ = nav.back();
-            }
+            })
         });
         match velocity {
             Some(v) => ctrl.reverse_with_velocity(v),
@@ -302,13 +318,15 @@ pub(crate) fn settle(
         // `onPageChangeCancel`), with the flash guard for a fast release.
         crate::render::keyboard::on_page_change_cancel();
         let done = Rc::new(RefCell::new(false));
-        ctrl.on_finish(move |finished| {
-            if finished && !*done.borrow() {
-                *done.borrow_mut() = true;
-                if let Some(d) = dim_drive {
-                    d.set(None);
+        bridge.owner.with(|| {
+            ctrl.on_finish(move |finished| {
+                if finished && registration.is_active() && !*done.borrow() {
+                    *done.borrow_mut() = true;
+                    if let Some(d) = dim_drive {
+                        d.set(None);
+                    }
                 }
-            }
+            })
         });
         match velocity {
             Some(v) => ctrl.forward_with_velocity(v),

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -25,11 +25,14 @@ use crate::render::transition::RouteTransition;
 /// Run `f` under a fresh runtime + a live owner (so `computed` reads have
 /// somewhere to allocate), then tear it down.
 fn with_runtime<F: FnOnce() -> T, T>(f: F) -> T {
-    whisker::runtime::reactive::__reset_for_tests();
-    let owner = Owner::new(None);
-    let out = owner.with(f);
-    owner.dispose();
-    out
+    let runtime =
+        whisker::runtime::RuntimeContext::new(whisker::runtime::RuntimeWakeHandle::new(|| {}));
+    runtime.enter(|| {
+        let owner = Owner::new(None);
+        let out = owner.with(f);
+        owner.dispose();
+        out
+    })
 }
 
 /// Drain the reactive queue so persistent `computed`s created *before* a
@@ -496,10 +499,8 @@ fn settle_animations() {
 
 #[test]
 fn push_pauses_the_covered_under_once_the_slide_finishes() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -534,10 +535,8 @@ fn can_pop_is_derivable_from_state_before_any_reconcile() {
     // The platform enabled effect computes can-pop from the state
     // signal; the gesture bridges update one reconcile later and must
     // not be its source.
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -560,10 +559,8 @@ fn can_pop_is_derivable_from_state_before_any_reconcile() {
 
 #[test]
 fn pop_settles_survivor_to_active_pose() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -598,15 +595,12 @@ fn pop_settles_survivor_to_active_pose() {
             "survivor settled to active 0% pose; role={role:?} progress={progress}"
         );
     });
-    owner.dispose();
 }
 
 #[test]
 fn push_settles_top_to_full_progress() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -628,17 +622,14 @@ fn push_settles_top_to_full_progress() {
             "top settles at progress 1.0 after push"
         );
     });
-    owner.dispose();
 }
 
 /// `replace` must slide the new screen in (drive 0 → 1) using the route
 /// transition, not snap it to its final pose.
 #[test]
 fn replace_animates_the_new_top_in() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -680,7 +671,6 @@ fn replace_animates_the_new_top_in() {
             "replaced top settles at progress 1.0"
         );
     });
-    owner.dispose();
 }
 
 /// After a `replace`, a `back` must still animate the revealed survivor (the
@@ -688,10 +678,8 @@ fn replace_animates_the_new_top_in() {
 /// for the "Home doesn't animate on back after replace" report.
 #[test]
 fn back_after_replace_animates_the_revealed_survivor() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -727,17 +715,14 @@ fn back_after_replace_animates_the_revealed_survivor() {
             "the revealed survivor must animate in on back-after-replace; traj={traj:?}"
         );
     });
-    owner.dispose();
 }
 
 /// Same as above but with a layout Route above the Stack (the tabbed example's
 /// shape). Reproduces the "Home doesn't animate on back after replace" report.
 #[test]
 fn back_after_replace_animates_under_a_layout_route() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = layout_slide_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -770,7 +755,6 @@ fn back_after_replace_animates_under_a_layout_route() {
             "survivor must animate in on back-after-replace under a layout route; traj={traj:?}"
         );
     });
-    owner.dispose();
 }
 
 /// An interactive swipe-back keeps buried route content paused while its
@@ -779,10 +763,8 @@ fn back_after_replace_animates_under_a_layout_route() {
 /// top entry's params during the preview.
 #[test]
 fn swipe_back_animates_under_presentation_without_resuming_its_content() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = layout_slide_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -830,15 +812,12 @@ fn swipe_back_animates_under_presentation_without_resuming_its_content() {
             "under presentation follows the scrubbed top controller",
         );
     });
-    owner.dispose();
 }
 
 #[test]
 fn pop_animates_outgoing_top_through_intermediate_frames() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -872,15 +851,12 @@ fn pop_animates_outgoing_top_through_intermediate_frames() {
              slide-out), not pop instantly; traj={traj:?}"
         );
     });
-    owner.dispose();
 }
 
 #[test]
 fn popped_leaf_content_survives_until_exit_animation_finishes() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         // Detail's render fn registers an `on_cleanup` bumping a counter,
         // so we can observe exactly WHEN its content subtree is disposed.
         let cleanups = Rc::new(RefCell::new(0usize));
@@ -938,7 +914,6 @@ fn popped_leaf_content_survives_until_exit_animation_finishes() {
             "detail content disposed exactly once, on exit-animation finish"
         );
     });
-    owner.dispose();
 }
 
 // The native module delivery can't run headless, but the mapping Android's
@@ -965,10 +940,8 @@ fn back_progress_reads_payload() {
 
 #[test]
 fn predictive_back_progress_scrubs_top_controller() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -996,15 +969,12 @@ fn predictive_back_progress_scrubs_top_controller() {
         scrub(&bridge, back_progress(&progress_payload(1.0)));
         assert_eq!(ctrl.value().get_untracked(), 0.0, "progress 1 → fully away");
     });
-    owner.dispose();
 }
 
 #[test]
 fn predictive_back_invoke_commits_pop() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -1023,17 +993,14 @@ fn predictive_back_invoke_commits_pop() {
 
         assert_eq!(h.current().get().path, NodePath(vec![0]), "popped to home");
     });
-    owner.dispose();
 }
 
 #[test]
 fn settle_commit_animates_from_current_value_without_jumping_back() {
     // A *partial* release commits by animating from the current value to 0
     // — it must NOT jump backward (toward 1) first.
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -1069,17 +1036,14 @@ fn settle_commit_animates_from_current_value_without_jumping_back() {
         settle_animations();
         assert_eq!(h.current().get().path, NodePath(vec![0]), "commits the pop");
     });
-    owner.dispose();
 }
 
 #[test]
 fn settle_full_drag_commits_immediately() {
     // A full drag (value already ≈ 0) commits with no extra animation —
     // the dismiss is already visually complete; it just pops.
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -1093,15 +1057,12 @@ fn settle_full_drag_commits_immediately() {
         settle_animations();
         assert_eq!(h.current().get().path, NodePath(vec![0]), "commits the pop");
     });
-    owner.dispose();
 }
 
 #[test]
 fn predictive_back_cancel_restores_top() {
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let h = slide_stack_handle();
         let _slot = mount_node(&h, NodePath::root());
         flush();
@@ -1118,7 +1079,6 @@ fn predictive_back_cancel_restores_top() {
         assert_eq!(ctrl.value().get_untracked(), 1.0, "top restored to present");
         assert_eq!(h.current().get().path, NodePath(vec![1]), "still on detail");
     });
-    owner.dispose();
 }
 
 /// Verify that predictive-back works for a **grouped tabbed** tree (the
@@ -1127,10 +1087,8 @@ fn predictive_back_cancel_restores_top() {
 #[test]
 fn predictive_back_works_with_grouped_tabs() {
     use crate::core::{RouteDef, RouteTree};
-    whisker::runtime::reactive::__reset_for_tests();
-    whisker_animation::__reset_for_tests();
-    let owner = Owner::new(None);
-    owner.with(|| {
+    with_runtime(|| {
+        whisker_animation::__reset_for_tests();
         let tree = CompiledTree::new(RouteTree::route_with(
             RouteDef {
                 id: "tabs_layout".into(),
@@ -1219,7 +1177,6 @@ fn predictive_back_works_with_grouped_tabs() {
             "commits the pop to home"
         );
     });
-    owner.dispose();
 }
 
 fn progress_payload(p: f64) -> WhiskerValue {
@@ -2202,5 +2159,39 @@ fn navigation_after_focused_form_disposal_reaches_home() {
 
         assert_eq!(router.state().get().current().location.pathname, "/");
         assert_eq!(whisker::focus::focused_element(), None);
+    });
+}
+
+#[test]
+fn router_drop_disposes_detached_state_owner() {
+    with_runtime(|| {
+        let router = simple_handle();
+        let state = router.state();
+        drop(router);
+        assert!(
+            state.is_disposed(),
+            "last RouterHandle drop must release its state owner"
+        );
+    });
+}
+
+#[test]
+fn stack_unmount_removes_registered_gesture_bridge() {
+    with_runtime(|| {
+        let router = slide_stack_handle();
+        let screen = Owner::new(None);
+        screen.with(|| mount_node(&router, NodePath::root()));
+        router.navigate("/detail/1").unwrap();
+        flush();
+        settle_animations();
+        let bridge = router.active_stack_bridge().unwrap();
+        screen.dispose();
+        assert!(router.active_stack_bridge().is_none());
+        crate::render::platform_navigation::scrub(&bridge, 0.5);
+        crate::render::platform_navigation::settle(&router, &bridge, true, None);
+        assert_eq!(
+            router.state().get().current().location.pathname,
+            "/detail/1"
+        );
     });
 }

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -2184,3 +2184,23 @@ mod replace_repro {
         });
     }
 }
+
+#[test]
+fn navigation_after_focused_form_disposal_reaches_home() {
+    with_runtime(|| {
+        let router = simple_handle();
+        router.navigate("/detail/form").unwrap();
+        let form = Owner::new(None);
+        let input = form.with(whisker::ElementRef::new);
+        input.__bind(whisker::runtime::view::Element::from_raw(42));
+        form.with(|| whisker::on_cleanup(move || input.__unbind()));
+        whisker::focus::note_focused(input);
+
+        router.navigate("/detail/connections").unwrap();
+        form.dispose();
+        router.navigate("/").unwrap();
+
+        assert_eq!(router.state().get().current().location.pathname, "/");
+        assert_eq!(whisker::focus::focused_element(), None);
+    });
+}

--- a/packages/whisker-safe-area/src/lib.rs
+++ b/packages/whisker-safe-area/src/lib.rs
@@ -72,12 +72,14 @@
 //! - iOS: `packages/whisker-safe-area/ios/Sources/WhiskerSafeArea/SafeAreaModule.swift`
 //! - Android: `packages/whisker-safe-area/android/src/main/kotlin/rs/whisker/modules/safe_area/SafeAreaModule.kt`
 
+#[cfg(test)]
+use whisker::Owner;
 #[cfg(any(target_os = "android", target_os = "ios", test))]
 use whisker::WhiskerValue;
 #[cfg(any(target_os = "android", target_os = "ios", test))]
 use whisker::module;
-use whisker::runtime::{module::ModuleSubscription, runtime_local};
-use whisker::{Owner, ReadSignal, RwSignal};
+use whisker::runtime::module::ModuleSubscription;
+use whisker::{ReadSignal, RwSignal};
 
 /// Safe-area inset amounts in **points (iOS) / dp (Android)** — the
 /// same density-independent units that the rest of Whisker's CSS
@@ -103,48 +105,37 @@ pub struct SafeAreaInsets {
 /// Hosts push the current insets when observation starts and whenever they
 /// change. Web and desktop always expose the all-zero value.
 ///
-/// The `Copy` handle lives under a detached owner in this runtime, so disposing
+/// The `Copy` handle belongs to the Runtime cache owner, so disposing
 /// a component or route does not invalidate other readers. It must not be
 /// retained across runtime shutdown or used in a different runtime.
 ///
 /// **Must be called on the runtime's UI thread with that runtime entered.**
 pub fn safe_area_insets() -> ReadSignal<SafeAreaInsets> {
-    #[cfg(any(target_os = "android", target_os = "ios"))]
-    {
-        insets_with_subscription(subscribe_to_native)
-    }
-    #[cfg(not(any(target_os = "android", target_os = "ios")))]
-    {
-        insets_with_subscription(|_| None)
-    }
+    INSETS.with(|slot| slot.read)
 }
 
 struct Slot {
     read: ReadSignal<SafeAreaInsets>,
-    // Dropping runtime-local state unsubscribes from this slot's original Host.
     _subscription: Option<ModuleSubscription>,
 }
 
-// Keep platform selection separate so host tests exercise the same native
-// subscription and runtime lifecycle without needing an Android or iOS device.
-fn insets_with_subscription(
-    subscribe: impl FnOnce(RwSignal<SafeAreaInsets>) -> Option<ModuleSubscription>,
-) -> ReadSignal<SafeAreaInsets> {
-    let state = runtime_local::state::<Option<Slot>>();
-    let mut state = state.borrow_mut();
-    state
-        .get_or_insert_with(|| {
-            // This owner outlives individual routes, but belongs to the current
-            // runtime's arena. A process-global handle would point into the old
-            // arena after Activity recreation.
-            let root = Owner::detached_root();
-            let signal = root.with(|| RwSignal::new(SafeAreaInsets::default()));
-            Slot {
-                read: signal.read_only(),
-                _subscription: subscribe(signal),
-            }
-        })
-        .read
+impl Slot {
+    fn new(subscribe: impl FnOnce(RwSignal<SafeAreaInsets>) -> Option<ModuleSubscription>) -> Self {
+        let signal = RwSignal::new(SafeAreaInsets::default());
+        Self {
+            read: signal.read_only(),
+            _subscription: subscribe(signal),
+        }
+    }
+}
+
+whisker::runtime_local! {
+    static INSETS: Slot = {
+        #[cfg(any(target_os = "android", target_os = "ios"))]
+        { Slot::new(subscribe_to_native) }
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
+        { Slot::new(|_| None) }
+    };
 }
 
 #[cfg(any(target_os = "android", target_os = "ios", test))]
@@ -228,7 +219,8 @@ mod tests {
     }
 
     fn native_insets() -> ReadSignal<SafeAreaInsets> {
-        insets_with_subscription(subscribe_to_native)
+        whisker::runtime_local! { static NATIVE: Slot = Slot::new(subscribe_to_native); }
+        NATIVE.with(|slot| slot.read)
     }
 
     #[test]
@@ -384,6 +376,6 @@ mod tests {
     #[cfg(not(any(target_os = "android", target_os = "ios")))]
     #[test]
     fn common_platform_fallback_is_all_zero() {
-        assert_eq!(safe_area_insets().get(), SafeAreaInsets::default());
+        runtime().enter(|| assert_eq!(safe_area_insets().get(), SafeAreaInsets::default()));
     }
 }


### PR DESCRIPTION
Leaving a screen can leave queued work holding its disposed Signals: a resource resumes after an await, a captured input or layout callback runs after unmount, or Router blurs an input retained by focus management. This PR ties framework-managed work to its registering Owner and gives shared services an explicit Runtime lifetime while preserving Copy Signals and existing component syntax.

### Runtime lifetime contract

- Cancel `spawn_local`, resource fetches, mount callbacks, module events, element events, layout observers, back handlers, and animation completion callbacks when their registering Owner is disposed. Restore that Owner while running callbacks and polling futures, including nested tasks.
- Mark a disposing Owner closed immediately, reject new work, and skip callbacks already copied into a delivery batch. Defer reclaiming its Signals until the current managed execution returns, so navigation inside a callback does not invalidate its remaining synchronous reads.
- Drop canceled futures without waiting for I/O, wake their pool entries for removal, and remove completed registrations rather than accumulating cleanup closures. Resource refetch also cancels its previous future.
- Run shutdown and cleanup in the original Runtime, disposing application scopes before Runtime caches and dropping cached values before their own Signals.

### Public API and framework integration

- Add `try_get()` / `try_get_untracked()` to Signal read handles and wrappers, and `StoredValue::try_get()`. Successful reads preserve dependency tracking; disposed values return `None`. Existing strict reads retain their failure behavior.
- Add `whisker::runtime_local! { static NAME: T = initializer; }` with `NAME.with(...)`. Each declaration initializes once per Runtime under its own untracked Owner. Values need not implement Send, Sync, Clone, or Default. Nested initialization is supported, recursive initialization is rejected, and failed initialization rolls back.
- Move Keyboard, SafeArea, Audio's shared subscription, and Router keyboard gesture state to Runtime-owned storage. Keep browser-history observation with the Router's own Owner.
- Release Router state on its last handle, remove StackBridge registrations when their Stack ends, and invalidate already-copied gesture references and late completion callbacks.
- Clear focus when inputs unbind and return `RefError::NotBound` for commands on disposed refs, including navigation's pre-transition blur.

`spawn_local` now requires an entered Runtime and cancels at Owner disposal; calls without a component Owner belong to the Runtime service scope. External executors, parent tasks holding shorter-lived child Signals, direct calls through retained Callback handles, and moving arena handles between Runtimes still require explicit lifetime discipline. `try_get` does not make Signals thread-safe or extend their lifetime. No Kotlin or Swift changes are included.

### Validation

- `cargo test --workspace --all-targets` with `RUST_TEST_THREADS=1`, plus targeted Runtime, Router, Audio, Keyboard, SafeArea, Animation, and Whisker tests.
- `cargo test --workspace --doc` and `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --lib`.
- `cargo fmt --all --check` and Rust 1.88 Clippy on all changed crates and their targets with the CI warning policy.
- Regression coverage includes the previous lifetime audit cases, pending-task cleanup without external wakes, disposal during callbacks/polls, explicit unsubscribe during delivery, cache rollback and Runtime recreation, shutdown order, and service subscriptions outliving their first component.

Android/iOS device smoke tests have not been run for this PR. The commits separate input/focus cleanup, the shared Runtime mechanism, and framework/package integration; temporary research documents are excluded.
