### PR TITLE
feat(release): version core and package groups independently

### DIFF
--- a/.agents/skills/release-whisker/SKILL.md
+++ b/.agents/skills/release-whisker/SKILL.md
@@ -10,22 +10,67 @@ Use `.github/workflows/release.yml`. Release logic lives in
 
 ## Prepare one release
 
-Run the `release` workflow on **main** with the Rust workspace `version`.
-Supply `sdk_version`, `gradle_version`, or `ios_version` when those
-sources changed. Blank native inputs reuse the current pins; preparation
-rejects unselected streams with changes since their pinned tag.
-`subsecond_version` is for the independently versioned fork crate.
+Run the `release` workflow on **main** with these inputs:
 
-The workflow updates workspace versions, local path dependency requirements,
-Cargo.lock, CLI SDK pins, and all module SwiftPM pins together. It records
-`.github/release.json` and `releases/<version>.md` in a single
-`codex/release-v<version>` PR, then explicitly dispatches CI on that branch.
+| Input | Meaning |
+| --- | --- |
+| `release_id` | Required identifier independent of versions, such as `20260908.1`; increment the suffix for another release that day |
+| `version` | New core version; leave blank for packages-only releases |
+| `package_versions` | Optional JSON overrides such as `{"whisker-router":"minor","whisker-input":"0.15.0"}`; values accept `patch`, `minor`, `major`, or a stable version |
+| `sdk_version`, `gradle_version`, `ios_version` | New native versions when those sources changed; blanks reuse current pins |
+| `subsecond_version` | Explicit version for the independently versioned fork |
+
+Core means publishable crates in `crates/` and `platforms/`, except
+`whisker-subsecond`. Core releases update the group together and pin
+core-to-core dependencies to the exact version. Each `packages/<directory>`
+is a separate version group, including nested web/desktop crates. Override
+keys use directory names. Every crate within a group must share its version.
+
+Preparation compares packaged files and resolved manifest metadata with the
+last completed release. Changed package groups receive a patch bump by
+default. An override also selects an unchanged group. If a dependency's new
+version falls outside an unselected group's requirement, that group is
+selected too. Core or fork changes require their explicit version inputs.
+Unchanged package groups keep their versions and dependency requirements;
+selected packages receive compatible minimum versions of their local
+dependencies. Review patch proposals for API compatibility, especially new
+APIs or breaking changes that require a core release or a larger version bump.
+
+Package versions and internal dependency requirements are detached from
+workspace inheritance during preparation. Native pin updates participate in
+change detection: updating CLI/CNG pins requires a core release, and updating
+module SwiftPM manifests selects the affected packages. Excluded files and
+root Cargo.lock-only changes do not automatically select crates; explicitly
+request a version when a lockfile change needs a new CLI binary.
+
+Preparation rejects omitted native streams with changes since their pinned
+tag, incomplete previous releases, and manual crate version changes outside
+release preparation. It records selected versions, reasons, content hashes,
+and Cargo.lock's hash in `.github/release.json`, with notes in
+`releases/<release_id>.md`. One `codex/release-<release_id>` PR includes all
+selected Rust and native changes, then CI is explicitly dispatched on it.
 The explicit dispatch is necessary because bot pushes do not start ordinary
 push/PR workflows reliably.
 
 Review the generated release notes, wait for CI, and merge the PR. Existing
 main protection still requires an approving review. The pipeline does not
 bypass that protection or push release commits directly to main.
+
+## Preview selection locally
+
+Fetch release tags, then run against the committed HEAD:
+
+```sh
+git fetch origin --tags
+RELEASE_ID=20260908.1 RELEASE_VERSION=0.13.9 cargo xtask release preview
+```
+
+Omit `RELEASE_VERSION` for packages-only changes; `PACKAGE_VERSIONS` accepts
+the same JSON as Actions. Native inputs use `SDK_VERSION`, `GRADLE_VERSION`,
+and `IOS_VERSION`. Preview prepares a temporary worktree and prints the plan;
+it does not modify the checkout, create a PR, or publish. Uncommitted edits
+are not included. Actions preparation additionally verifies remote release
+and native tags before creating the PR.
 
 ## Publication order
 
@@ -40,8 +85,8 @@ The release-plan merge triggers the same workflow's publishing jobs:
 3. After all selected native jobs succeed, verify reused SDKs too, then use
    Cargo workspace publishing for the unpublished Rust versions. Publishing
    uses Cargo 1.98.1; the framework's consumer MSRV is unchanged.
-4. Verify every planned crate version in the registry, then create **one**
-   GitHub Release, `Whisker <version>`, at `whisker-v<version>`.
+4. Verify every selected crate version in the registry, then create **one**
+   GitHub Release, `Whisker <release_id>`, at `whisker-release-<release_id>`.
 
 `sdk-v*`, `gradle-plugin-v*`, and SwiftPM's `v*` tags remain as artifact
 identifiers. New per-crate GitHub Releases are not created. Historical
