### PR TITLE
perf(list): measure a small initial window before expanding

### DIFF
--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -39,6 +39,8 @@ use whisker_engine::{
     lower_color, lower_paint, lower_transform,
 };
 
+const MAX_LIST_LAYOUT_PASSES: usize = 4;
+
 /// A mutation emitted by `render!` that could not enter the retained surface.
 #[derive(Clone, Debug, PartialEq)]
 pub enum RuntimeBindingError {
@@ -404,6 +406,7 @@ impl SurfaceRuntime {
                 resource_events: HashMap::new(),
                 background_resources: BackgroundResourceManager::default(),
                 mutation_batch: None,
+                list_layout_requested: false,
                 #[cfg(test)]
                 surface_snapshot_count: 0,
                 #[cfg(test)]
@@ -818,9 +821,22 @@ impl SurfaceRuntime {
         sink: &mut Sink,
         options: LayoutOptions,
     ) -> Result<RuntimeFrame, RuntimeFrameError<Provider::Error, Sink::Error>> {
-        let layout = self
+        self.state.borrow_mut().list_layout_requested = false;
+        let mut layout = self
             .drive_layout(viewport, environment_epoch, provider, options)
             .map_err(RuntimeFrameError::Layout)?;
+        for _ in 1..MAX_LIST_LAYOUT_PASSES {
+            let needs_list_layout = {
+                let mut state = self.state.borrow_mut();
+                std::mem::take(&mut state.list_layout_requested) && state.surface.needs_layout()
+            };
+            if !layout.has_layout() || !needs_list_layout {
+                break;
+            }
+            layout = self
+                .drive_layout(viewport, environment_epoch, provider, options)
+                .map_err(RuntimeFrameError::Layout)?;
+        }
         let presentation = if layout.has_layout() {
             self.present(viewport_epoch, sink)
                 .map_err(RuntimeFrameError::Present)?
@@ -958,6 +974,7 @@ struct BindingState {
     resource_events: HashMap<(ResourceId, u64), ResourceEvent>,
     background_resources: BackgroundResourceManager,
     mutation_batch: Option<MutationBatch>,
+    list_layout_requested: bool,
     #[cfg(test)]
     surface_snapshot_count: usize,
     #[cfg(test)]

--- a/crates/whisker-runtime/src/surface_runtime/renderer.rs
+++ b/crates/whisker-runtime/src/surface_runtime/renderer.rs
@@ -314,6 +314,10 @@ impl DynRenderer for SurfaceRuntime {
         state.record(result);
     }
 
+    fn request_list_layout(&self) {
+        self.state.borrow_mut().list_layout_requested = true;
+    }
+
     fn invoke_element_command(
         &self,
         handle: Element,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -213,6 +213,9 @@ pub trait DynRenderer {
     /// layout notification batches may ignore it.
     fn observe_layout_batch_end(&self, _handle: Element, _callback: Box<dyn Fn() + 'static>) {}
 
+    #[doc(hidden)]
+    fn request_list_layout(&self) {}
+
     /// Plan how a reported event (`event_name` at `target_sign`,
     /// carrying `body`) propagates through Whisker's reconstructed
     /// chain — capture phase (root → target) then bubble phase
@@ -966,6 +969,10 @@ pub fn observe_layout_batch_end(handle: Element, callback: Box<dyn Fn() + 'stati
         |renderer| renderer.observe_layout_batch_end(handle, callback),
         (),
     )
+}
+
+pub(crate) fn request_list_layout() {
+    with_renderer(|renderer| renderer.request_list_layout(), ())
 }
 
 /// Gives the installed renderer the first opportunity to handle an element

--- a/crates/whisker-runtime/src/view/virtualizer.rs
+++ b/crates/whisker-runtime/src/view/virtualizer.rs
@@ -26,12 +26,13 @@ use super::handle::Element;
 use super::list::{ListRef, ListScrollTarget, ScrollAlignment, ScrollAxis};
 use super::renderer::{
     BindType, append_child, children_of, create_element, insert_child_at, observe_layout,
-    observe_layout_batch_end, remove_child, set_event_listener, set_specified_style,
-    specified_style, try_invoke_element_command,
+    observe_layout_batch_end, remove_child, request_list_layout, set_event_listener,
+    set_specified_style, specified_style, try_invoke_element_command,
 };
 
 const DEFAULT_ITEM_SIZE: f32 = 44.0;
 const DEFAULT_VIEWPORT_SIZE: f32 = 600.0;
+const INITIAL_MEASUREMENT_TRACKS: usize = 2;
 const DEFAULT_OVERSCAN_ITEMS: usize = 2;
 const DEFAULT_OVERSCAN_VIEWPORTS: f32 = 1.0;
 
@@ -437,18 +438,52 @@ where
         let end_track = first_after_overscan
             .max(first_after_viewport.saturating_add(DEFAULT_OVERSCAN_ITEMS))
             .min(track_count);
-        let start = self.track_start_item(start_track);
-        let end = self.track_start_item(end_track);
+        self.track_window(start_track, end_track)
+    }
 
+    fn mount_window(
+        &self,
+        geometry: ScrollGeometry,
+        initial_target: Option<&ListScrollTarget<K>>,
+    ) -> LayoutWindow {
+        let geometry = ScrollGeometry {
+            offset: initial_target
+                .and_then(|target| resolve_layout_target(self, target, geometry))
+                .unwrap_or(geometry.offset),
+            ..geometry
+        };
+        if self.measured_sizes.is_empty() && !self.items.is_empty() {
+            let target_item = match initial_target {
+                Some(ListScrollTarget::Index { index, .. }) if *index < self.items.len() => {
+                    Some(*index)
+                }
+                Some(ListScrollTarget::Key { key, .. }) => self.key_to_index.get(key).copied(),
+                Some(ListScrollTarget::End) => self.items.len().checked_sub(1),
+                _ => None,
+            };
+            let target_track = target_item
+                .map(|item| self.track_for_item(item))
+                .unwrap_or_else(|| self.first_track_with_end_after(geometry.offset));
+            let start = target_track.min(
+                self.track_count()
+                    .saturating_sub(INITIAL_MEASUREMENT_TRACKS),
+            );
+            let end = (start + INITIAL_MEASUREMENT_TRACKS).min(self.track_count());
+            return self.track_window(start, end);
+        }
+        self.window(geometry)
+    }
+
+    fn track_window(&self, start_track: usize, end_track: usize) -> LayoutWindow {
         LayoutWindow {
             generation: self.generation,
             source_generation: self.source_generation,
-            start,
-            end,
+            start: self.track_start_item(start_track),
+            end: self.track_start_item(end_track),
             start_track,
             end_track,
             leading_extent: self.track_start(start_track) - self.header_extent,
-            trailing_extent: self.track_start(track_count) - self.track_start(end_track),
+            trailing_extent: self.track_start(self.track_count()) - self.track_start(end_track),
         }
     }
 }
@@ -679,6 +714,7 @@ pub fn virtualize<T, K>(
         let observe_track = Rc::clone(&observe_track);
         let virtual_layout = virtual_layout.clone();
         let configured_scroll_extent = Rc::clone(&configured_scroll_extent);
+        let pending_initial_scroll = Rc::clone(&pending_initial_scroll);
         Rc::new(move || {
             let geometry = *geometry.borrow();
             let window = {
@@ -690,7 +726,8 @@ pub fn virtualize<T, K>(
                     configured_scroll_extent.set(total_extent);
                     set_scroll_extent_size(scroll_extent, total_extent, axis);
                 }
-                let window = layout.window(geometry);
+                let window =
+                    layout.mount_window(geometry, pending_initial_scroll.borrow().as_ref());
                 if rendered_window
                     .get()
                     .is_some_and(|rendered| rendered.identity() == window.identity())
@@ -699,6 +736,8 @@ pub fn virtualize<T, K>(
                 }
                 window
             };
+
+            request_list_layout();
 
             set_spacer_size(leading_spacer, window.leading_extent, axis);
             set_spacer_size(trailing_spacer, window.trailing_extent, axis);
@@ -1741,6 +1780,19 @@ mod tests {
     }
 
     #[test]
+    fn grid_bootstrap_measures_complete_tracks_at_the_initial_target() {
+        let mut index = LayoutIndex::new(3, 8.0);
+        index.replace((0_u32..31).collect(), |item| *item);
+        let window = index.mount_window(
+            ScrollGeometry::default(),
+            Some(&ListScrollTarget::index(7, ScrollAlignment::Start)),
+        );
+        assert_eq!((window.start, window.end), (6, 12));
+        let window = index.mount_window(ScrollGeometry::default(), Some(&ListScrollTarget::End));
+        assert_eq!((window.start, window.end), (27, 31));
+    }
+
+    #[test]
     fn key_index_is_rebuilt_after_source_reordering() {
         let mut index = LayoutIndex::new(1, 0.0);
         index.replace(vec!["alpha", "beta", "gamma"], |item| *item);
@@ -1796,6 +1848,8 @@ mod tests {
 
         assert_eq!(index.estimated_track_size, DEFAULT_ITEM_SIZE);
         assert_eq!(index.total_extent(), 800.0 * DEFAULT_ITEM_SIZE);
+        let bootstrap = index.mount_window(ScrollGeometry::default(), None);
+        assert_eq!((bootstrap.start, bootstrap.end), (0, 2));
         let window = index.window(ScrollGeometry {
             offset: 0.0,
             viewport: 768.0,

--- a/crates/whisker/tests/list_giga_diagnostics.rs
+++ b/crates/whisker/tests/list_giga_diagnostics.rs
@@ -43,6 +43,246 @@ fn frame(surface: &SurfaceRuntime, renderer: &mut RecordingRenderer, epoch: u32)
 }
 
 #[test]
+fn pager_measures_two_pages_before_expanding_its_window() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(98).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let created = Rc::new(RefCell::new(Vec::new()));
+    let list = owner.with(ListHandle::<u32>::new);
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            let created = created.clone();
+            render! {
+                List(
+                    list_ref: list.r(),
+                    axis: ScrollAxis::Horizontal,
+                    style: css!(width: px(390), height: px(600)),
+                    content_style: css!(height: percent(100)),
+                    each: || (0_u32..800).collect::<Vec<_>>(),
+                    key: |page: &u32| *page,
+                    children: move |page: ReadSignal<u32>| {
+                        created.borrow_mut().push(page.get_untracked());
+                        render! { View(style: css!(width: px(390), height: percent(100), flex_shrink: 0.0)) }
+                    },
+                )
+            }
+        });
+        set_root(root);
+    });
+    assert_eq!(
+        *created.borrow(),
+        [0, 1],
+        "unmeasured pages must not fill a 600px viewport using the 44px fallback"
+    );
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    for epoch in 1..=4 {
+        frame(&surface, &mut renderer, epoch);
+    }
+    assert!(
+        created.borrow().len() <= 3,
+        "unexpected speculative pages: {:?}",
+        created.borrow()
+    );
+    let snapshot = list.snapshot().unwrap();
+    assert_eq!(snapshot.viewport_extent, 390.0);
+    assert_eq!(snapshot.visible_keys, [0]);
+    assert_eq!(snapshot.content_extent, 390.0 * 800.0);
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn progressive_rows_fill_the_first_presented_viewport() {
+    for height in [44, 60] {
+        __reset_for_tests();
+        let owner = Owner::new(None);
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(99).unwrap(),
+            StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+        );
+        let measured = Rc::new(RefCell::new(HashMap::new()));
+        with_installed_renderer(surface.renderer(), || {
+            let root = owner.with(|| {
+                let measured = measured.clone();
+                render! {
+                    List(
+                        style: css!(width: px(390), height: px(600)),
+                        each: || (0_u32..800).collect::<Vec<_>>(),
+                        key: |row: &u32| *row,
+                        children: move |row: ReadSignal<u32>| {
+                            let key = row.get_untracked();
+                            let measured = measured.clone();
+                            let node = render! { View(style: css!(height: px(height), flex_shrink: 0.0)) };
+                            observe_layout(node, Box::new(move |layout| {
+                                measured.borrow_mut().insert(key, layout.geometry.border_box);
+                            }));
+                            node
+                        },
+                    )
+                }
+            });
+            set_root(root);
+        });
+        let mut renderer = RecordingRenderer::new(surface.surface());
+        frame(&surface, &mut renderer, 1);
+        let last_visible = (599 / height) as u32;
+        assert!(
+            measured.borrow().contains_key(&last_visible),
+            "first frame only measured {:?}, viewport needs row {last_visible}",
+            measured.borrow().keys()
+        );
+        assert_eq!(renderer.frames().len(), 1);
+        with_installed_renderer(surface.renderer(), || owner.dispose());
+    }
+}
+
+#[test]
+fn pager_bootstrap_measures_the_requested_page_instead_of_unrelated_pages() {
+    for (target, expected, sample) in [
+        (
+            ListScrollTarget::index(400, ScrollAlignment::Start),
+            400,
+            [400, 401],
+        ),
+        (
+            ListScrollTarget::key(400, ScrollAlignment::Start),
+            400,
+            [400, 401],
+        ),
+        (ListScrollTarget::end(), 799, [798, 799]),
+    ] {
+        __reset_for_tests();
+        let owner = Owner::new(None);
+        let surface = SurfaceRuntime::new(
+            SurfaceId::new(100).unwrap(),
+            StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+        );
+        let created = Rc::new(RefCell::new(Vec::new()));
+        let list = owner.with(ListHandle::<u32>::new);
+        with_installed_renderer(surface.renderer(), || {
+            let root = owner.with(|| {
+                let created = created.clone();
+                render! {
+                    List(
+                        list_ref: list.r(),
+                        axis: ScrollAxis::Horizontal,
+                        initial_scroll: target,
+                        style: css!(width: px(390), height: px(600)),
+                        content_style: css!(height: percent(100)),
+                        each: || (0_u32..800).collect::<Vec<_>>(),
+                        key: |page: &u32| *page,
+                        children: move |page: ReadSignal<u32>| {
+                            created.borrow_mut().push(page.get_untracked());
+                            render! { View(style: css!(width: px(390), height: percent(100), flex_shrink: 0.0)) }
+                        },
+                    )
+                }
+            });
+            set_root(root);
+        });
+        assert_eq!(*created.borrow(), sample);
+        let mut renderer = RecordingRenderer::new(surface.surface());
+        for epoch in 1..=4 {
+            frame(&surface, &mut renderer, epoch);
+        }
+        assert_eq!(list.snapshot().unwrap().first_visible_key, Some(expected));
+        assert!(
+            created.borrow().len() <= 5,
+            "unexpected pages for target {expected}: {:?}",
+            created.borrow()
+        );
+        with_installed_renderer(surface.renderer(), || owner.dispose());
+    }
+}
+
+#[test]
+fn replacing_a_loading_row_bootstraps_the_new_page_source() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(101).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let loaded = owner.with(|| signal(false));
+    let created = Rc::new(RefCell::new(Vec::new()));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            let created = created.clone();
+            render! {
+                List(
+                    axis: ScrollAxis::Horizontal,
+                    style: css!(width: px(390), height: px(600)),
+                    content_style: css!(height: percent(100)),
+                    each: move || if loaded.get() { (0_u32..800).collect::<Vec<_>>() } else { vec![999] },
+                    key: |page: &u32| *page,
+                    children: move |page: ReadSignal<u32>| {
+                        let page = page.get_untracked();
+                        created.borrow_mut().push(page);
+                        render! { View(style: css!(width: px(if page == 999 { 640 } else { 390 }), height: percent(100), flex_shrink: 0.0)) }
+                    },
+                )
+            }
+        });
+        set_root(root);
+    });
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    frame(&surface, &mut renderer, 1);
+    created.borrow_mut().clear();
+    with_installed_renderer(surface.renderer(), || {
+        loaded.set(true);
+        whisker::flush();
+    });
+    assert_eq!(*created.borrow(), [0, 1]);
+    frame(&surface, &mut renderer, 2);
+    assert_eq!(*created.borrow(), [0, 1, 2]);
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
+fn list_layout_feedback_yields_after_a_bounded_number_of_passes() {
+    __reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(102).unwrap(),
+        StyleEnvironment::new(390.0, 600.0, 1.0, 14.0),
+    );
+    let passes = Rc::new(std::cell::Cell::new(0));
+    with_installed_renderer(surface.renderer(), || {
+        let root = owner.with(|| {
+            let passes = passes.clone();
+            render! {
+                List(
+                    style: css!(width: px(390), height: px(600)),
+                    each: || vec![0_u32],
+                    key: |row: &u32| *row,
+                    children: move |_: ReadSignal<u32>| {
+                        let passes = passes.clone();
+                        let row = View::builder().style(css!(height: px(60))).build();
+                        observe_layout(row, Box::new(move |layout| {
+                            passes.set(passes.get() + 1);
+                            let height = if layout.geometry.border_box.height == 60.0 { 61 } else { 60 };
+                            whisker::runtime::view::set_specified_style(row, &css!(height: px(height)).to_specified_style());
+                        }));
+                        row
+                    },
+                )
+            }
+        });
+        set_root(root);
+    });
+    let mut renderer = RecordingRenderer::new(surface.surface());
+    frame(&surface, &mut renderer, 1);
+    assert!(passes.get() > 1 && passes.get() <= 4);
+    assert_eq!(renderer.frames().len(), 1);
+    let previous = passes.get();
+    frame(&surface, &mut renderer, 2);
+    assert!(passes.get() > previous && passes.get() - previous <= 4);
+    with_installed_renderer(surface.renderer(), || owner.dispose());
+}
+
+#[test]
 fn giga_row_margin_does_not_move_a_retained_row() {
     for (axis, leading, margin) in [
         (ScrollAxis::Vertical, 0, 0),

--- a/crates/whisker/tests/surface_render_pipeline.rs
+++ b/crates/whisker/tests/surface_render_pipeline.rs
@@ -703,6 +703,7 @@ fn list_scroll_reuses_the_indexed_source_and_only_mutates_window_edges() {
         )
         .unwrap();
     item_clones.set(0);
+    let scroll_frame = renderer.frames().len();
 
     with_installed_renderer(surface.renderer(), || {
         surface
@@ -746,7 +747,7 @@ fn list_scroll_reuses_the_indexed_source_and_only_mutates_window_edges() {
         item_clones.get() <= 5,
         "scrolling plus automatic size feedback should clone only window-edge rows"
     );
-    let structural_operations = renderer.frames()[2]
+    let structural_operations = renderer.frames()[scroll_frame]
         .packet
         .operations
         .iter()


### PR DESCRIPTION
## Summary

Opening a pager currently constructs about 28 page components from the initial 44px item estimate and 600px viewport fallback, starting unnecessary resource work before the actual page size is measured.

Bootstrap List with two items (two complete tracks for grids) around the requested initial position, then expand the window using measured sizes and existing overscan. When List changes its window during layout, allow up to four layout passes before presenting the frame so newly added visible rows receive geometry in the first frame. Replacing the item source also resets the measurement bootstrap.

This change is limited to List initialization and its layout feedback. It does not introduce generic Create/Delete cancellation or change native hosts or application-facing List APIs.

## Validation

- Pager regression: component creation drops from 28 to 3 for a 390px page/viewport.
- Coverage includes initial index/key/end, grid tracks, source replacement, first-frame viewport coverage, and bounded layout feedback.
- 288 tests passed across whisker-runtime, list_giga_diagnostics, and surface_render_pipeline.
- Rust 1.88 CI Clippy configuration, formatting, and diff checks passed.
- Android device frame times have not been measured; the regressions use the headless render pipeline.
