### PR TITLE
fix(layout): reuse pending intrinsic sizes within each layout pass

### DIFF
--- a/crates/whisker-layout/src/backend.rs
+++ b/crates/whisker-layout/src/backend.rs
@@ -16,6 +16,9 @@ use taffy::{
 };
 
 mod paragraph;
+mod pending_sizes;
+
+use pending_sizes::{PendingSize, PendingSizes};
 
 const SIZE_CACHE_CAPACITY: usize = 32;
 
@@ -116,6 +119,7 @@ impl LayoutState {
                 tree,
                 state: self,
                 measure,
+                pending_sizes: PendingSizes::default(),
             },
             root,
             available,
@@ -151,6 +155,7 @@ struct LayoutPass<'a, Context, Measure> {
     tree: &'a mut TaffyTree<Context>,
     state: &'a mut LayoutState,
     measure: Measure,
+    pending_sizes: PendingSizes,
 }
 
 impl<Context: Clone, Measure> LayoutPass<'_, Context, Measure>
@@ -171,6 +176,11 @@ where
         if input.run_mode == RunMode::PerformHiddenLayout {
             return compute_hidden_layout(self, node);
         }
+        if let Some(cached) = self.pending_sizes.get(node, &input) {
+            self.state.blocked += u64::from(cached.blocked);
+            self.state.provisional += u64::from(cached.provisional);
+            return cached.output;
+        }
         let before = (self.state.blocked, self.state.provisional);
         let output = compute_cached_layout(self, node, input, |tree, node, input| {
             let display = tree.tree.style(node).expect("retained style").display;
@@ -189,6 +199,15 @@ where
         if before != (self.state.blocked, self.state.provisional) {
             self.cache_clear(node);
             self.state.transient.insert(node);
+            self.pending_sizes.insert(
+                node,
+                input,
+                PendingSize {
+                    output,
+                    blocked: self.state.blocked != before.0,
+                    provisional: self.state.provisional != before.1,
+                },
+            );
         }
         output
     }
@@ -384,6 +403,7 @@ mod tests {
         let mut pass = LayoutPass {
             tree: &mut tree,
             state: &mut state,
+            pending_sizes: PendingSizes::default(),
             measure: |known: Size<Option<f32>>, _, _: Option<&()>, _: &[MeasuredInlineChild]| {
                 calls.set(calls.get() + 1);
                 LayoutSize::new(known.width.unwrap_or(40.0), 20.0).into()
@@ -557,3 +577,6 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+mod pending_tests;

--- a/crates/whisker-layout/src/backend/pending_sizes.rs
+++ b/crates/whisker-layout/src/backend/pending_sizes.rs
@@ -1,0 +1,35 @@
+use super::{LayoutInput, LayoutOutput, NodeId, RunMode, SIZE_CACHE_CAPACITY};
+use std::collections::{HashMap, VecDeque};
+
+#[derive(Clone, Copy)]
+pub(super) struct PendingSize {
+    pub output: LayoutOutput,
+    pub blocked: bool,
+    pub provisional: bool,
+}
+
+#[derive(Default)]
+pub(super) struct PendingSizes {
+    nodes: HashMap<NodeId, VecDeque<(LayoutInput, PendingSize)>>,
+}
+
+impl PendingSizes {
+    pub fn get(&self, node: NodeId, input: &LayoutInput) -> Option<PendingSize> {
+        self.nodes
+            .get(&node)?
+            .iter()
+            .find_map(|(key, value)| (key == input).then_some(*value))
+    }
+
+    pub fn insert(&mut self, node: NodeId, input: LayoutInput, value: PendingSize) {
+        // PerformLayout also updates descendant geometry and cannot reuse size alone.
+        if input.run_mode != RunMode::ComputeSize {
+            return;
+        }
+        let sizes = self.nodes.entry(node).or_default();
+        if sizes.len() == SIZE_CACHE_CAPACITY {
+            sizes.pop_front();
+        }
+        sizes.push_back((input, value));
+    }
+}

--- a/crates/whisker-layout/src/backend/pending_tests.rs
+++ b/crates/whisker-layout/src/backend/pending_tests.rs
@@ -1,0 +1,169 @@
+use super::*;
+use std::cell::Cell;
+use taffy::{AvailableSpace, FlexDirection};
+
+#[test]
+fn pending_measurements_do_not_expand_with_nested_flex_depth() {
+    for measurement_state in [MeasurementState::Blocked, MeasurementState::Provisional] {
+        let mut tree = TaffyTree::new();
+        let leaf = tree.new_leaf_with_context(Style::default(), ()).unwrap();
+        let mut root = leaf;
+        for depth in 0..8 {
+            root = tree
+                .new_with_children(
+                    Style {
+                        flex_direction: if depth % 2 == 0 {
+                            FlexDirection::Row
+                        } else {
+                            FlexDirection::Column
+                        },
+                        ..Style::default()
+                    },
+                    &[root],
+                )
+                .unwrap();
+        }
+        let available = Size {
+            width: AvailableSpace::Definite(600.0),
+            height: AvailableSpace::Definite(800.0),
+        };
+        let mut state = LayoutState::default();
+        let calls = Cell::new(0);
+        state.compute_detailed(&mut tree, root, available, |_, _, _, _| {
+            calls.set(calls.get() + 1);
+            IntrinsicResult {
+                size: LayoutSize::new(40.0, 20.0),
+                state: measurement_state,
+                ..IntrinsicResult::default()
+            }
+        });
+        assert!(
+            calls.get() < 100,
+            "{measurement_state:?}: {} measurements",
+            calls.get()
+        );
+        assert!(tree.dirty(root).unwrap());
+
+        let ready_calls = Cell::new(0);
+        state.compute_detailed(&mut tree, root, available, |_, _, _, _| {
+            ready_calls.set(ready_calls.get() + 1);
+            LayoutSize::new(90.0, 45.0).into()
+        });
+        assert!(ready_calls.get() > 0);
+        assert_eq!(
+            state.layout(leaf).size,
+            Size {
+                width: 90.0,
+                height: 45.0
+            }
+        );
+        state.compute_detailed(&mut tree, root, available, |_, _, _, _| {
+            panic!("ready geometry must remain reusable")
+        });
+    }
+}
+
+fn size_input(width: f32) -> LayoutInput {
+    LayoutInput {
+        run_mode: RunMode::ComputeSize,
+        sizing_mode: taffy::SizingMode::InherentSize,
+        axis: taffy::RequestedAxis::Both,
+        known_dimensions: Size {
+            width: Some(width),
+            height: None,
+        },
+        parent_size: Size::NONE,
+        available_space: Size {
+            width: AvailableSpace::MaxContent,
+            height: AvailableSpace::MaxContent,
+        },
+        vertical_margins_are_collapsible: taffy::Line::FALSE,
+    }
+}
+
+#[test]
+fn cached_pending_sizes_preserve_dependency_flags_and_input_constraints() {
+    for measurement_state in [MeasurementState::Blocked, MeasurementState::Provisional] {
+        let mut tree = TaffyTree::new();
+        let leaf = tree.new_leaf_with_context(Style::default(), ()).unwrap();
+        let mut state = LayoutState::default();
+        let calls = Cell::new(0);
+        let mut pass = LayoutPass {
+            tree: &mut tree,
+            state: &mut state,
+            pending_sizes: PendingSizes::default(),
+            measure: |known: Size<Option<f32>>, _, _: Option<&()>, _: &[MeasuredInlineChild]| {
+                calls.set(calls.get() + 1);
+                IntrinsicResult {
+                    size: LayoutSize::new(known.width.unwrap(), known.width.unwrap() / 2.0),
+                    state: measurement_state,
+                    ..IntrinsicResult::default()
+                }
+            },
+        };
+        for iteration in 0..3 {
+            for width in 1..=12 {
+                let before = (pass.state.blocked, pass.state.provisional);
+                let output = pass.compute(leaf, size_input(width as f32), None);
+                assert_eq!(output.size.height, width as f32 / 2.0);
+                assert_eq!(
+                    pass.state.blocked > before.0,
+                    measurement_state == MeasurementState::Blocked
+                );
+                assert_eq!(
+                    pass.state.provisional > before.1,
+                    measurement_state == MeasurementState::Provisional
+                );
+            }
+            assert_eq!(
+                calls.get(),
+                12,
+                "iteration {iteration} must reuse all widths"
+            );
+        }
+        for width in 13..=SIZE_CACHE_CAPACITY + 1 {
+            pass.compute(leaf, size_input(width as f32), None);
+        }
+        let before = calls.get();
+        let output = pass.compute(leaf, size_input(1.0), None);
+        assert_eq!(calls.get(), before + 1, "old widths must be evicted");
+        assert_eq!(output.size.height, 0.5);
+
+        let mut other_constraints = size_input(1.0);
+        other_constraints.parent_size.width = Some(500.0);
+        let before = calls.get();
+        pass.compute(leaf, other_constraints, None);
+        assert_eq!(
+            calls.get(),
+            before + 1,
+            "parent constraints belong to the cache key"
+        );
+    }
+}
+
+#[test]
+fn pending_layout_execution_is_not_replaced_by_a_size_cache_hit() {
+    let mut tree = TaffyTree::new();
+    let leaf = tree.new_leaf_with_context(Style::default(), ()).unwrap();
+    let mut state = LayoutState::default();
+    let calls = Cell::new(0);
+    let mut pass = LayoutPass {
+        tree: &mut tree,
+        state: &mut state,
+        pending_sizes: PendingSizes::default(),
+        measure: |_: Size<Option<f32>>, _, _: Option<&()>, _: &[MeasuredInlineChild]| {
+            calls.set(calls.get() + 1);
+            IntrinsicResult {
+                size: LayoutSize::new(40.0, 20.0),
+                state: MeasurementState::Provisional,
+                ..IntrinsicResult::default()
+            }
+        },
+    };
+    pass.compute(leaf, size_input(40.0), None);
+    let mut input = size_input(40.0);
+    input.run_mode = RunMode::PerformLayout;
+    pass.compute(leaf, input, None);
+    pass.compute(leaf, input, None);
+    assert_eq!(calls.get(), 3);
+}


### PR DESCRIPTION
Nested Flex layout repeatedly recalculates intrinsic sizes while waiting for Host measurements. Clearing unsettled results from the persistent cache also discards useful work within the current layout pass, causing long frames when mounting UI such as the Chat sidebar.

Cache pending `ComputeSize` results within each `LayoutPass`, bounded to 32 entries per node and keyed by the full layout input. Cache hits propagate blocked/provisional dependency flags so ancestors remain invalidated. The cache is discarded after the pass, and `PerformLayout` continues to execute to update descendant geometry.

The nested Flex regression previously made 9,841 measurement calls; it now stays below 100. Tests also cover readiness changes between passes, dependency propagation, constraints, eviction, and actual layout execution. This change is limited to the layout crate and adds no public or Host APIs.

Validation:
- Layout, Engine, and Runtime tests: 355 passed.
- Layout Clippy with warnings denied: passed.
- Workspace formatting and diff checks: passed.
- Web sidebar opening, closing, and reopening verified. Browser timings varied, so no fixed frame-time improvement is claimed.
- Combined Layout/Engine Clippy is blocked by an existing `collapsible_if` warning in unchanged `crates/whisker-engine/src/measurement.rs:735`.