@@ -77,6 +122,8 @@ gh run rerun <run-id> --failed
 ```
 
 The checkout must remain the same commit. Native tags reject another commit.
+Changes to packaged Rust content or Cargo.lock after preparation are rejected
+before publishing. Re-prepare the release if main acquired those changes.
 Maven publication receipts prevent overwriting a successful upload when
 Pages propagation is delayed. SwiftPM skips an already verified tag at the
 same commit. Rust checks exact registry versions and publishes only those
@@ -90,6 +137,8 @@ error, never evidence that a crate is unpublished.
 Re-running preparation with identical inputs on the original source commit
 reuses its branch/PR. A closed or merged PR, a conflicting plan, or another
 open unified release PR requires inspection rather than overwriting history.
+Legacy plans without a selective inventory retain their original publication
+set and `whisker-v<version>` tag, so their original failed jobs can still resume.
 
 ## Verify delivery to an app
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,13 @@ name: release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: Rust workspace version (e.g. 0.13.4)
+      release_id:
+        description: Release identifier independent of crate versions (e.g. 20260908.1)
         required: true
+      version:
+        description: New core version (blank for packages-only releases)
+      package_versions:
+        description: 'Optional JSON overrides, e.g. {"whisker-router":"minor"}; changed package groups default to patch'
       sdk_version:
         description: Android SDK version (blank to reuse the current SDK)
       gradle_version:
@@ -50,6 +54,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_ID: ${{ inputs.release_id }}
+          PACKAGE_VERSIONS: ${{ inputs.package_versions }}
           SDK_VERSION: ${{ inputs.sdk_version }}
           GRADLE_VERSION: ${{ inputs.gradle_version }}
           IOS_VERSION: ${{ inputs.ios_version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8256,6 +8256,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "toml_edit 0.22.27",
  "ureq",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,12 +13,11 @@ httpdate = "1"
 semver = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = "0.10"
+tempfile = "3"
 toml_edit = "0.22"
 ureq = { version = "2", features = ["json"] }
 whisker-build = { workspace = true }
 whisker-cli = { workspace = true }
 whisker-dev-server = { workspace = true }
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
-
-[dev-dependencies]
-tempfile = "3"

--- a/xtask/src/release/mod.rs
+++ b/xtask/src/release/mod.rs
@@ -15,6 +15,9 @@ use toml_edit::DocumentMut;
 mod native;
 mod prepare;
 mod publish;
+mod selection;
+#[cfg(test)]
+mod selection_tests;
 #[cfg(test)]
 mod tests;
 
@@ -33,12 +36,17 @@ struct ReleasePlan {
     ios: Option<String>,
     subsecond: Option<String>,
     crates: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    selective: Option<selection::SelectivePlan>,
 }
 
 impl ReleasePlan {
     fn read(root: &Path) -> Result<Self> {
         let plan: Self = serde_json::from_str(&fs::read_to_string(root.join(PLAN_PATH))?)?;
         version(&plan.version)?;
+        if let Some(selection) = &plan.selective {
+            selection::validate_id(&selection.id)?;
+        }
         for value in [&plan.sdk, &plan.gradle, &plan.ios, &plan.subsecond]
             .into_iter()
             .flatten()
@@ -49,11 +57,32 @@ impl ReleasePlan {
     }
 
     fn notes_path(&self) -> String {
-        format!("releases/{}.md", self.version)
+        format!("releases/{}.md", self.label())
+    }
+
+    fn label(&self) -> &str {
+        self.selective
+            .as_ref()
+            .map_or(&self.version, |selection| &selection.id)
     }
 
     fn tag(&self) -> String {
-        format!("whisker-v{}", self.version)
+        match &self.selective {
+            Some(selection) => format!("whisker-release-{}", selection.id),
+            None => format!("whisker-v{}", self.version),
+        }
+    }
+
+    fn publishing(&self) -> BTreeMap<String, String> {
+        self.crates
+            .iter()
+            .filter(|(name, _)| {
+                self.selective
+                    .as_ref()
+                    .is_none_or(|selection| selection.publish.contains(*name))
+            })
+            .map(|(name, version)| (name.clone(), version.clone()))
+            .collect()
     }
 
     fn validate_checkout(&self, root: &Path) -> Result<()> {
@@ -84,6 +113,9 @@ impl ReleasePlan {
             "release notes are missing"
         );
         git(root, &["merge-base", "--is-ancestor", &self.source, "HEAD"])?;
+        if let Some(selection) = &self.selective {
+            selection.validate(root, &self.crates)?;
+        }
         Ok(())
     }
 
@@ -123,6 +155,7 @@ impl ReleasePlan {
 pub fn run(root: &Path, mode: &str, args: Vec<String>) -> Result<()> {
     match (mode, args.as_slice()) {
         ("prepare", []) => prepare::run(root),
+        ("preview", []) => prepare::preview(root),
         ("plan", []) => plan(root),
         ("publish", []) => publish::run(root),
         ("native-check", [stream, value]) => native::check(root, stream, value),
@@ -131,7 +164,7 @@ pub fn run(root: &Path, mode: &str, args: Vec<String>) -> Result<()> {
         ("native-tag", [stream, value]) => native::tag(root, stream, value),
         ("native-verify", [stream, value]) => native::verify(stream, value),
         _ => bail!(
-            "usage: cargo xtask release <prepare|plan|publish>\n       cargo xtask release <native-check|native-stamp|native-tag|native-verify> <sdk|gradle|ios> <version>"
+            "usage: cargo xtask release <preview|prepare|plan|publish>\n       cargo xtask release <native-check|native-stamp|native-tag|native-verify> <sdk|gradle|ios> <version>"
         ),
     }
 }

--- a/xtask/src/release/prepare.rs
+++ b/xtask/src/release/prepare.rs
@@ -12,19 +12,8 @@ pub(super) fn run(root: &Path) -> Result<()> {
             .is_empty(),
         "release preparation requires a clean checkout"
     );
-    let requested = std::env::var("RELEASE_VERSION").context("RELEASE_VERSION is required")?;
-    version(&requested)?;
-    let source = git(root, &["rev-parse", "HEAD"])?.trim().to_owned();
-    let mut plan = ReleasePlan {
-        version: requested,
-        source,
-        sdk: optional("SDK_VERSION")?,
-        gradle: optional("GRADLE_VERSION")?,
-        ios: optional("IOS_VERSION")?,
-        subsecond: optional("SUBSECOND_VERSION")?,
-        crates: BTreeMap::new(),
-    };
-    let branch = format!("codex/release-v{}", plan.version);
+    let (mut plan, core) = request(root)?;
+    let branch = format!("codex/release-{}", plan.label());
     let remote = git(
         root,
         &[
@@ -38,38 +27,47 @@ pub(super) fn run(root: &Path) -> Result<()> {
         git(root, &["fetch", "origin", &branch])?;
         git(root, &["checkout", "--detach", "FETCH_HEAD"])?;
         let previous = ReleasePlan::read(root)?;
+        let previous_selection = previous
+            .selective
+            .as_ref()
+            .context("existing release is not selective")?;
+        ensure!(
+            plan.selective.as_ref().unwrap().id == previous_selection.id
+                && plan.selective.as_ref().unwrap().packages == previous_selection.packages,
+            "existing release has a different identifier or package overrides"
+        );
         plan.crates = previous.crates.clone();
+        plan.selective = previous.selective.clone();
         ensure!(
             plan == previous,
-            "{branch} already has a different release plan; reuse the original run or choose a new version"
+            "{branch} already has a different release plan; reuse the original run or choose another release_id"
         );
         plan.validate_checkout(root)?;
     } else {
-        let old = read_toml(&root.join("Cargo.toml"))?["workspace"]["package"]["version"]
-            .as_str()
-            .context("workspace version")?
-            .to_owned();
-        ensure!(
-            version(&plan.version)? > version(&old)?,
-            "Rust version must be newer than {old}"
-        );
-        if plan.subsecond.is_none() {
-            let changed = git(
-                root,
-                &[
-                    "diff",
-                    "--name-only",
-                    &format!("whisker-v{old}"),
-                    "HEAD",
-                    "--",
-                    "crates/whisker-subsecond",
-                ],
-            )?;
+        if let Some(next) = &core {
             ensure!(
-                changed.trim().is_empty(),
-                "whisker-subsecond changed; specify its independent version:\n{changed}"
+                version(next)?
+                    > version(
+                        read_toml(&root.join("Cargo.toml"))?["workspace"]["package"]["version"]
+                            .as_str()
+                            .context("workspace version")?
+                    )?,
+                "core version must be newer than the current workspace version"
             );
         }
+        let previous = ReleasePlan::read(root)?;
+        let previous_tag = previous.tag();
+        let baseline = remote_tag(root, &previous_tag)?.with_context(|| {
+            format!(
+                "previous release {previous_tag} is incomplete; resume its publishing job first"
+            )
+        })?;
+        git(root, &["fetch", "origin", "tag", &previous_tag])?;
+        git(
+            root,
+            &["merge-base", "--is-ancestor", &baseline, &plan.source],
+        )?;
+        plan.selective.as_mut().unwrap().baseline = baseline;
         for (stream, selected) in [
             ("sdk", &plan.sdk),
             ("gradle", &plan.gradle),
@@ -89,18 +87,12 @@ pub(super) fn run(root: &Path) -> Result<()> {
         ensure!(
             !open.iter().any(|pr| pr["headRefName"]
                 .as_str()
-                .is_some_and(|name| name.starts_with("codex/release-v"))),
+                .is_some_and(|name| name.starts_with("codex/release-"))),
             "another release PR is open; finish or close it first"
         );
         git(root, &["switch", "-c", &branch])?;
-        stamp_versions(root, &plan)?;
-        crate::run(
-            Command::new(crate::cargo())
-                .current_dir(root)
-                .args(["update", "--workspace"]),
-        )?;
-        plan.crates = published_packages(root)?;
-        let notes = release_notes(root, &plan, &old)?;
+        prepare_selection(root, &mut plan, core.as_deref())?;
+        let notes = release_notes(root, &plan, &previous_tag)?;
         fs::create_dir_all(root.join("releases"))?;
         fs::write(root.join(plan.notes_path()), notes)?;
         fs::write(
@@ -112,7 +104,7 @@ pub(super) fn run(root: &Path) -> Result<()> {
         git(root, &["add", PLAN_PATH, &plan.notes_path()])?;
         git(
             root,
-            &["commit", "-m", &format!("chore: release v{}", plan.version)],
+            &["commit", "-m", &format!("chore: release {}", plan.label())],
         )?;
         git(root, &["push", "--set-upstream", "origin", &branch])?;
     }
@@ -147,7 +139,7 @@ pub(super) fn run(root: &Path) -> Result<()> {
                 "--head",
                 &branch,
                 "--title",
-                &format!("chore: release v{}", plan.version),
+                &format!("chore: release {}", plan.label()),
                 "--body-file",
                 &plan.notes_path(),
             ],
@@ -155,17 +147,139 @@ pub(super) fn run(root: &Path) -> Result<()> {
         .trim()
         .to_owned()
     };
-    // GITHUB_TOKEN pushes don't trigger ordinary CI. An explicit dispatch does,
-    // and its check runs attach to the release branch's commit for protection.
     gh(root, &["workflow", "run", "ci.yml", "--ref", &branch])?;
     output("pr", &url)?;
     output("branch", &branch)?;
     if let Some(path) = std::env::var_os("GITHUB_STEP_SUMMARY") {
         writeln!(
             OpenOptions::new().append(true).open(path)?,
-            "Release PR: {url}\n\nApprove and merge after CI passes. Native SDKs and Rust will publish automatically, followed by one GitHub Release."
+            "Release PR: {url}\n\nReview selected packages and version bumps before merging. Selected native SDKs and Rust crates publish automatically, followed by one GitHub Release."
         )?;
     }
+    Ok(())
+}
+
+fn request(root: &Path) -> Result<(ReleasePlan, Option<String>)> {
+    let id = std::env::var("RELEASE_ID").context("RELEASE_ID is required (e.g. 20260908.1)")?;
+    selection::validate_id(&id)?;
+    let core = optional("RELEASE_VERSION")?;
+    let old = read_toml(&root.join("Cargo.toml"))?["workspace"]["package"]["version"]
+        .as_str()
+        .context("workspace version")?
+        .to_owned();
+    let packages: BTreeMap<String, String> = serde_json::from_str(
+        &std::env::var("PACKAGE_VERSIONS").ok().filter(|v| !v.trim().is_empty()).unwrap_or_else(|| "{}".into())
+    ).context("package_versions must be a JSON object mapping package groups to patch/minor/major or a version")?;
+    let plan = ReleasePlan {
+        version: core.clone().unwrap_or_else(|| old.clone()),
+        source: git(root, &["rev-parse", "HEAD"])?.trim().into(),
+        sdk: optional("SDK_VERSION")?,
+        gradle: optional("GRADLE_VERSION")?,
+        ios: optional("IOS_VERSION")?,
+        subsecond: optional("SUBSECOND_VERSION")?,
+        crates: BTreeMap::new(),
+        selective: Some(selection::SelectivePlan {
+            id: id.clone(),
+            baseline: String::new(),
+            packages,
+            publish: Default::default(),
+            reasons: BTreeMap::new(),
+            contents: BTreeMap::new(),
+            lockfile: String::new(),
+        }),
+    };
+    Ok((plan, core))
+}
+
+pub(super) fn preview(root: &Path) -> Result<()> {
+    let (mut plan, core) = request(root)?;
+    let tag = ReleasePlan::read(root)?.tag();
+    let commit = git(root, &["rev-parse", &format!("{tag}^{{commit}}")])?
+        .trim()
+        .to_owned();
+    plan.selective.as_mut().unwrap().baseline = commit;
+    let checkout = selection::Baseline::new(root, &plan.source)?;
+    prepare_selection(checkout.path(), &mut plan, core.as_deref())?;
+    println!("{}", serde_json::to_string_pretty(&plan)?);
+    Ok(())
+}
+
+pub(super) fn prepare_selection(
+    root: &Path,
+    plan: &mut ReleasePlan,
+    core: Option<&str>,
+) -> Result<()> {
+    let selected = plan.selective.as_ref().context("selective plan")?;
+    let baseline = selection::Baseline::new(root, &selected.baseline)?;
+    let previous = selection::Inventory::read(baseline.path())?;
+    let previous_contents = previous.contents(baseline.path())?;
+    selection::detach_packages(root)?;
+    for (stream, next) in [
+        ("sdk", &plan.sdk),
+        ("gradle", &plan.gradle),
+        ("ios", &plan.ios),
+    ] {
+        if let Some(next) = next {
+            native::update_pin(root, stream, next)?;
+        }
+    }
+    let current = selection::Inventory::read(root)?;
+    ensure!(
+        previous
+            .packages
+            .keys()
+            .all(|name| current.packages.contains_key(name)),
+        "removing published crates requires an explicit release migration"
+    );
+    for (name, package) in &current.packages {
+        if let Some(old) = previous.packages.get(name) {
+            ensure!(
+                package.version == old.version,
+                "{name} version changed outside release preparation; use package_versions or version inputs"
+            );
+        }
+    }
+    let contents = current.contents(root)?;
+    let changed = contents
+        .iter()
+        .filter(|(name, content)| previous_contents.get(*name) != Some(*content))
+        .map(|(name, _)| name.clone())
+        .collect();
+    let (versions, reasons) = current.select(
+        &previous,
+        &changed,
+        core,
+        plan.subsecond.as_deref(),
+        &selected.packages,
+    )?;
+    ensure!(
+        !reasons.is_empty(),
+        "no unpublished package changes or requested versions"
+    );
+    plan.crates = versions;
+    let selected = plan.selective.as_mut().unwrap();
+    selected.publish = reasons.keys().cloned().collect();
+    selected.reasons = reasons;
+    stamp_versions(root, plan)?;
+    crate::run(
+        Command::new(crate::cargo())
+            .current_dir(root)
+            .args(["update", "--workspace"]),
+    )?;
+    let final_inventory = selection::Inventory::read(root)?;
+    ensure!(
+        final_inventory.versions() == plan.crates,
+        "stamped package versions differ from selection"
+    );
+    let selected = plan.selective.as_mut().unwrap();
+    selected.contents = final_inventory.contents(root)?;
+    for (name, content) in &selected.contents {
+        ensure!(
+            selected.publish.contains(name) || previous_contents.get(name) == Some(content),
+            "unselected package {name} changed while preparing dependencies; include it in package_versions"
+        );
+    }
+    selected.lockfile = selection::lockfile(root)?;
     Ok(())
 }
 
@@ -180,6 +294,9 @@ fn optional(key: &str) -> Result<Option<String>> {
 }
 
 pub(super) fn stamp_versions(root: &Path, plan: &ReleasePlan) -> Result<()> {
+    if plan.selective.is_some() {
+        return stamp_selected_versions(root, plan);
+    }
     let mut versions = published_packages(root)?;
     let fork = versions
         .get("whisker-subsecond")
@@ -245,12 +362,12 @@ fn update_path_dependencies(table: &mut dyn TableLike, versions: &BTreeMap<Strin
     }
 }
 
-fn release_notes(root: &Path, plan: &ReleasePlan, previous: &str) -> Result<String> {
-    let previous_tag = format!("whisker-v{previous}");
-    ensure!(
-        remote_tag(root, &previous_tag)?.is_some(),
-        "missing previous release tag {previous_tag}; establish a release baseline first"
-    );
+fn release_notes(root: &Path, plan: &ReleasePlan, previous_tag: &str) -> Result<String> {
+    let selected = plan.selective.as_ref().context("selective notes")?;
+    let previous_plan: ReleasePlan = serde_json::from_str(&git(
+        root,
+        &["show", &format!("{previous_tag}:{PLAN_PATH}")],
+    )?)?;
     let commits = git(
         root,
         &[
@@ -261,14 +378,122 @@ fn release_notes(root: &Path, plan: &ReleasePlan, previous: &str) -> Result<Stri
         ],
     )?;
     let mut notes = format!(
-        "# Whisker {}\n\nOne release for the Rust workspace and selected native SDKs.\n\n| Stream | Version |\n| --- | --- |\n| Rust | {} |\n",
-        plan.version, plan.version
+        "# Whisker {}\n\nCore version: {}. One release for the selected Rust packages and native SDKs.\n\n| Crate | Previous | Next | Reason |\n| --- | --- | --- | --- |\n",
+        plan.label(),
+        plan.version
     );
-    for stream in ["sdk", "gradle", "ios"] {
-        notes.push_str(&format!("| {stream} | {} |\n", native::pin(root, stream)?));
+    for name in &selected.publish {
+        notes.push_str(&format!(
+            "| {name} | {} | {} | {} |\n",
+            previous_plan
+                .crates
+                .get(name)
+                .map(String::as_str)
+                .unwrap_or("new"),
+            plan.crates[name],
+            selected.reasons[name]
+        ));
     }
-    notes.push_str(&format!("| whisker-subsecond | {} |\n\n## Changes\n\n{commits}\n## Publishing\n\nAfter this PR is approved and merged, the selected native SDKs publish first, then all unpublished Rust versions. A single GitHub Release is created after verification.\n", plan.crates["whisker-subsecond"]));
+    notes.push_str("\nUnlisted Rust packages retain their published versions. Automatic patch bumps are proposals; review API compatibility before merging.\n\n| Native stream | Version | Publication |\n| --- | --- | --- |\n");
+    for (stream, next) in [
+        ("sdk", &plan.sdk),
+        ("gradle", &plan.gradle),
+        ("ios", &plan.ios),
+    ] {
+        notes.push_str(&format!(
+            "| {stream} | {} | {} |\n",
+            native::pin(root, stream)?,
+            if next.is_some() { "publish" } else { "reuse" }
+        ));
+    }
+    notes.push_str(&format!("\n## Changes\n\n{commits}\n## Publishing\n\nMerging publishes the selected native SDKs, then the selected Rust crates in dependency order. Failed jobs resume only missing versions. One GitHub Release is created after verification.\n"));
     Ok(notes)
+}
+
+fn stamp_selected_versions(root: &Path, plan: &ReleasePlan) -> Result<()> {
+    let inventory = selection::Inventory::read(root)?;
+    let selected = plan.selective.as_ref().unwrap();
+    let core: std::collections::BTreeSet<_> = inventory
+        .packages
+        .iter()
+        .filter(|(_, package)| package.group == "core")
+        .map(|(name, _)| name.clone())
+        .collect();
+    let core_selected = selected.publish.iter().any(|name| core.contains(name));
+    for path in manifests(root)? {
+        let mut doc = read_toml(&path)?;
+        let name = doc
+            .get("package")
+            .and_then(|item| item.get("name"))
+            .and_then(Item::as_str)
+            .map(str::to_owned);
+        let is_root = path == root.join("Cargo.toml");
+        let is_selected = name
+            .as_ref()
+            .is_some_and(|name| selected.publish.contains(name));
+        if name
+            .as_ref()
+            .is_some_and(|name| inventory.packages.contains_key(name))
+            && !is_selected
+        {
+            continue;
+        }
+        if is_root {
+            doc["workspace"]["package"]["version"] = value(&plan.version);
+        }
+        if let Some(next) = name.as_ref().and_then(|name| plan.crates.get(name)) {
+            if doc["package"]["version"].as_str().is_some() {
+                doc["package"]["version"] = value(next);
+            }
+        }
+        let exact_core =
+            core_selected && (is_root || name.as_ref().is_some_and(|name| core.contains(name)));
+        stamp_dependencies(
+            doc.as_table_mut(),
+            &plan.crates,
+            &core,
+            exact_core,
+            is_selected,
+        )?;
+        fs::write(path, doc.to_string())?;
+    }
+    Ok(())
+}
+
+fn stamp_dependencies(
+    table: &mut dyn TableLike,
+    versions: &BTreeMap<String, String>,
+    core: &std::collections::BTreeSet<String>,
+    exact_core: bool,
+    force: bool,
+) -> Result<()> {
+    for (key, item) in table.iter_mut() {
+        if let Some(nested) = item.as_table_like_mut() {
+            let name = nested
+                .get("package")
+                .and_then(Item::as_str)
+                .unwrap_or(&key)
+                .to_owned();
+            if let (Some(next), Some(current)) = (
+                versions.get(&name),
+                nested.get("version").and_then(Item::as_str),
+            ) {
+                if nested.contains_key("path") {
+                    let matches = semver::VersionReq::parse(current)?.matches(&version(next)?);
+                    if force || !matches || (exact_core && core.contains(&name)) {
+                        let next = if exact_core && core.contains(&name) {
+                            format!("={next}")
+                        } else {
+                            next.clone()
+                        };
+                        nested.insert("version", value(next));
+                    }
+                }
+            }
+            stamp_dependencies(nested, versions, core, exact_core, force)?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/release/publish.rs
+++ b/xtask/src/release/publish.rs
@@ -35,10 +35,11 @@ pub(super) fn run(root: &Path) -> Result<()> {
     );
 
     let agent = http();
+    let publishing = plan.publishing();
     let started = Instant::now();
     for attempt in 1..=80 {
         let mut pending = Vec::new();
-        for (name, value) in &plan.crates {
+        for (name, value) in &publishing {
             if !is_published(&agent, name, value)? {
                 pending.push(name.clone());
             }
@@ -60,7 +61,7 @@ pub(super) fn run(root: &Path) -> Result<()> {
                         &plan.tag(),
                         "--verify-tag",
                         "--title",
-                        &format!("Whisker {}", plan.version),
+                        &format!("Whisker {}", plan.label()),
                         "--notes-file",
                         &plan.notes_path(),
                     ],
@@ -68,7 +69,7 @@ pub(super) fn run(root: &Path) -> Result<()> {
             }
             println!(
                 "All {} crates verified; one GitHub Release: {}",
-                plan.crates.len(),
+                publishing.len(),
                 plan.tag()
             );
             return Ok(());

--- a/xtask/src/release/selection.rs
+++ b/xtask/src/release/selection.rs
@@ -1,0 +1,523 @@
+use super::*;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use toml_edit::{Item, Table, TableLike, value};
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct SelectivePlan {
+    pub id: String,
+    pub baseline: String,
+    pub packages: BTreeMap<String, String>,
+    pub publish: BTreeSet<String>,
+    pub reasons: BTreeMap<String, String>,
+    pub contents: BTreeMap<String, String>,
+    pub lockfile: String,
+}
+
+impl SelectivePlan {
+    pub fn validate(&self, root: &Path, versions: &BTreeMap<String, String>) -> Result<()> {
+        validate_id(&self.id)?;
+        ensure!(!self.publish.is_empty(), "release has no selected crates");
+        ensure!(
+            self.publish.iter().all(|name| versions.contains_key(name)),
+            "release selects an unknown crate"
+        );
+        ensure!(
+            self.baseline.len() == 40 && self.baseline.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "invalid release baseline"
+        );
+        git(
+            root,
+            &["merge-base", "--is-ancestor", &self.baseline, "HEAD"],
+        )?;
+        let previous: ReleasePlan = serde_json::from_str(&git(
+            root,
+            &["show", &format!("{}:{PLAN_PATH}", self.baseline)],
+        )?)?;
+        ensure!(
+            previous
+                .crates
+                .keys()
+                .all(|name| versions.contains_key(name)),
+            "a published crate was removed from the release inventory"
+        );
+        let updated: BTreeSet<_> = versions
+            .iter()
+            .filter(|(name, next)| previous.crates.get(*name) != Some(*next))
+            .map(|(name, _)| name.clone())
+            .collect();
+        ensure!(
+            updated == self.publish,
+            "publication selection does not match changed package versions"
+        );
+        for name in &updated {
+            if let Some(old) = previous.crates.get(name) {
+                ensure!(
+                    version(&versions[name])? > version(old)?,
+                    "{name} must use a newer version than {old}"
+                );
+            }
+        }
+        ensure!(
+            self.contents == Inventory::read(root)?.contents(root)?,
+            "package contents changed after release preparation; prepare a new release"
+        );
+        ensure!(
+            self.lockfile == lockfile(root)?,
+            "Cargo.lock changed after release preparation; prepare a new release"
+        );
+        Ok(())
+    }
+}
+
+pub(super) fn validate_id(id: &str) -> Result<()> {
+    let (date, sequence) = id
+        .split_once('.')
+        .context("release_id must look like 20260908.1")?;
+    ensure!(
+        date.len() == 8
+            && date.bytes().all(|b| b.is_ascii_digit())
+            && !sequence.is_empty()
+            && sequence.bytes().all(|b| b.is_ascii_digit())
+            && sequence.parse::<u32>().is_ok_and(|n| n > 0),
+        "release_id must look like 20260908.1"
+    );
+    Ok(())
+}
+
+pub(super) fn lockfile(root: &Path) -> Result<String> {
+    Ok(format!(
+        "{:x}",
+        Sha256::digest(fs::read(root.join("Cargo.lock"))?)
+    ))
+}
+
+pub(super) struct Baseline {
+    directory: tempfile::TempDir,
+    repository: PathBuf,
+}
+
+impl Baseline {
+    pub fn new(root: &Path, commit: &str) -> Result<Self> {
+        let directory = tempfile::tempdir()?;
+        git(
+            root,
+            &[
+                "worktree",
+                "add",
+                "--detach",
+                directory.path().to_str().context("baseline path")?,
+                commit,
+            ],
+        )?;
+        Ok(Self {
+            directory,
+            repository: root.to_owned(),
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.directory.path()
+    }
+}
+
+impl Drop for Baseline {
+    fn drop(&mut self) {
+        let _ = Command::new("git")
+            .current_dir(&self.repository)
+            .args(["worktree", "remove", "--force"])
+            .arg(self.directory.path())
+            .output();
+    }
+}
+
+pub(super) struct Package {
+    pub version: String,
+    pub manifest: PathBuf,
+    pub group: String,
+    metadata: serde_json::Value,
+}
+
+pub(super) struct Inventory {
+    pub packages: BTreeMap<String, Package>,
+}
+
+impl Inventory {
+    pub fn read(root: &Path) -> Result<Self> {
+        let root = root.canonicalize()?;
+        let data = metadata(&root)?;
+        let members = data["workspace_members"]
+            .as_array()
+            .context("workspace members")?;
+        let mut packages = BTreeMap::new();
+        for package in data["packages"].as_array().context("workspace packages")? {
+            if !members.contains(&package["id"]) || package["publish"] == serde_json::json!([]) {
+                continue;
+            }
+            ensure!(
+                package["publish"].is_null()
+                    || package["publish"] == serde_json::json!(["crates-io"]),
+                "only crates.io is supported"
+            );
+            let name = package["name"].as_str().context("package name")?.to_owned();
+            let manifest =
+                PathBuf::from(package["manifest_path"].as_str().context("manifest path")?);
+            let relative = manifest.strip_prefix(&root)?;
+            let group = if name == "whisker-subsecond" {
+                name.clone()
+            } else if relative.starts_with("packages") {
+                relative
+                    .iter()
+                    .nth(1)
+                    .context("package group")?
+                    .to_string_lossy()
+                    .into_owned()
+            } else {
+                "core".into()
+            };
+            packages.insert(
+                name,
+                Package {
+                    version: package["version"]
+                        .as_str()
+                        .context("package version")?
+                        .into(),
+                    manifest,
+                    group,
+                    metadata: package.clone(),
+                },
+            );
+        }
+        ensure!(!packages.is_empty(), "no publishable packages");
+        Ok(Self { packages })
+    }
+
+    pub fn contents(&self, root: &Path) -> Result<BTreeMap<String, String>> {
+        let root = root.canonicalize()?;
+        self.packages
+            .iter()
+            .map(|(name, package)| {
+                let list = crate::capture(Command::new(crate::cargo()).current_dir(&root).args([
+                    "package",
+                    "--list",
+                    "--allow-dirty",
+                    "-p",
+                    name,
+                ]))?;
+                let directory = package.manifest.parent().context("crate directory")?;
+                let mut hash = Sha256::new();
+                hash_part(&mut hash, &manifest_contents(package, &root)?);
+                for path in list.lines().collect::<BTreeSet<_>>() {
+                    if matches!(
+                        path,
+                        "Cargo.toml" | "Cargo.toml.orig" | "Cargo.lock" | ".cargo_vcs_info.json"
+                    ) {
+                        continue;
+                    }
+                    let mut source = directory.join(path);
+                    if !source.is_file() {
+                        for field in ["readme", "license_file"] {
+                            if let Some(external) = package.metadata[field].as_str() {
+                                if Path::new(external).file_name() == Path::new(path).file_name() {
+                                    source = directory.join(external);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    hash_part(&mut hash, path.as_bytes());
+                    let contents = if let Some(nested) = self
+                        .packages
+                        .values()
+                        .find(|package| package.manifest == source)
+                    {
+                        manifest_contents(nested, &root)?
+                    } else {
+                        fs::read(&source)
+                            .with_context(|| format!("read packaged file {}", source.display()))?
+                    };
+                    hash_part(&mut hash, &contents);
+                }
+                Ok((name.clone(), format!("{:x}", hash.finalize())))
+            })
+            .collect()
+    }
+
+    pub fn versions(&self) -> BTreeMap<String, String> {
+        self.packages
+            .iter()
+            .map(|(name, package)| (name.clone(), package.version.clone()))
+            .collect()
+    }
+
+    pub fn select(
+        &self,
+        baseline: &Inventory,
+        changed: &BTreeSet<String>,
+        core: Option<&str>,
+        fork: Option<&str>,
+        overrides: &BTreeMap<String, String>,
+    ) -> Result<(BTreeMap<String, String>, BTreeMap<String, String>)> {
+        let mut group_versions = BTreeMap::new();
+        for package in self.packages.values() {
+            if let Some(existing) = group_versions.insert(&package.group, &package.version) {
+                ensure!(
+                    existing == &package.version,
+                    "all crates in group {} must share a version",
+                    package.group
+                );
+            }
+        }
+        let mut groups = BTreeMap::new();
+        for name in changed {
+            groups.insert(
+                self.packages[name].group.clone(),
+                "package contents changed".to_owned(),
+            );
+        }
+        for group in overrides.keys() {
+            ensure!(
+                group != "core"
+                    && group != "whisker-subsecond"
+                    && self.packages.values().any(|p| &p.group == group),
+                "unknown package group {group}"
+            );
+            groups.insert(group.clone(), "explicit package version".into());
+        }
+        if core.is_some() {
+            groups.insert("core".into(), "core release".into());
+        }
+        if fork.is_some() {
+            groups.insert("whisker-subsecond".into(), "fork release".into());
+        }
+        loop {
+            ensure!(
+                !groups.contains_key("core") || core.is_some(),
+                "core has changes; specify version (the new core version)"
+            );
+            ensure!(
+                !groups.contains_key("whisker-subsecond") || fork.is_some(),
+                "whisker-subsecond has changes; specify subsecond_version"
+            );
+            let mut versions = self.versions();
+            for (name, package) in &self.packages {
+                if !groups.contains_key(&package.group) {
+                    continue;
+                }
+                let requested = match package.group.as_str() {
+                    "core" => core.unwrap(),
+                    "whisker-subsecond" => fork.unwrap(),
+                    group => overrides.get(group).map(String::as_str).unwrap_or("patch"),
+                };
+                let next = next_version(
+                    &package.version,
+                    requested,
+                    !baseline
+                        .packages
+                        .values()
+                        .any(|old| old.group == package.group),
+                )?;
+                versions.insert(name.clone(), next);
+            }
+            let mut expanded = false;
+            for (name, package) in &self.packages {
+                if groups.contains_key(&package.group) {
+                    continue;
+                }
+                for dependency in package.metadata["dependencies"]
+                    .as_array()
+                    .context("dependencies")?
+                {
+                    if dependency["path"].is_null() {
+                        continue;
+                    }
+                    let target = dependency["name"].as_str().context("dependency name")?;
+                    if let Some(next) = versions.get(target) {
+                        let requirement = semver::VersionReq::parse(
+                            dependency["req"].as_str().context("dependency version")?,
+                        )?;
+                        if !requirement.matches(&version(next)?) {
+                            groups.insert(
+                                package.group.clone(),
+                                format!("{name} requires an update for {target} {next}"),
+                            );
+                            expanded = true;
+                        }
+                    }
+                }
+            }
+            if !expanded {
+                let reasons = self
+                    .packages
+                    .iter()
+                    .filter_map(|(name, p)| {
+                        groups
+                            .get(&p.group)
+                            .map(|reason| (name.clone(), reason.clone()))
+                    })
+                    .collect();
+                return Ok((versions, reasons));
+            }
+        }
+    }
+}
+
+fn manifest_contents(package: &Package, root: &Path) -> Result<Vec<u8>> {
+    let mut manifest = package.metadata.clone();
+    let object = manifest.as_object_mut().context("package metadata")?;
+    object.remove("id");
+    object.remove("manifest_path");
+    for dependency in object["dependencies"]
+        .as_array_mut()
+        .context("dependencies")?
+    {
+        dependency
+            .as_object_mut()
+            .context("dependency")?
+            .remove("path");
+    }
+    let targets = object["targets"].as_array_mut().context("targets")?;
+    targets.retain(|target| {
+        !target["kind"].as_array().is_some_and(|kinds| {
+            kinds
+                .iter()
+                .any(|kind| matches!(kind.as_str(), Some("test" | "bench" | "example")))
+        })
+    });
+    for target in targets {
+        let source = Path::new(target["src_path"].as_str().context("target source")?);
+        target["src_path"] = source.strip_prefix(root)?.to_string_lossy().as_ref().into();
+    }
+    Ok(serde_json::to_vec(&manifest)?)
+}
+
+fn hash_part(hash: &mut Sha256, bytes: &[u8]) {
+    hash.update((bytes.len() as u64).to_le_bytes());
+    hash.update(bytes);
+}
+
+fn next_version(current: &str, request: &str, new: bool) -> Result<String> {
+    let old = version(current)?;
+    let mut next = old.clone();
+    match request {
+        "patch" if new => {}
+        "patch" => next.patch += 1,
+        "minor" => {
+            next.minor += 1;
+            next.patch = 0;
+        }
+        "major" => {
+            next.major += 1;
+            next.minor = 0;
+            next.patch = 0;
+        }
+        explicit => next = version(explicit)?,
+    }
+    ensure!(
+        next > old || (new && next == old),
+        "new version {next} must be newer than {old}"
+    );
+    Ok(next.to_string())
+}
+
+pub(super) fn detach_packages(root: &Path) -> Result<()> {
+    let inventory = Inventory::read(root)?;
+    let workspace = read_toml(&root.join("Cargo.toml"))?;
+    let dependencies = workspace["workspace"]["dependencies"]
+        .as_table_like()
+        .context("workspace dependencies")?;
+    let root = root.canonicalize()?;
+    for package in inventory
+        .packages
+        .values()
+        .filter(|p| p.group != "core" && p.group != "whisker-subsecond")
+    {
+        let mut doc = read_toml(&package.manifest)?;
+        doc["package"]["version"] = value(&package.version);
+        detach_dependencies(
+            doc.as_table_mut(),
+            dependencies,
+            &root,
+            package.manifest.parent().unwrap(),
+        )?;
+        fs::write(&package.manifest, doc.to_string())?;
+    }
+    Ok(())
+}
+
+fn detach_dependencies(
+    table: &mut dyn TableLike,
+    workspace: &dyn TableLike,
+    root: &Path,
+    directory: &Path,
+) -> Result<()> {
+    for (key, item) in table.iter_mut() {
+        if matches!(
+            &*key,
+            "dependencies" | "dev-dependencies" | "build-dependencies"
+        ) {
+            if let Some(dependencies) = item.as_table_like_mut() {
+                for (name, item) in dependencies.iter_mut() {
+                    if item.get("workspace").and_then(Item::as_bool) != Some(true) {
+                        continue;
+                    }
+                    let Some(inherited) = workspace.get(&name).and_then(Item::as_table_like) else {
+                        continue;
+                    };
+                    let Some(path) = inherited.get("path").and_then(Item::as_str) else {
+                        continue;
+                    };
+                    let mut local = Table::new();
+                    for (key, val) in inherited.iter() {
+                        local.insert(key, val.clone());
+                    }
+                    local.insert("path", value(relative_path(directory, &root.join(path))?));
+                    let overrides = item.as_table_like().context("inherited dependency")?;
+                    for (key, val) in overrides.iter().filter(|(key, _)| *key != "workspace") {
+                        if key == "features" {
+                            let mut features = local
+                                .get("features")
+                                .and_then(Item::as_array)
+                                .cloned()
+                                .unwrap_or_default();
+                            for feature in val.as_array().context("dependency features")?.iter() {
+                                if !features
+                                    .iter()
+                                    .any(|existing| existing.as_str() == feature.as_str())
+                                {
+                                    features.push(feature.clone());
+                                }
+                            }
+                            local.insert(key, value(features));
+                        } else {
+                            local.insert(key, val.clone());
+                        }
+                    }
+                    *item = value(local.into_inline_table());
+                }
+            }
+        } else if let Some(nested) = item.as_table_like_mut() {
+            detach_dependencies(nested, workspace, root, directory)?;
+        }
+    }
+    Ok(())
+}
+
+fn relative_path(from: &Path, to: &Path) -> Result<String> {
+    let from: Vec<_> = from.components().collect();
+    let to: Vec<_> = to.components().collect();
+    let common = from.iter().zip(&to).take_while(|(a, b)| a == b).count();
+    ensure!(
+        common > 0,
+        "dependency path is outside the repository volume"
+    );
+    let mut path = PathBuf::new();
+    for _ in common..from.len() {
+        path.push("..");
+    }
+    for component in &to[common..] {
+        path.push(component.as_os_str());
+    }
+    Ok(path.to_string_lossy().replace('\\', "/"))
+}

--- a/xtask/src/release/selection_tests.rs
+++ b/xtask/src/release/selection_tests.rs
@@ -1,0 +1,474 @@
+use super::*;
+use tests::{fixture, write};
+
+fn workspace() -> tempfile::TempDir {
+    let directory = fixture();
+    let root = directory.path();
+    let mut manifest = read_toml(&root.join("Cargo.toml")).unwrap();
+    for member in [
+        "crates/whisker-runtime",
+        "crates/whisker-cli",
+        "packages/router",
+        "packages/router/web",
+        "packages/untouched",
+    ] {
+        manifest["workspace"]["members"]
+            .as_array_mut()
+            .unwrap()
+            .push(member);
+    }
+    write(root, "Cargo.toml", &manifest.to_string());
+    for (path, name, dependency) in [
+        ("crates/whisker-runtime", "whisker-runtime", ""),
+        (
+            "crates/whisker-cli",
+            "whisker-cli",
+            "[dependencies]\nwhisker.workspace = true\n",
+        ),
+        (
+            "packages/router",
+            "router",
+            "[dependencies]\nwhisker.workspace = true\n",
+        ),
+        (
+            "packages/router/web",
+            "router-web",
+            "[dependencies]\nwhisker.workspace = true\n",
+        ),
+        (
+            "packages/untouched",
+            "untouched",
+            "[dependencies]\nwhisker.workspace = true\n",
+        ),
+    ] {
+        let include = if name == "router" {
+            "include = ['Cargo.toml', 'src/**', 'web/Cargo.toml', 'web/src/**', 'Package.swift']\n"
+        } else {
+            ""
+        };
+        write(
+            root,
+            &format!("{path}/Cargo.toml"),
+            &format!(
+                "[package]\nname = '{name}'\nversion.workspace = true\nedition.workspace = true\n{include}{dependency}"
+            ),
+        );
+        write(root, &format!("{path}/src/lib.rs"), "");
+    }
+    write(
+        root,
+        "packages/router/Package.swift",
+        ".package(url: \"https://github.com/whiskerrs/whisker.git\", exact: \"0.1.13\")\n",
+    );
+    crate::run(
+        Command::new(crate::cargo())
+            .current_dir(root)
+            .args(["generate-lockfile", "--offline"]),
+    )
+    .unwrap();
+    let mut previous = plan(root);
+    previous.selective = None;
+    previous.crates = published_packages(root).unwrap();
+    write(
+        root,
+        PLAN_PATH,
+        &serde_json::to_string_pretty(&previous).unwrap(),
+    );
+    commit(root);
+    directory
+}
+
+fn commit(root: &Path) {
+    git(root, &["add", "."]).unwrap();
+    git(root, &["commit", "-m", "fixture changes"]).unwrap();
+}
+
+fn plan(root: &Path) -> ReleasePlan {
+    let source = git(root, &["rev-parse", "HEAD"]).unwrap().trim().to_owned();
+    ReleasePlan {
+        version: "0.13.3".into(),
+        source: source.clone(),
+        sdk: None,
+        gradle: None,
+        ios: None,
+        subsecond: None,
+        crates: BTreeMap::new(),
+        selective: Some(selection::SelectivePlan {
+            id: "20260908.1".into(),
+            baseline: source,
+            packages: BTreeMap::new(),
+            publish: Default::default(),
+            reasons: BTreeMap::new(),
+            contents: BTreeMap::new(),
+            lockfile: String::new(),
+        }),
+    }
+}
+
+#[test]
+fn packages_only_release_preserves_core_and_unrelated_package_requirements() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut plan = plan(root);
+    write(
+        root,
+        "packages/router/web/src/lib.rs",
+        "pub fn changed() {}\n",
+    );
+    commit(root);
+    prepare::prepare_selection(root, &mut plan, None).unwrap();
+    assert_eq!(
+        plan.publishing(),
+        BTreeMap::from([
+            ("router".into(), "0.13.4".into()),
+            ("router-web".into(), "0.13.4".into())
+        ])
+    );
+    assert_eq!(plan.crates["whisker"], "0.13.3");
+    assert_eq!(plan.crates["untouched"], "0.13.3");
+    let manifest = read_toml(&root.join("packages/untouched/Cargo.toml")).unwrap();
+    assert_eq!(
+        manifest["dependencies"]["whisker"]["version"].as_str(),
+        Some("0.13.3")
+    );
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.13.3"));
+    write(root, &plan.notes_path(), "notes");
+    plan.validate_checkout(root).unwrap();
+}
+
+#[test]
+fn core_patch_pins_core_without_republishing_packages() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut plan = plan(root);
+    plan.version = "0.13.4".into();
+    write(
+        root,
+        "crates/whisker-runtime/src/lib.rs",
+        "pub fn changed() {}\n",
+    );
+    commit(root);
+    prepare::prepare_selection(root, &mut plan, Some("0.13.4")).unwrap();
+    assert_eq!(
+        plan.publishing().keys().cloned().collect::<Vec<_>>(),
+        ["whisker", "whisker-cli", "whisker-runtime"]
+    );
+    let workspace = read_toml(&root.join("Cargo.toml")).unwrap();
+    assert_eq!(
+        workspace["workspace"]["dependencies"]["whisker"]["version"].as_str(),
+        Some("=0.13.4")
+    );
+    let package = read_toml(&root.join("packages/router/Cargo.toml")).unwrap();
+    assert_eq!(
+        package["dependencies"]["whisker"]["version"].as_str(),
+        Some("0.13.3")
+    );
+}
+
+#[test]
+fn packages_only_release_after_a_core_release_keeps_core_exact_pins() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut first = plan(root);
+    first.version = "0.13.4".into();
+    prepare::prepare_selection(root, &mut first, Some("0.13.4")).unwrap();
+    write(
+        root,
+        PLAN_PATH,
+        &serde_json::to_string_pretty(&first).unwrap(),
+    );
+    write(root, &first.notes_path(), "notes");
+    commit(root);
+    let mut second = plan(root);
+    second.version = first.version;
+    second.selective.as_mut().unwrap().id = "20260908.2".into();
+    write(root, "packages/router/src/lib.rs", "pub fn changed() {}\n");
+    commit(root);
+    prepare::prepare_selection(root, &mut second, None).unwrap();
+    assert_eq!(
+        second.publishing().keys().cloned().collect::<Vec<_>>(),
+        ["router", "router-web"]
+    );
+    let workspace = read_toml(&root.join("Cargo.toml")).unwrap();
+    assert_eq!(
+        workspace["workspace"]["dependencies"]["whisker"]["version"].as_str(),
+        Some("=0.13.4")
+    );
+    assert_eq!(second.crates["whisker"], "0.13.4");
+    write(root, &second.notes_path(), "notes");
+    second.validate_checkout(root).unwrap();
+}
+
+#[test]
+fn detaching_preserves_commented_renamed_target_dependencies_and_additive_features() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut workspace = fs::read_to_string(root.join("Cargo.toml")).unwrap();
+    workspace.push_str("\nalias = { package = 'whisker', path = 'crates/whisker', version = '0.13.3', default-features = false, features = ['a'] }\n");
+    write(root, "Cargo.toml", &workspace);
+    let core = fs::read_to_string(root.join("crates/whisker/Cargo.toml")).unwrap();
+    write(
+        root,
+        "crates/whisker/Cargo.toml",
+        &format!("{core}\n[features]\na = []\nb = []\n"),
+    );
+    write(
+        root,
+        "packages/untouched/Cargo.toml",
+        "[package]\nname = 'untouched'\nversion.workspace = true\nedition.workspace = true\n[target.'cfg(unix)'.dependencies]\n# A dependency with a retained comment.\nalias = { workspace = true, features = ['b'], optional = true }\n",
+    );
+    commit(root);
+    let before = selection::Inventory::read(root)
+        .unwrap()
+        .contents(root)
+        .unwrap();
+    selection::detach_packages(root).unwrap();
+    assert_eq!(
+        before,
+        selection::Inventory::read(root)
+            .unwrap()
+            .contents(root)
+            .unwrap()
+    );
+    let manifest = read_toml(&root.join("packages/untouched/Cargo.toml")).unwrap();
+    let dependency = &manifest["target"]["cfg(unix)"]["dependencies"]["alias"];
+    assert_eq!(dependency["path"].as_str(), Some("../../crates/whisker"));
+    assert_eq!(dependency["package"].as_str(), Some("whisker"));
+    assert_eq!(dependency["default-features"].as_bool(), Some(false));
+    assert_eq!(dependency["optional"].as_bool(), Some(true));
+    assert_eq!(
+        dependency["features"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        ["a", "b"]
+    );
+}
+
+#[test]
+fn native_pin_changes_require_core_and_select_packages_whose_swift_manifests_change() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut selected = plan(root);
+    selected.sdk = Some("0.1.22".into());
+    assert!(
+        prepare::prepare_selection(root, &mut selected, None)
+            .unwrap_err()
+            .to_string()
+            .contains("core has changes")
+    );
+    selected.version = "0.13.4".into();
+    selected.ios = Some("0.1.14".into());
+    prepare::prepare_selection(root, &mut selected, Some("0.13.4")).unwrap();
+    assert!(selected.publishing().contains_key("whisker-cli"));
+    assert!(selected.publishing().contains_key("router"));
+    assert!(!selected.publishing().contains_key("untouched"));
+    write(root, &selected.notes_path(), "notes");
+    selected.validate_checkout(root).unwrap();
+}
+
+#[test]
+fn publication_selection_cannot_omit_updated_crates_or_include_unchanged_crates() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut selected = plan(root);
+    selected
+        .selective
+        .as_mut()
+        .unwrap()
+        .packages
+        .insert("router".into(), "patch".into());
+    prepare::prepare_selection(root, &mut selected, None).unwrap();
+    write(root, &selected.notes_path(), "notes");
+    let mut missing = selected.clone();
+    missing
+        .selective
+        .as_mut()
+        .unwrap()
+        .publish
+        .remove("router-web");
+    assert!(
+        missing
+            .validate_checkout(root)
+            .unwrap_err()
+            .to_string()
+            .contains("publication selection")
+    );
+    selected
+        .selective
+        .as_mut()
+        .unwrap()
+        .publish
+        .insert("untouched".into());
+    assert!(
+        selected
+            .validate_checkout(root)
+            .unwrap_err()
+            .to_string()
+            .contains("publication selection")
+    );
+}
+
+#[test]
+fn overrides_reject_unknown_groups_version_reuse_and_unaligned_group_members() {
+    for (group, request) in [
+        ("missing", "patch"),
+        ("core", "patch"),
+        ("router", "0.13.3"),
+        ("router", "0.12.0"),
+    ] {
+        let directory = workspace();
+        let root = directory.path();
+        let current = selection::Inventory::read(root).unwrap();
+        assert!(
+            current
+                .select(
+                    &current,
+                    &Default::default(),
+                    None,
+                    None,
+                    &BTreeMap::from([(group.into(), request.into())])
+                )
+                .is_err()
+        );
+    }
+    let directory = workspace();
+    let root = directory.path();
+    let mut current = selection::Inventory::read(root).unwrap();
+    let baseline = selection::Inventory::read(root).unwrap();
+    current.packages.get_mut("router-web").unwrap().version = "0.1.0".into();
+    assert!(
+        current
+            .select(&baseline, &Default::default(), None, None, &BTreeMap::new())
+            .unwrap_err()
+            .to_string()
+            .contains("must share a version")
+    );
+}
+
+#[test]
+fn incompatible_core_release_expands_to_dependents_and_keeps_one_package_group_version() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut plan = plan(root);
+    plan.version = "0.14.0".into();
+    plan.selective
+        .as_mut()
+        .unwrap()
+        .packages
+        .insert("router".into(), "minor".into());
+    prepare::prepare_selection(root, &mut plan, Some("0.14.0")).unwrap();
+    assert_eq!(plan.crates["router"], "0.14.0");
+    assert_eq!(plan.crates["router-web"], "0.14.0");
+    assert_eq!(plan.crates["untouched"], "0.13.4");
+    let package = read_toml(&root.join("packages/untouched/Cargo.toml")).unwrap();
+    assert_eq!(
+        package["dependencies"]["whisker"]["version"].as_str(),
+        Some("0.14.0")
+    );
+    assert!(!plan.publishing().contains_key("whisker-subsecond"));
+}
+
+#[test]
+fn core_and_fork_changes_require_explicit_versions() {
+    for path in [
+        "crates/whisker-runtime/src/lib.rs",
+        "crates/whisker-subsecond/src/lib.rs",
+    ] {
+        let directory = workspace();
+        let root = directory.path();
+        let mut plan = plan(root);
+        write(root, path, "pub fn changed() {}\n");
+        commit(root);
+        let error = prepare::prepare_selection(root, &mut plan, None)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("specify"), "{error}");
+    }
+}
+
+#[test]
+fn excluded_tests_do_not_trigger_publication_but_packaged_native_files_do() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut plan = plan(root);
+    write(
+        root,
+        "packages/router/tests/test.rs",
+        "#[test] fn test() {}\n",
+    );
+    commit(root);
+    let inventory = selection::Inventory::read(root).unwrap();
+    let baseline =
+        selection::Baseline::new(root, &plan.selective.as_ref().unwrap().baseline).unwrap();
+    assert_eq!(
+        inventory.contents(root).unwrap(),
+        selection::Inventory::read(baseline.path())
+            .unwrap()
+            .contents(baseline.path())
+            .unwrap()
+    );
+    write(
+        root,
+        "packages/router/Package.swift",
+        "// changed native manifest\n",
+    );
+    commit(root);
+    prepare::prepare_selection(root, &mut plan, None).unwrap();
+    assert!(plan.publishing().contains_key("router"));
+}
+
+#[test]
+fn preparation_fingerprints_reject_late_selected_and_unselected_changes_and_lockfile_edits() {
+    let directory = workspace();
+    let root = directory.path();
+    let mut plan = plan(root);
+    plan.selective
+        .as_mut()
+        .unwrap()
+        .packages
+        .insert("router".into(), "0.15.0".into());
+    prepare::prepare_selection(root, &mut plan, None).unwrap();
+    write(root, &plan.notes_path(), "notes");
+    plan.validate_checkout(root).unwrap();
+    for path in [
+        "packages/router/src/lib.rs",
+        "packages/untouched/src/lib.rs",
+        "Cargo.lock",
+    ] {
+        let previous = fs::read_to_string(root.join(path)).unwrap();
+        write(root, path, &format!("{previous}\n// unexpected change\n"));
+        assert!(plan.validate_checkout(root).is_err(), "{path}");
+        write(root, path, &previous);
+    }
+}
+
+#[test]
+fn selective_identifiers_are_safe_and_legacy_plans_keep_their_publication_set_and_tag() {
+    for id in [
+        "../../main",
+        "20260908.0",
+        "20260908.1\nrelease=true",
+        "20260908.$(id)",
+        "0.13.9",
+    ] {
+        assert!(selection::validate_id(id).is_err());
+    }
+    selection::validate_id("20260908.12").unwrap();
+    let mut legacy: ReleasePlan = serde_json::from_str(r#"{"version":"0.13.3","source":"abc","sdk":null,"gradle":null,"ios":null,"subsecond":null,"crates":{"whisker":"0.13.3","router":"0.13.3"}}"#).unwrap();
+    assert_eq!(legacy.publishing(), legacy.crates);
+    assert_eq!(legacy.tag(), "whisker-v0.13.3");
+    assert_eq!(legacy.notes_path(), "releases/0.13.3.md");
+    let directory = workspace();
+    legacy.selective = plan(directory.path()).selective;
+    legacy
+        .selective
+        .as_mut()
+        .unwrap()
+        .publish
+        .insert("router".into());
+    assert_eq!(legacy.publishing().len(), 1);
+    assert_eq!(legacy.tag(), "whisker-release-20260908.1");
+}

--- a/xtask/src/release/tests.rs
+++ b/xtask/src/release/tests.rs
@@ -255,7 +255,7 @@ whisker = { path = "../whisker" }
     assert!(updated.contains("features = [\"hot-reload\"]"));
 }
 
-fn fixture() -> tempfile::TempDir {
+pub(super) fn fixture() -> tempfile::TempDir {
     let directory = tempfile::tempdir().unwrap();
     let root = directory.path();
     write(
@@ -308,7 +308,7 @@ fn fixture() -> tempfile::TempDir {
     directory
 }
 
-fn write(root: &Path, path: &str, text: &str) {
+pub(super) fn write(root: &Path, path: &str, text: &str) {
     let path = root.join(path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     fs::write(path, text).unwrap();
@@ -323,6 +323,7 @@ fn fixture_plan(root: &Path) -> ReleasePlan {
         ios: Some("0.1.14".into()),
         subsecond: None,
         crates: BTreeMap::new(),
+        selective: None,
     }
 }
 


### PR DESCRIPTION
Core releases currently bump all 61 non-fork Rust crates, including unchanged modules. This causes unnecessary crates.io uploads and repeated rate limits. Keep the existing crate layout and separate release version groups: core crates advance together, while each `packages/<directory>` and its nested backends advance independently.

### Release behavior

- Actions takes a required `release_id` such as `20260908.1`. The existing `version` input becomes the optional core version; leave it blank for packages-only releases. `package_versions` accepts JSON overrides with patch/minor/major or explicit versions.
- Compare Cargo-packaged files and resolved manifest metadata with the last completed release. Changed package groups default to a patch bump; incompatible local dependency requirements also select their dependent groups. Core and fork changes require explicit version inputs.
- Keep core-to-core dependencies exact-pinned. Detach package versions and internal dependencies from workspace inheritance during preparation, preserving unchanged packages' compatible minimum requirements. Native pin changes participate in selection.
- Generate one release PR with selected versions and reasons. Publish only the selected crates and finish with one `whisker-release-<release_id>` GitHub Release. Native SDK ordering and resumable 429 handling remain in place.
- Freeze packaged content and Cargo.lock in the plan to reject intervening changes before publication. Legacy release plans retain their original versions and tags for recovery.
- Add `cargo xtask release preview`, which prepares a temporary checkout of committed HEAD and prints the selection without creating a PR or publishing. Update the release skill with the new inputs and recovery flow.

This PR does not bump or publish any framework/package versions. The first generated release PR performs the manifest inheritance migration. Core updates still publish all 27 core crates; this reduces upload volume but does not guarantee that crates.io will never rate-limit a release. Review automatic patch proposals for semver compatibility.

### Validation

- `cargo test -p xtask`: 36 passed, including packages-only releases after exact core pinning, nested backend groups, incompatible dependency propagation, native pins, manifest comments/features/renames, and stale/tampered plans.
- Rust 1.88 Clippy for xtask and all targets, with the CI warning flags: passed.
- `cargo fmt --all -- --check`, `git diff --check`, and workflow YAML parsing: passed.
- Real-repository preview of main `0d21a0cc` against `whisker-v0.13.8`, requesting core `0.13.9`: selects 34 crates (27 core + 7 package crates) instead of updating all 61 non-fork crates. No release was published.
