### PR TITLE
fix(cli): serve web apps without opening a browser

### DIFF
--- a/.github/scripts/install-ubuntu-packages.sh
+++ b/.github/scripts/install-ubuntu-packages.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sources=(
+  -o Dir::Etc::sourcelist=/etc/apt/sources.list.d/ubuntu.sources
+  -o Dir::Etc::sourceparts=-
+)
+sudo apt-get "${sources[@]}" update
+sudo apt-get "${sources[@]}" install -y "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux text and GPU dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
       - run: cargo test --workspace --all-targets
         env:
           RUST_TEST_THREADS: 1
@@ -60,7 +60,7 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux text dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev
       # These two style-only lints create repository-wide churn when Clippy changes its
       # preferred spelling. Correctness and all other warnings remain denied.
       - run: >-
@@ -77,7 +77,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux text dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev
       - name: Build workspace library documentation
         run: cargo doc --workspace --no-deps --lib
         env:
@@ -151,7 +151,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux text dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev
       # `+version` takes precedence over the repository's stable toolchain file.
       - run: cargo +1.88.0 check --workspace --all-targets
 
@@ -175,7 +175,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install Linux text and GPU dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
       - run: cargo xtask host-conformance desktop
         env:
           WGPU_BACKEND: vulkan
@@ -255,7 +255,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install Linux text and GPU dependencies
-        run: sudo apt-get update && sudo apt-get install -y libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev libvulkan1 mesa-vulkan-drivers
 
       - name: Generate coverage
         # `--doctests` is nightly-only; stable runs doctest-free coverage.

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -14,7 +14,6 @@
 
 use anyhow::{Context, Result};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::process::Command;
 
 use crate::{AndroidParams, IosParams, MacosParams, Target};
@@ -56,7 +55,6 @@ pub struct Installer {
     /// `adb shell setprop debug.whisker_dev_token`. `None` = token-less.
     dev_token: Option<String>,
     macos_child: tokio::sync::Mutex<Option<tokio::process::Child>>,
-    web_opened: AtomicBool,
 }
 
 impl Installer {
@@ -85,7 +83,6 @@ impl Installer {
             dev_port,
             dev_token,
             macos_child: tokio::sync::Mutex::new(None),
-            web_opened: AtomicBool::new(false),
         }
     }
 
@@ -149,11 +146,8 @@ impl Installer {
                 Ok(())
             }
             Target::Web => {
-                if self.web_opened.swap(true, Ordering::AcqRel) {
-                    Ok(())
-                } else {
-                    open_browser(self.dev_port).await
-                }
+                whisker_build::ui::info(format!("Local: http://127.0.0.1:{}/", self.dev_port));
+                Ok(())
             }
         }
     }
@@ -175,34 +169,9 @@ impl Installer {
                 ios_launch(params, self.dev_port, self.dev_token.as_deref()).await
             }
             Target::Macos => self.install_and_launch().await,
-            Target::Web => open_browser(self.dev_port).await,
+            Target::Web => Ok(()),
         }
     }
-}
-
-async fn open_browser(port: u16) -> Result<()> {
-    let url = format!("http://127.0.0.1:{port}/");
-    let open_step = whisker_build::ui::step(whisker_build::ui::OperationKind::Open, url.clone());
-    let mut command = if cfg!(target_os = "macos") {
-        let mut command = Command::new("open");
-        command.arg(&url);
-        command
-    } else if cfg!(target_os = "windows") {
-        let mut command = Command::new("cmd");
-        command.args(["/C", "start", "", &url]);
-        command
-    } else {
-        let mut command = Command::new("xdg-open");
-        command.arg(&url);
-        command
-    };
-    let status = command.status().await.context("open Web Host in browser")?;
-    if !status.success() {
-        open_step.fail(status.to_string());
-        anyhow::bail!("browser launcher exited with {status}");
-    }
-    open_step.done("");
-    Ok(())
 }
 
 /// Run a `tokio::process::Command` to completion, capture its stderr,

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -675,7 +675,12 @@ impl DevServer {
                 Input::Command(DevCommand::Relaunch) => {
                     emit(&self.on_event, Event::HostLaunching);
                     match installer.relaunch().await {
-                        Ok(()) => emit(&self.on_event, Event::HostLaunched),
+                        Ok(()) => {
+                            if self.config.target == Target::Web {
+                                sender.reload_browser();
+                            }
+                            emit(&self.on_event, Event::HostLaunched);
+                        }
                         Err(error) => {
                             let message = format!("{error:#}");
                             whisker_build::ui::error(format!("relaunch failed: {message}"));


### PR DESCRIPTION
`whisker run web` now prints the local URL after a successful build and lets the user open it. Remove automatic browser launching and its one-time launch state.

The relaunch shortcut reloads connected Web clients instead of opening another browser tab. Native launch behavior is unchanged.

Validation: `cargo check -p whisker-dev-server --locked`, `cargo fmt --all -- --check`, and `git diff --check` passed.

CI also failed before Rust compilation because the runner's unrelated Chrome APT repository returned `Hash Sum mismatch` on both attempts. Linux build dependency installation now uses a shared script restricted to Ubuntu's package sources. Bash and workflow YAML syntax checks passed; the updated workflow is being verified in Actions.
