### PR TITLE
feat(input): add auto sizing through generic module measurement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6924,6 +6924,7 @@ name = "whisker-input"
 version = "0.13.8"
 dependencies = [
  "serde",
+ "serde_json",
  "whisker",
 ]
 
@@ -6933,6 +6934,8 @@ version = "0.13.8"
 dependencies = [
  "csscolorparser",
  "glyphon",
+ "serde",
+ "serde_json",
  "unicode-segmentation",
  "whisker-desktop",
  "whisker-protocol",
@@ -6950,6 +6953,8 @@ dependencies = [
 name = "whisker-input-web"
 version = "0.13.8"
 dependencies = [
+ "serde",
+ "serde_json",
  "wasm-bindgen-test",
  "web-sys",
  "whisker-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6924,7 +6924,6 @@ name = "whisker-input"
 version = "0.13.8"
 dependencies = [
  "serde",
- "serde_json",
  "whisker",
 ]
 
@@ -6935,7 +6934,6 @@ dependencies = [
  "csscolorparser",
  "glyphon",
  "serde",
- "serde_json",
  "unicode-segmentation",
  "whisker-desktop",
  "whisker-protocol",
@@ -6954,7 +6952,6 @@ name = "whisker-input-web"
 version = "0.13.8"
 dependencies = [
  "serde",
- "serde_json",
  "wasm-bindgen-test",
  "web-sys",
  "whisker-protocol",

--- a/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
+++ b/crates/whisker-driver-sys/bridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 31
+#define WHISKER_MOBILE_ABI_MINOR 32
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -433,7 +433,7 @@ typedef struct WhiskerMobileMeasureRequest {
   float indent_logical_pixels;
   float indent_percentage;
   uint32_t max_lines;
-  struct WhiskerBytesRef payload;
+  const struct WhiskerValueRaw *payload;
   float intrinsic_width;
   float intrinsic_height;
   uint32_t intrinsic_mask;
@@ -852,7 +852,7 @@ WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerKeyValueRaw) == 40, "WhiskerKeyValueRaw 
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileHostCapabilities) == 24, "WhiskerMobileHostCapabilities ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
-WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 232, "WhiskerMobileMeasureRequest ABI drift");
+WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 224, "WhiskerMobileMeasureRequest ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureResponse) == 96, "WhiskerMobileMeasureResponse ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileText) == 256, "WhiskerMobileText ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");

--- a/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
+++ b/crates/whisker-driver-sys/bridge/src/whisker_mobile_android.c
@@ -713,7 +713,6 @@ static bool present_frame(void* data, const WhiskerMobileFrame* frame, WhiskerMo
 static bool valid_measure_request(const WhiskerMobileMeasureRequest* r) {
     return r->text.len <= INT32_MAX && (r->text.ptr == NULL) == (r->text.len == 0) &&
         r->locale.len <= INT32_MAX && (r->locale.ptr == NULL) == (r->locale.len == 0) &&
-        r->payload.len <= INT32_MAX && (r->payload.ptr == NULL) == (r->payload.len == 0) &&
         r->font_family_count <= 4096 &&
         (r->font_families == NULL) == (r->font_family_count == 0) &&
         (r->kind != WHISKER_MEASURE_TEXT || r->font_family_count != 0) &&
@@ -745,17 +744,16 @@ static bool measure_host(void* data, const WhiskerMobileMeasureRequest* requests
     jfloatArray request_floats = (*env)->NewFloatArray(env, (jsize)(count * MEASURE_REQUEST_FLOAT_STRIDE));
     jclass string_class = (*env)->FindClass(env, "java/lang/String");
     jclass string_array_class = (*env)->FindClass(env, "[Ljava/lang/String;");
-    jclass byte_array_class = (*env)->FindClass(env, "[B");
-    jclass paragraph_class = (*env)->FindClass(env, "rs/whisker/runtime/WhiskerValue");
-    jobjectArray paragraphs = paragraph_class == NULL ? NULL : (*env)->NewObjectArray(env, (jsize)count, paragraph_class, NULL);
+    jclass value_class = (*env)->FindClass(env, "rs/whisker/runtime/WhiskerValue");
+    jobjectArray paragraphs = value_class == NULL ? NULL : (*env)->NewObjectArray(env, (jsize)count, value_class, NULL);
     jobjectArray request_strings = string_class == NULL ? NULL : (*env)->NewObjectArray(
         env, (jsize)(count * MEASURE_REQUEST_STRING_STRIDE), string_class, NULL);
     jobjectArray family_batches = string_array_class == NULL ? NULL : (*env)->NewObjectArray(
         env, (jsize)count, string_array_class, NULL);
     jobjectArray setting_batches = string_array_class == NULL ? NULL : (*env)->NewObjectArray(
         env, (jsize)count, string_array_class, NULL);
-    jobjectArray payload_batches = byte_array_class == NULL ? NULL : (*env)->NewObjectArray(
-        env, (jsize)count, byte_array_class, NULL);
+    jobjectArray payload_batches = value_class == NULL ? NULL : (*env)->NewObjectArray(
+        env, (jsize)count, value_class, NULL);
     jlong* longs = calloc(count * MEASURE_REQUEST_LONG_STRIDE + 1, sizeof(jlong));
     jint* ints = calloc(count * MEASURE_REQUEST_INT_STRIDE + 1, sizeof(jint));
     jfloat* values = calloc(count * MEASURE_REQUEST_FLOAT_STRIDE + 1, sizeof(jfloat));
@@ -807,12 +805,9 @@ static bool measure_host(void* data, const WhiskerMobileMeasureRequest* requests
         jobjectArray families = string_refs(env, r->font_families, r->font_family_count);
         jobjectArray settings = font_settings(env, r->font_features, r->font_feature_count,
                                                r->font_variations, r->font_variation_count);
-        jbyteArray payload = (*env)->NewByteArray(env, (jsize)r->payload.len);
-        ok = text != NULL && locale != NULL && families != NULL && settings != NULL && payload != NULL;
-        if (ok && r->payload.len > 0) {
-            (*env)->SetByteArrayRegion(env, payload, 0, (jsize)r->payload.len,
-                                      (const jbyte*)r->payload.ptr);
-        }
+        jobject payload = r->payload ? raw_to_value(env, r->payload) : NULL;
+        ok = text != NULL && locale != NULL && families != NULL && settings != NULL &&
+            (r->payload == NULL || payload != NULL);
         if (ok) {
             (*env)->SetObjectArrayElement(env, request_strings,
                 (jsize)(i * MEASURE_REQUEST_STRING_STRIDE), text);
@@ -930,11 +925,10 @@ static bool measure_host(void* data, const WhiskerMobileMeasureRequest* requests
     if (result) (*env)->DeleteLocalRef(env, result);
     if (payload_batches) (*env)->DeleteLocalRef(env, payload_batches);
     if (paragraphs) (*env)->DeleteLocalRef(env, paragraphs);
-    if (paragraph_class) (*env)->DeleteLocalRef(env, paragraph_class);
+    if (value_class) (*env)->DeleteLocalRef(env, value_class);
     if (setting_batches) (*env)->DeleteLocalRef(env, setting_batches);
     if (family_batches) (*env)->DeleteLocalRef(env, family_batches);
     if (request_strings) (*env)->DeleteLocalRef(env, request_strings);
-    if (byte_array_class) (*env)->DeleteLocalRef(env, byte_array_class);
     if (string_array_class) (*env)->DeleteLocalRef(env, string_array_class);
     if (string_class) (*env)->DeleteLocalRef(env, string_class);
     if (request_floats) (*env)->DeleteLocalRef(env, request_floats);
@@ -1099,7 +1093,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     METHOD(g_finish_bootstrap,"finishBootstrapFromNative","()Z")
     METHOD(g_present_frame,"presentFrameFromNative","(IIJJ[J[[F[Ljava/lang/String;[[Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;[J)Z")
     METHOD(g_current_revision,"currentRevisionFromNative","()J")
-    METHOD(g_measure_batch,"measureBatchFromNative","([J[I[F[Ljava/lang/String;[[Ljava/lang/String;[[Ljava/lang/String;[[B[Lrs/whisker/runtime/WhiskerValue;)Lrs/whisker/runtime/measure/HostMeasureBatchResponse;")
+    METHOD(g_measure_batch,"measureBatchFromNative","([J[I[F[Ljava/lang/String;[[Ljava/lang/String;[[Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;[Lrs/whisker/runtime/WhiskerValue;)Lrs/whisker/runtime/measure/HostMeasureBatchResponse;")
     METHOD(g_resource_command,"resourceCommandFromNative","(IIIJJLjava/lang/String;[B)Z")
     METHOD(g_invoke_module,"invokeModuleFromNative","(Ljava/lang/String;Ljava/lang/String;[Lrs/whisker/runtime/WhiskerValue;ZJJ)Z")
     METHOD(g_observe_module,"observeModuleFromNative","(Ljava/lang/String;Ljava/lang/String;Z)V")

--- a/crates/whisker-driver-sys/src/mobile.rs
+++ b/crates/whisker-driver-sys/src/mobile.rs
@@ -8,7 +8,7 @@ use std::ffi::c_void;
 use crate::{WhiskerBytesRef, WhiskerStringRef, WhiskerValueRaw};
 
 pub const MOBILE_ABI_MAJOR: u16 = 2;
-pub const MOBILE_ABI_MINOR: u16 = 31;
+pub const MOBILE_ABI_MINOR: u16 = 32;
 pub const FRAME_PROTOCOL_MAJOR: u16 = 1;
 pub const FRAME_PROTOCOL_MINOR: u16 = 5;
 
@@ -504,7 +504,7 @@ pub struct MobileMeasureRequest {
     pub indent_logical_pixels: f32,
     pub indent_percentage: f32,
     pub max_lines: u32,
-    pub payload: WhiskerBytesRef,
+    pub payload: *const WhiskerValueRaw,
     pub intrinsic_width: f32,
     pub intrinsic_height: f32,
     pub intrinsic_mask: u32,
@@ -677,7 +677,7 @@ mod tests {
             assert_eq!(std::mem::size_of::<MobileMemberRegistration>(), 24);
             assert_eq!(std::mem::size_of::<MobileElementRegistration>(), 72);
             assert_eq!(std::mem::size_of::<MobileBootstrap>(), 24);
-            assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 232);
+            assert_eq!(std::mem::size_of::<MobileMeasureRequest>(), 224);
             assert_eq!(std::mem::size_of::<MobileMeasureResponse>(), 96);
             assert_eq!(std::mem::size_of::<MobileText>(), 256);
             assert_eq!(std::mem::size_of::<MobileBoxPaint>(), 272);

--- a/crates/whisker-driver/src/ffi_runtime/measurement.rs
+++ b/crates/whisker-driver/src/ffi_runtime/measurement.rs
@@ -142,7 +142,10 @@ impl MeasurementProvider for MobileMeasurementHost {
 pub(super) struct MobileMeasureBatch {
     _paragraphs: super::paragraph::MobileParagraphs,
     _strings: Vec<Box<[u8]>>,
-    _bytes: Vec<Vec<u8>>,
+    _payload_arena: RawValueArena,
+    // FFI pointers must survive subsequent pushes.
+    #[allow(clippy::vec_box)]
+    _payloads: Vec<Box<WhiskerValueRaw>>,
     _font_families: Vec<Box<[WhiskerStringRef]>>,
     _font_features: Vec<Box<[MobileFontFeature]>>,
     _font_variations: Vec<Box<[MobileFontVariation]>>,
@@ -173,7 +176,8 @@ impl MobileMeasureBatch {
     pub(super) fn new(source: &[MeasurementRequest]) -> Self {
         let mut strings = Vec::new();
         let mut paragraphs = super::paragraph::MobileParagraphs::default();
-        let mut bytes = Vec::new();
+        let mut payload_arena = RawValueArena::default();
+        let mut payloads = Vec::new();
         let mut font_families = Vec::new();
         let mut font_features = Vec::new();
         let mut font_variations = Vec::new();
@@ -217,10 +221,7 @@ impl MobileMeasureBatch {
                 indent_logical_pixels: 0.0,
                 indent_percentage: 0.0,
                 max_lines: 0,
-                payload: WhiskerBytesRef {
-                    ptr: std::ptr::null(),
-                    len: 0,
-                },
+                payload: std::ptr::null(),
                 intrinsic_width: 0.0,
                 intrinsic_height: 0.0,
                 intrinsic_mask: 0,
@@ -312,7 +313,11 @@ impl MobileMeasureBatch {
                 MeasurementPayload::NativeControl(value) => {
                     raw.kind = MEASURE_NATIVE_CONTROL;
                     raw.payload_version = value.version;
-                    raw.payload = push_bytes(&mut bytes, &value.state);
+                    raw.payload = push_value(
+                        &mut payload_arena,
+                        &mut payloads,
+                        &WhiskerValue::Bytes(value.state.clone()),
+                    );
                 }
                 MeasurementPayload::EmbeddedSurface(value) => {
                     raw.kind = MEASURE_EMBEDDED_SURFACE;
@@ -325,7 +330,7 @@ impl MobileMeasureBatch {
                 MeasurementPayload::Custom(value) => {
                     raw.kind = MEASURE_CUSTOM;
                     raw.payload_version = value.version;
-                    raw.payload = push_bytes(&mut bytes, &value.data);
+                    raw.payload = push_value(&mut payload_arena, &mut payloads, &value.data);
                 }
             }
             responses.push(MobileMeasureResponse {
@@ -338,7 +343,8 @@ impl MobileMeasureBatch {
         Self {
             _strings: strings,
             _paragraphs: paragraphs,
-            _bytes: bytes,
+            _payload_arena: payload_arena,
+            _payloads: payloads,
             _font_families: font_families,
             _font_features: font_features,
             _font_variations: font_variations,
@@ -348,14 +354,17 @@ impl MobileMeasureBatch {
     }
 }
 
-fn push_bytes(storage: &mut Vec<Vec<u8>>, value: &[u8]) -> WhiskerBytesRef {
-    let value = value.to_vec();
-    let result = WhiskerBytesRef {
-        ptr: value.as_ptr(),
-        len: value.len(),
-    };
-    storage.push(value);
-    result
+#[allow(clippy::vec_box)]
+fn push_value(
+    arena: &mut RawValueArena,
+    storage: &mut Vec<Box<WhiskerValueRaw>>,
+    value: &WhiskerValue,
+) -> *const WhiskerValueRaw {
+    storage.push(Box::new(arena.encode(value)));
+    storage
+        .last()
+        .expect("retained measurement payload")
+        .as_ref()
 }
 
 pub(super) fn mobile_font_features(

--- a/crates/whisker-driver/src/ffi_runtime/tests.rs
+++ b/crates/whisker-driver/src/ffi_runtime/tests.rs
@@ -1057,3 +1057,65 @@ fn paragraph_geometry_is_released_on_rejected_and_malformed_measurement_batches(
         assert_eq!(released.get(), 2);
     }
 }
+
+#[test]
+fn mobile_measure_batch_retains_structured_payloads_and_native_bytes() {
+    use whisker_engine::whisker_protocol::{
+        CustomMeasurePayload, ElementTypeId, MeasureConstraints, MeasurementKey,
+        NativeControlMeasurePayload,
+    };
+    let value = WhiskerValue::map([
+        ("text", WhiskerValue::String("こんにちは".into())),
+        (
+            "metrics",
+            WhiskerValue::Array(vec![
+                WhiskerValue::Float(24.5),
+                WhiskerValue::Bool(true),
+                WhiskerValue::Null,
+            ]),
+        ),
+        ("opaque", WhiskerValue::Bytes(vec![0, 255])),
+    ]);
+    let request = |index, payload| MeasurementRequest {
+        key: MeasurementKey::new(index).unwrap(),
+        node: NodeId::new(index).unwrap(),
+        element_type: ElementTypeId::new(9).unwrap(),
+        environment_epoch: 1,
+        constraints: MeasureConstraints {
+            known_dimensions: [None, None],
+            available_space: [AvailableSpace::MaxContent; 2],
+        },
+        payload,
+    };
+    let mut requests: Vec<_> = (1..65)
+        .map(|index| {
+            request(
+                index,
+                MeasurementPayload::Custom(CustomMeasurePayload {
+                    version: 3,
+                    data: value.clone(),
+                }),
+            )
+        })
+        .collect();
+    requests.push(request(
+        65,
+        MeasurementPayload::NativeControl(NativeControlMeasurePayload {
+            control_type: 1,
+            version: 2,
+            state: vec![1, 2, 3],
+        }),
+    ));
+    let batch = MobileMeasureBatch::new(&requests);
+    drop(requests);
+    for raw in &batch.requests[..64] {
+        assert_eq!(raw.payload_version, 3);
+        // SAFETY: the batch owns each value tree until it is dropped.
+        assert_eq!(unsafe { decode_value(raw.payload) }, value);
+    }
+    // SAFETY: the batch owns the native-control value until it is dropped.
+    assert_eq!(
+        unsafe { decode_value(batch.requests[64].payload) },
+        WhiskerValue::Bytes(vec![1, 2, 3])
+    );
+}

--- a/crates/whisker-engine/src/measurement.rs
+++ b/crates/whisker-engine/src/measurement.rs
@@ -1046,7 +1046,7 @@ mod tests {
             MeasurementKind::Custom { version } => {
                 MeasurementPayload::Custom(CustomMeasurePayload {
                     version,
-                    data: b"payload".to_vec(),
+                    data: whisker_protocol::WhiskerValue::Bytes(b"payload".to_vec()),
                 })
             }
         }

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -67,6 +67,11 @@ impl SceneNode {
         }
     }
 
+    /// Returns the current explicitly set element properties.
+    pub fn properties(&self) -> &BTreeMap<PropertyId, WhiskerValue> {
+        &self.properties
+    }
+
     /// Returns the registered element type.
     pub const fn element_type(&self) -> ElementTypeId {
         self.element_type

--- a/crates/whisker-engine/src/scene.rs
+++ b/crates/whisker-engine/src/scene.rs
@@ -1707,9 +1707,20 @@ mod tests {
         scene
             .set_property(root, property, WhiskerValue::Bool(true))
             .expect("set property");
+        assert_eq!(
+            scene.node(root).unwrap().properties().get(&property),
+            Some(&WhiskerValue::Bool(true))
+        );
         scene
             .clear_property(root, property)
             .expect("clear property");
+        assert!(
+            !scene
+                .node(root)
+                .unwrap()
+                .properties()
+                .contains_key(&property)
+        );
         scene
             .set_pointer_capture(root, pointer)
             .expect("capture pointer");

--- a/crates/whisker-engine/src/surface.rs
+++ b/crates/whisker-engine/src/surface.rs
@@ -1574,7 +1574,7 @@ mod tests {
             MeasurementKind::Custom { version } => {
                 MeasurementPayload::Custom(CustomMeasurePayload {
                     version,
-                    data: Vec::new(),
+                    data: whisker_protocol::WhiskerValue::Bytes(Vec::new()),
                 })
             }
         }

--- a/crates/whisker-macros/src/lib.rs
+++ b/crates/whisker-macros/src/lib.rs
@@ -541,6 +541,12 @@ pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// `ElementRef::command(name, parameters)`. Commands must be declared
 /// in the macro's `commands = [("name", ValueKind)]` schema.
 ///
+/// Leaf elements can declare `measurement = Custom(path::to_payload)`;
+/// the function accepts `ModuleMeasureContext<'_>` and returns
+/// `Option<CustomMeasurePayload>`, with `None` disabling intrinsic measurement.
+/// The macro registers it automatically, and Runtime refreshes its payload
+/// from current props and resolved text style before layout.
+///
 /// Call-site shape mirrors built-in tags + user components:
 ///
 /// ```ignore

--- a/crates/whisker-macros/src/module_element.rs
+++ b/crates/whisker-macros/src/module_element.rs
@@ -976,6 +976,7 @@ const RESERVED_EVENT_NAMES: &[&str] = &[
 /// always excluded from the element schema, while the declared children type
 /// determines its child policy.
 const COMMON_ELEMENT_PROP_NAMES: &[&str] = &[
+    "measure_with",
     "id",
     "dataset",
     "accessibility",

--- a/crates/whisker-macros/src/module_element.rs
+++ b/crates/whisker-macros/src/module_element.rs
@@ -103,6 +103,7 @@ enum ModuleElementArgs {
     Schema {
         name: LitStr,
         measurement: Ident,
+        measurement_payload: Option<syn::Path>,
         text_style: bool,
         commands: Vec<(LitStr, Ident)>,
     },
@@ -111,6 +112,7 @@ enum ModuleElementArgs {
 struct SchemaArgs {
     name: LitStr,
     measurement: Ident,
+    measurement_payload: Option<syn::Path>,
     text_style: bool,
     commands: Vec<(LitStr, Ident)>,
 }
@@ -126,6 +128,7 @@ impl Parse for SchemaArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let mut name = None;
         let mut measurement = None;
+        let mut measurement_payload = None;
         let mut text_style = None;
         let mut commands = None;
 
@@ -157,7 +160,23 @@ impl Parse for SchemaArgs {
                             "duplicate `measurement` argument",
                         ));
                     }
-                    measurement = Some(input.parse()?);
+                    let kind: Ident = input.parse()?;
+                    if input.peek(syn::token::Paren) {
+                        if kind != "Custom" {
+                            return Err(syn::Error::new(
+                                kind.span(),
+                                "only `Custom` accepts a measurement payload function",
+                            ));
+                        }
+                        let content;
+                        syn::parenthesized!(content in input);
+                        measurement_payload = Some(content.parse::<syn::Path>()?);
+                        if !content.is_empty() {
+                            return Err(content
+                                .error("expected a single measurement payload function path"));
+                        }
+                    }
+                    measurement = Some(kind);
                 }
                 "text_style" => {
                     if text_style.is_some() {
@@ -212,6 +231,7 @@ impl Parse for SchemaArgs {
             name: name.ok_or_else(|| syn::Error::new(input.span(), "missing `name` argument"))?,
             measurement: measurement
                 .ok_or_else(|| syn::Error::new(input.span(), "missing `measurement` argument"))?,
+            measurement_payload,
             text_style: text_style.unwrap_or(false),
             commands: commands.unwrap_or_default(),
         })
@@ -226,6 +246,7 @@ fn parse_args(attr: TokenStream2) -> syn::Result<ModuleElementArgs> {
     Ok(ModuleElementArgs::Schema {
         name: args.name,
         measurement: args.measurement,
+        measurement_payload: args.measurement_payload,
         text_style: args.text_style,
         commands: args.commands,
     })
@@ -488,9 +509,26 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
         ModuleElementArgs::Schema {
             name,
             measurement,
+            measurement_payload,
             text_style,
             commands,
         } => {
+            if let Some(path) = measurement_payload
+                && props
+                    .iter()
+                    .any(|prop| matches!(prop.kind, PropKind::Children | PropKind::TextChildren))
+            {
+                return syn::Error::new(
+                    path.span(),
+                    "measurement payload functions require a leaf module element without children",
+                )
+                .to_compile_error();
+            }
+            let registration = measurement_payload.as_ref().map(|path| {
+                quote! {
+                    ::whisker::runtime::view::renderer::set_measurement_builder(__element, #path);
+                }
+            });
             let definition = SchemaDefinition {
                 name,
                 measurement,
@@ -503,9 +541,13 @@ pub fn expand(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
             };
             (
                 quote! {
-                    ::whisker::runtime::view::create_element_by_schema(
-                        &#schema_mod::schema()
-                    )
+                    {
+                        let __element = ::whisker::runtime::view::create_element_by_schema(
+                            &#schema_mod::schema()
+                        );
+                        #registration
+                        __element
+                    }
                 },
                 schema,
             )
@@ -629,9 +671,15 @@ pub fn expand_builtin(attr: TokenStream2, item: TokenStream2) -> TokenStream2 {
         Ok(ModuleElementArgs::Schema {
             name,
             measurement,
+            measurement_payload,
             text_style,
             commands,
-        }) => (name, measurement, text_style, commands),
+        }) => {
+            if let Some(path) = measurement_payload {
+                return syn::Error::new(path.span(), "measurement payload functions are supported by `module_element`, not `builtin_element`").to_compile_error();
+            }
+            (name, measurement, text_style, commands)
+        }
         Ok(ModuleElementArgs::Legacy(name)) => {
             return syn::Error::new(
                 name.span(),
@@ -976,7 +1024,6 @@ const RESERVED_EVENT_NAMES: &[&str] = &[
 /// always excluded from the element schema, while the declared children type
 /// determines its child policy.
 const COMMON_ELEMENT_PROP_NAMES: &[&str] = &[
-    "measure_with",
     "id",
     "dataset",
     "accessibility",
@@ -1365,6 +1412,57 @@ fn to_pascal_case(snake: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn measurement_payload_declarations_reject_non_custom_kinds() {
+        for kind in ["None", "Text", "ReplacedContent"] {
+            let args: TokenStream2 =
+                format!("name = \"test:Control\", measurement = {kind}(payload)")
+                    .parse()
+                    .unwrap();
+            let error = parse_args(args).err().expect("invalid measurement kind");
+            assert!(error.to_string().contains("only `Custom`"));
+        }
+    }
+
+    #[test]
+    fn measurement_payload_declarations_require_one_function_path() {
+        for arguments in ["", "one, two", "|context| context"] {
+            let args: TokenStream2 =
+                format!("name = \"test:Control\", measurement = Custom({arguments})")
+                    .parse()
+                    .unwrap();
+            assert!(parse_args(args).is_err());
+        }
+    }
+
+    #[test]
+    fn measurement_payload_declarations_require_leaf_module_elements() {
+        for children in [quote!(Children), quote!(TextChildren)] {
+            let output = expand(
+                quote!(
+                    name = "test:Control",
+                    measurement = Custom(measurement::payload)
+                ),
+                quote!(pub fn control(children: #children) {}),
+            )
+            .to_string();
+            assert!(output.contains("compile_error"));
+            assert!(output.contains("leaf module element"));
+        }
+        let output = expand_builtin(
+            quote!(
+                name = "test:Control",
+                measurement = Custom(measurement::payload)
+            ),
+            quote!(
+                pub fn control() {}
+            ),
+        )
+        .to_string();
+        assert!(output.contains("compile_error"));
+        assert!(output.contains("not `builtin_element`"));
+    }
 
     #[test]
     fn common_builder_props_cannot_enter_a_component_schema() {

--- a/crates/whisker-protocol/src/measurement.rs
+++ b/crates/whisker-protocol/src/measurement.rs
@@ -297,8 +297,8 @@ pub struct EmbeddedSurfaceMeasurePayload {
 pub struct CustomMeasurePayload {
     /// Module payload schema version.
     pub version: u16,
-    /// Opaque bytes interpreted only by the negotiated module schema.
-    pub data: Vec<u8>,
+    /// Structured data interpreted only by the negotiated module schema.
+    pub data: WhiskerValue,
 }
 
 /// Typed provider input carried across the Rust-to-Host boundary.
@@ -578,7 +578,7 @@ pub struct ModuleMeasureRequest {
     pub known_dimensions: [Option<f32>; 2],
     /// Remaining width and height availability, including min/max-content.
     pub available_space: [AvailableSpace; 2],
-    /// Version of module-owned payload bytes, or zero when no payload exists.
+    /// Version of module-owned payload data, or zero when no payload exists.
     pub payload_version: u16,
     /// Module-owned application data affecting intrinsic size.
     pub payload: WhiskerValue,
@@ -590,9 +590,7 @@ impl From<&MeasurementRequest> for ModuleMeasureRequest {
             MeasurementPayload::NativeControl(payload) => {
                 (payload.version, WhiskerValue::Bytes(payload.state.clone()))
             }
-            MeasurementPayload::Custom(payload) => {
-                (payload.version, WhiskerValue::Bytes(payload.data.clone()))
-            }
+            MeasurementPayload::Custom(payload) => (payload.version, payload.data.clone()),
             MeasurementPayload::Text(_)
             | MeasurementPayload::ReplacedContent(_)
             | MeasurementPayload::EmbeddedSurface(_) => (0, WhiskerValue::Null),
@@ -948,7 +946,10 @@ mod tests {
         request.constraints.known_dimensions = [Some(40.0), None];
         request.payload = MeasurementPayload::Custom(CustomMeasurePayload {
             version: 3,
-            data: vec![1, 2, 3],
+            data: WhiskerValue::map([
+                ("text", WhiskerValue::String("hello".into())),
+                ("width", WhiskerValue::Float(40.0)),
+            ]),
         });
         let module = ModuleMeasureRequest::from(&request);
         assert_eq!(module.known_dimensions, [Some(40.0), None]);
@@ -957,7 +958,13 @@ mod tests {
             [AvailableSpace::MaxContent, AvailableSpace::MinContent]
         );
         assert_eq!(module.payload_version, 3);
-        assert_eq!(module.payload, WhiskerValue::Bytes(vec![1, 2, 3]));
+        assert_eq!(
+            module.payload,
+            WhiskerValue::map([
+                ("text", WhiskerValue::String("hello".into())),
+                ("width", WhiskerValue::Float(40.0))
+            ])
+        );
 
         request.payload = MeasurementPayload::NativeControl(NativeControlMeasurePayload {
             control_type: 2,
@@ -1283,7 +1290,7 @@ mod tests {
 
         let custom_data = CustomMeasurePayload {
             version: 3,
-            data: vec![1, 2],
+            data: WhiskerValue::Bytes(vec![1, 2]),
         };
         let cloned = <CustomMeasurePayload as Clone>::clone(std::hint::black_box(&custom_data));
         assert_eq!(std::hint::black_box(cloned), custom_data);
@@ -1294,7 +1301,7 @@ mod tests {
         assert_eq!(
             MeasurementPayload::Custom(CustomMeasurePayload {
                 version: 0,
-                data: Vec::new(),
+                data: WhiskerValue::Bytes(Vec::new()),
             })
             .validate(),
             Err(MeasurementPayloadError::InvalidPayloadVersion)

--- a/crates/whisker-protocol/src/paragraph_contract_tests.rs
+++ b/crates/whisker-protocol/src/paragraph_contract_tests.rs
@@ -155,7 +155,7 @@ fn paragraph_metrics_reject_unmatched_duplicate_and_nonfinite_placements() {
     assert!(!metrics.matches_payload(&payload));
     let custom = MeasurementPayload::Custom(CustomMeasurePayload {
         version: 1,
-        data: vec![],
+        data: WhiskerValue::Bytes(vec![]),
     });
     assert!(!metrics.matches_payload(&custom));
     metrics.paragraph = None;

--- a/crates/whisker-runtime/src/lib.rs
+++ b/crates/whisker-runtime/src/lib.rs
@@ -23,6 +23,7 @@ pub mod event;
 #[doc(hidden)]
 pub mod lifetime;
 pub mod module;
+pub mod module_measurement;
 pub mod reactive;
 mod runtime_context;
 mod runtime_instance;

--- a/crates/whisker-runtime/src/module_measurement.rs
+++ b/crates/whisker-runtime/src/module_measurement.rs
@@ -7,7 +7,7 @@ pub use whisker_protocol::{
 use whisker_protocol::{ElementRegistration, PropertyId, TextStyleSnapshot, WhiskerValue};
 
 /// Current inputs available when a module builds its Host measurement payload.
-/// The Runtime calls the builder before layout, after reactive property updates.
+/// The Runtime calls the declared payload function before layout, after reactive property updates.
 pub struct ModuleMeasureContext<'a> {
     pub(crate) registration: &'a ElementRegistration,
     pub(crate) properties: &'a BTreeMap<PropertyId, WhiskerValue>,

--- a/crates/whisker-runtime/src/module_measurement.rs
+++ b/crates/whisker-runtime/src/module_measurement.rs
@@ -34,6 +34,6 @@ impl ModuleMeasureContext<'_> {
 }
 
 /// Builds versioned Host inputs without accessing Signals or mounted native views.
-/// Include every size-affecting input in the payload; the Runtime hashes its bytes.
+/// Include every size-affecting input in the payload; the Runtime hashes its value tree.
 /// Returning `None` disables intrinsic measurement for the element.
 pub type MeasurementPayloadBuilder = fn(ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload>;

--- a/crates/whisker-runtime/src/module_measurement.rs
+++ b/crates/whisker-runtime/src/module_measurement.rs
@@ -1,0 +1,39 @@
+//! Property-driven intrinsic measurement for module elements.
+
+use std::collections::BTreeMap;
+pub use whisker_protocol::{
+    CustomMeasurePayload, MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+};
+use whisker_protocol::{ElementRegistration, PropertyId, TextStyleSnapshot, WhiskerValue};
+
+/// Current inputs available when a module builds its Host measurement payload.
+/// The Runtime calls the builder before layout, after reactive property updates.
+pub struct ModuleMeasureContext<'a> {
+    pub(crate) registration: &'a ElementRegistration,
+    pub(crate) properties: &'a BTreeMap<PropertyId, WhiskerValue>,
+    pub(crate) scale_factor: f32,
+    pub(crate) text_style: Option<&'a TextStyleSnapshot>,
+}
+
+impl ModuleMeasureContext<'_> {
+    /// Physical pixels per logical layout unit for this surface.
+    pub fn scale_factor(&self) -> f32 {
+        self.scale_factor
+    }
+
+    /// Returns a currently set property by its declared Host name.
+    pub fn property(&self, name: &str) -> Option<&WhiskerValue> {
+        let property = self.registration.property_named(name)?;
+        self.properties.get(&property.property)
+    }
+
+    /// Resolved inherited text style, when the element declares `text_style = true`.
+    pub fn text_style(&self) -> Option<&TextStyleSnapshot> {
+        self.text_style
+    }
+}
+
+/// Builds versioned Host inputs without accessing Signals or mounted native views.
+/// Include every size-affecting input in the payload; the Runtime hashes its bytes.
+/// Returning `None` disables intrinsic measurement for the element.
+pub type MeasurementPayloadBuilder = fn(ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload>;

--- a/crates/whisker-runtime/src/surface_runtime.rs
+++ b/crates/whisker-runtime/src/surface_runtime.rs
@@ -39,11 +39,18 @@ use whisker_engine::{
     lower_color, lower_paint, lower_transform,
 };
 
+mod module_measurement;
+
 const MAX_LIST_LAYOUT_PASSES: usize = 4;
 
 /// A mutation emitted by `render!` that could not enter the retained surface.
 #[derive(Clone, Debug, PartialEq)]
 pub enum RuntimeBindingError {
+    /// A payload builder requires a leaf element with Custom measurement.
+    InvalidMeasurementBinding {
+        /// Element with an incompatible schema.
+        element: Element,
+    },
     /// Logical text content could not be lowered into a valid paragraph.
     InvalidParagraph {
         /// Element whose content failed validation.
@@ -405,6 +412,7 @@ impl SurfaceRuntime {
                 elements: HashMap::new(),
                 node_elements: HashMap::new(),
                 text_layout_observed: HashSet::new(),
+                module_measurements: HashMap::new(),
                 #[cfg(debug_assertions)]
                 text_style_diagnostics: RefCell::new(HashSet::new()),
                 presented_paragraphs: HashMap::new(),
@@ -795,6 +803,9 @@ impl SurfaceRuntime {
             state
                 .flush_background_projections()
                 .map_err(RuntimeLayoutError::Binding)?;
+            state
+                .flush_module_measurements()
+                .map_err(RuntimeLayoutError::Binding)?;
             let root = state.root.ok_or(RuntimeLayoutError::MissingRoot)?;
             let layout = state
                 .surface
@@ -1095,6 +1106,7 @@ struct BindingState {
     node_elements: HashMap<NodeId, Element>,
     text_queries: Rc<RefCell<crate::text_query::Queries>>,
     text_layout_observed: HashSet<Element>,
+    module_measurements: HashMap<Element, module_measurement::Binding>,
     #[cfg(debug_assertions)]
     text_style_diagnostics: RefCell<
         HashSet<(

--- a/crates/whisker-runtime/src/surface_runtime/module_measurement.rs
+++ b/crates/whisker-runtime/src/surface_runtime/module_measurement.rs
@@ -1,0 +1,86 @@
+use super::*;
+use crate::module_measurement::{MeasurementPayloadBuilder, ModuleMeasureContext};
+use std::hash::{DefaultHasher, Hash, Hasher};
+use whisker_protocol::{
+    MeasurementPayload, MeasurementSpec, PendingMeasurePolicy, PropertyId, TextStyleSnapshot,
+};
+
+#[derive(PartialEq)]
+struct Inputs {
+    scale_factor: f32,
+    properties: BTreeMap<PropertyId, WhiskerValue>,
+    text_style: Option<TextStyleSnapshot>,
+}
+
+pub(super) struct Binding {
+    builder: MeasurementPayloadBuilder,
+    previous: Option<Inputs>,
+}
+
+impl BindingState {
+    pub(super) fn bind_measurement(
+        &mut self,
+        element: Element,
+        builder: MeasurementPayloadBuilder,
+    ) -> Result<(), RuntimeBindingError> {
+        let entry = self.element(element)?;
+        if !entry.kind.registration().is_some_and(|registration| {
+            registration.measurement == whisker_protocol::ElementMeasurement::Custom
+                && registration.child_policy == whisker_protocol::ChildPolicy::None
+        }) {
+            return Err(RuntimeBindingError::InvalidMeasurementBinding { element });
+        }
+        self.module_measurements.insert(
+            element,
+            Binding {
+                builder,
+                previous: None,
+            },
+        );
+        Ok(())
+    }
+
+    pub(super) fn flush_module_measurements(&mut self) -> Result<(), RuntimeBindingError> {
+        for (element, binding) in &mut self.module_measurements {
+            let Some(entry) = self.elements.get(element) else {
+                continue;
+            };
+            let Some(node) = entry.node else { continue };
+            let Some(scene) = self.surface.node(node) else {
+                continue;
+            };
+            if binding.previous.as_ref().is_some_and(|previous| {
+                previous.scale_factor == self.environment.scale_factor()
+                    && &previous.properties == scene.properties()
+                    && previous.text_style.as_ref() == scene.text_style()
+            }) {
+                continue;
+            }
+            let inputs = Inputs {
+                scale_factor: self.environment.scale_factor(),
+                properties: scene.properties().clone(),
+                text_style: scene.text_style().cloned(),
+            };
+            let payload = (binding.builder)(ModuleMeasureContext {
+                scale_factor: inputs.scale_factor,
+                registration: entry.kind.registration().expect("registered measurement"),
+                properties: &inputs.properties,
+                text_style: inputs.text_style.as_ref(),
+            });
+            let spec = payload.map(|payload| {
+                let mut hash = DefaultHasher::new();
+                payload.version.hash(&mut hash);
+                payload.data.hash(&mut hash);
+                MeasurementSpec {
+                    content_hash: hash.finish(),
+                    style_hash: 0,
+                    payload: MeasurementPayload::Custom(payload),
+                    pending_policy: PendingMeasurePolicy::Block,
+                }
+            });
+            self.surface.set_measurement(node, spec)?;
+            binding.previous = Some(inputs);
+        }
+        Ok(())
+    }
+}

--- a/crates/whisker-runtime/src/surface_runtime/module_measurement.rs
+++ b/crates/whisker-runtime/src/surface_runtime/module_measurement.rs
@@ -70,7 +70,7 @@ impl BindingState {
             let spec = payload.map(|payload| {
                 let mut hash = DefaultHasher::new();
                 payload.version.hash(&mut hash);
-                payload.data.hash(&mut hash);
+                hash_value(&payload.data, &mut hash);
                 MeasurementSpec {
                     content_hash: hash.finish(),
                     style_hash: 0,
@@ -82,5 +82,84 @@ impl BindingState {
             binding.previous = Some(inputs);
         }
         Ok(())
+    }
+}
+
+fn hash_value(value: &WhiskerValue, hash: &mut impl Hasher) {
+    std::mem::discriminant(value).hash(hash);
+    match value {
+        WhiskerValue::Null => {}
+        WhiskerValue::Bool(value) => value.hash(hash),
+        WhiskerValue::Int(value) => value.hash(hash),
+        WhiskerValue::Float(value) => {
+            (if *value == 0.0 { 0.0_f64 } else { *value })
+                .to_bits()
+                .hash(hash);
+        }
+        WhiskerValue::String(value) | WhiskerValue::Error(value) => value.hash(hash),
+        WhiskerValue::Bytes(value) => value.hash(hash),
+        WhiskerValue::Array(values) => {
+            values.len().hash(hash);
+            for value in values {
+                hash_value(value, hash);
+            }
+        }
+        WhiskerValue::Map(values) => {
+            values.len().hash(hash);
+            for (key, value) in values {
+                key.hash(hash);
+                hash_value(value, hash);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(value: &WhiskerValue) -> u64 {
+        let mut state = DefaultHasher::new();
+        hash_value(value, &mut state);
+        state.finish()
+    }
+
+    #[test]
+    fn measurement_hash_preserves_value_types_structure_and_float_equality() {
+        let variants = [
+            WhiskerValue::Null,
+            WhiskerValue::Bool(false),
+            WhiskerValue::Int(0),
+            WhiskerValue::Float(0.0),
+            WhiskerValue::String("0".into()),
+            WhiskerValue::Bytes(vec![0]),
+            WhiskerValue::Array(vec![WhiskerValue::Int(0)]),
+            WhiskerValue::map([("n", WhiskerValue::Int(0))]),
+            WhiskerValue::Error("0".into()),
+        ];
+        let hashes: std::collections::HashSet<_> = variants.iter().map(hash).collect();
+        assert_eq!(hashes.len(), variants.len());
+        assert_eq!(
+            hash(&WhiskerValue::Float(0.0)),
+            hash(&WhiskerValue::Float(-0.0))
+        );
+        let nested = |value| {
+            WhiskerValue::map([(
+                "values",
+                WhiskerValue::Array(vec![WhiskerValue::Float(value)]),
+            )])
+        };
+        assert_ne!(hash(&nested(1.0)), hash(&nested(2.0)));
+        assert_eq!(hash(&nested(1.0)), hash(&nested(1.0).clone()));
+        assert_ne!(
+            hash(&WhiskerValue::Array(vec![
+                WhiskerValue::Int(1),
+                WhiskerValue::Int(2)
+            ])),
+            hash(&WhiskerValue::Array(vec![
+                WhiskerValue::Int(2),
+                WhiskerValue::Int(1)
+            ]))
+        );
     }
 }

--- a/crates/whisker-runtime/src/surface_runtime/renderer.rs
+++ b/crates/whisker-runtime/src/surface_runtime/renderer.rs
@@ -46,10 +46,21 @@ impl DynRenderer for SurfaceRuntime {
         }
     }
 
+    fn set_measurement_builder(
+        &self,
+        handle: Element,
+        builder: crate::module_measurement::MeasurementPayloadBuilder,
+    ) {
+        let mut state = self.state.borrow_mut();
+        let result = state.bind_measurement(handle, builder);
+        state.record(result);
+    }
+
     fn release_element(&self, handle: Element) {
         let mut state = self.state.borrow_mut();
         let result = (|| {
             state.text_layout_observed.remove(&handle);
+            state.module_measurements.remove(&handle);
             #[cfg(debug_assertions)]
             state
                 .text_style_diagnostics

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -1088,7 +1088,8 @@ pub fn mark_inline_truncation(handle: Element) {
     with_renderer(|renderer| renderer.mark_inline_truncation(handle), ());
 }
 
-/// Registers a stateless measurement payload builder for a module element.
+/// Registers the payload function declared by `module_element`.
+#[doc(hidden)]
 pub fn set_measurement_builder(
     handle: Element,
     builder: crate::module_measurement::MeasurementPayloadBuilder,

--- a/crates/whisker-runtime/src/view/renderer.rs
+++ b/crates/whisker-runtime/src/view/renderer.rs
@@ -117,6 +117,13 @@ pub trait DynRenderer {
     fn create_element_by_schema(&self, schema: &ElementSchema) -> Element {
         self.create_element_by_name(&schema.name)
     }
+    /// Registers a property-to-payload projection for a Custom leaf element.
+    fn set_measurement_builder(
+        &self,
+        _handle: Element,
+        _builder: crate::module_measurement::MeasurementPayloadBuilder,
+    ) {
+    }
     fn release_element(&self, handle: Element);
 
     fn set_attribute(&self, handle: Element, key: &str, value: &str);
@@ -1079,4 +1086,17 @@ pub fn flush() {
 #[doc(hidden)]
 pub fn mark_inline_truncation(handle: Element) {
     with_renderer(|renderer| renderer.mark_inline_truncation(handle), ());
+}
+
+/// Registers a stateless measurement payload builder for a module element.
+pub fn set_measurement_builder(
+    handle: Element,
+    builder: crate::module_measurement::MeasurementPayloadBuilder,
+) {
+    if !is_phantom(handle) {
+        with_renderer(
+            |renderer| renderer.set_measurement_builder(handle, builder),
+            (),
+        );
+    }
 }

--- a/crates/whisker/src/builtins/mod.rs
+++ b/crates/whisker/src/builtins/mod.rs
@@ -53,14 +53,6 @@ pub trait ElementBuilder: Sized {
         self
     }
 
-    /// Builds Host measurement inputs from the current props and resolved text style.
-    /// Requires a leaf `module_element` with `measurement = Custom`. The builder
-    /// must be pure; returning `None` disables intrinsic measurement.
-    fn measure_with(self, builder: crate::MeasurementPayloadBuilder) -> Self {
-        crate::runtime::view::renderer::set_measurement_builder(self.__element(), builder);
-        self
-    }
-
     // ---- Common semantics (shared by all elements) ------------------
 
     /// Stable identifier surfaced through event target metadata.

--- a/crates/whisker/src/builtins/mod.rs
+++ b/crates/whisker/src/builtins/mod.rs
@@ -53,6 +53,14 @@ pub trait ElementBuilder: Sized {
         self
     }
 
+    /// Builds Host measurement inputs from the current props and resolved text style.
+    /// Requires a leaf `module_element` with `measurement = Custom`. The builder
+    /// must be pure; returning `None` disables intrinsic measurement.
+    fn measure_with(self, builder: crate::MeasurementPayloadBuilder) -> Self {
+        crate::runtime::view::renderer::set_measurement_builder(self.__element(), builder);
+        self
+    }
+
     // ---- Common semantics (shared by all elements) ------------------
 
     /// Stable identifier surfaced through event target metadata.

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -106,6 +106,9 @@ pub use whisker_engine::whisker_protocol::LayoutRect as TextRect;
 pub use whisker_runtime::text_query::TextQueryError;
 
 pub use whisker_runtime::module::PlatformModule;
+pub use whisker_runtime::module_measurement::{
+    CustomMeasurePayload, MeasurementPayloadBuilder, ModuleMeasureContext,
+};
 
 pub use attrs::ScrollSnap;
 pub use whisker_runtime::event::Dataset;

--- a/crates/whisker/src/lib.rs
+++ b/crates/whisker/src/lib.rs
@@ -106,9 +106,7 @@ pub use whisker_engine::whisker_protocol::LayoutRect as TextRect;
 pub use whisker_runtime::text_query::TextQueryError;
 
 pub use whisker_runtime::module::PlatformModule;
-pub use whisker_runtime::module_measurement::{
-    CustomMeasurePayload, MeasurementPayloadBuilder, ModuleMeasureContext,
-};
+pub use whisker_runtime::module_measurement::{CustomMeasurePayload, ModuleMeasureContext};
 
 pub use attrs::ScrollSnap;
 pub use whisker_runtime::event::Dataset;

--- a/crates/whisker/tests/module_measurement.rs
+++ b/crates/whisker/tests/module_measurement.rs
@@ -11,7 +11,7 @@ use whisker_engine::whisker_protocol::{
 use whisker_engine::whisker_style::StyleEnvironment;
 use whisker_engine::{LayoutOptions, MeasurementProvider, RecordingRenderer};
 
-#[whisker::module_element(name = "whisker.test/MeasuredControl", measurement = Custom, text_style = true)]
+#[whisker::module_element(name = "whisker.test/MeasuredControl", measurement = Custom(payload), text_style = true)]
 fn measured_control(value: Signal<String>, enabled: Signal<bool>, decoration: Signal<bool>) {}
 
 fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload> {
@@ -91,7 +91,6 @@ fn custom_payload_tracks_props_and_inherited_style_without_host_views() {
                             value: value,
                             enabled: enabled,
                             decoration: decoration,
-                            measure_with: payload,
                             style: Css::new().width(px(150)).max_height(px(60)),
                         )
                     }
@@ -184,19 +183,4 @@ fn custom_payload_tracks_props_and_inherited_style_without_host_views() {
         calls,
         "disposing the reactive owner does not leave borrowed state in the payload builder"
     );
-}
-
-#[test]
-fn payload_builders_reject_elements_without_custom_leaf_measurement() {
-    whisker::runtime::reactive::__reset_for_tests();
-    let surface = SurfaceRuntime::new(
-        SurfaceId::new(1).unwrap(),
-        StyleEnvironment::new(300.0, 600.0, 1.0, 14.0),
-    );
-    with_installed_renderer(surface.renderer(), || {
-        let root = View::builder().measure_with(payload).build();
-        assert!(
-            matches!(surface.binding_error(), Some(whisker::RuntimeBindingError::InvalidMeasurementBinding { element }) if element == root)
-        );
-    });
 }

--- a/crates/whisker/tests/module_measurement.rs
+++ b/crates/whisker/tests/module_measurement.rs
@@ -25,7 +25,7 @@ fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload> {
     let size = context.text_style().unwrap().style.font_size;
     Some(CustomMeasurePayload {
         version: 1,
-        data: format!("{value}:{size}:{}", context.scale_factor()).into_bytes(),
+        data: WhiskerValue::String(format!("{value}:{size}:{}", context.scale_factor())),
     })
 }
 
@@ -45,7 +45,9 @@ impl MeasurementProvider for Host {
             let MeasurementPayload::Custom(payload) = &request.payload else {
                 panic!("custom payload expected")
             };
-            let text = String::from_utf8(payload.data.clone()).unwrap();
+            let WhiskerValue::String(text) = &payload.data else {
+                panic!("string payload expected")
+            };
             let length = text.split(':').next().unwrap().len() as f32;
             let width = request.constraints.known_dimensions[0].unwrap_or(100.0);
             responses.push(MeasurementResponse::Ready {
@@ -159,7 +161,7 @@ fn custom_payload_tracks_props_and_inherited_style_without_host_views() {
     let MeasurementPayload::Custom(last) = &host.requests.last().unwrap().payload else {
         unreachable!()
     };
-    assert!(String::from_utf8_lossy(&last.data).contains(":24:"));
+    assert!(matches!(&last.data, WhiskerValue::String(text) if text.contains(":24:")));
     with_installed_renderer(surface.renderer(), || {
         value.set(String::new());
         whisker::flush();

--- a/crates/whisker/tests/module_measurement.rs
+++ b/crates/whisker/tests/module_measurement.rs
@@ -1,0 +1,202 @@
+use std::convert::Infallible;
+use whisker::prelude::*;
+use whisker::runtime::view::{set_root, with_installed_renderer};
+use whisker::runtime::{ElementRegistry, SurfaceRuntime};
+use whisker::{CustomMeasurePayload, ModuleMeasureContext, Owner};
+use whisker_engine::whisker_layout::LayoutSize;
+use whisker_engine::whisker_protocol::{
+    MeasuredSize, MeasurementMetrics, MeasurementPayload, MeasurementRequest, MeasurementResponse,
+    Operation, SurfaceId, WhiskerValue,
+};
+use whisker_engine::whisker_style::StyleEnvironment;
+use whisker_engine::{LayoutOptions, MeasurementProvider, RecordingRenderer};
+
+#[whisker::module_element(name = "whisker.test/MeasuredControl", measurement = Custom, text_style = true)]
+fn measured_control(value: Signal<String>, enabled: Signal<bool>, decoration: Signal<bool>) {}
+
+fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload> {
+    if context.property("enabled") == Some(&WhiskerValue::Bool(false)) {
+        return None;
+    }
+    let value = match context.property("value") {
+        Some(WhiskerValue::String(value)) => value.as_str(),
+        _ => "",
+    };
+    let size = context.text_style().unwrap().style.font_size;
+    Some(CustomMeasurePayload {
+        version: 1,
+        data: format!("{value}:{size}:{}", context.scale_factor()).into_bytes(),
+    })
+}
+
+#[derive(Default)]
+struct Host {
+    requests: Vec<MeasurementRequest>,
+}
+impl MeasurementProvider for Host {
+    type Error = Infallible;
+    fn measure_batch(
+        &mut self,
+        _: SurfaceId,
+        requests: &[MeasurementRequest],
+        responses: &mut Vec<MeasurementResponse>,
+    ) -> Result<(), Self::Error> {
+        for request in requests {
+            let MeasurementPayload::Custom(payload) = &request.payload else {
+                panic!("custom payload expected")
+            };
+            let text = String::from_utf8(payload.data.clone()).unwrap();
+            let length = text.split(':').next().unwrap().len() as f32;
+            let width = request.constraints.known_dimensions[0].unwrap_or(100.0);
+            responses.push(MeasurementResponse::Ready {
+                key: request.key,
+                environment_epoch: request.environment_epoch,
+                metrics: MeasurementMetrics::from_size(MeasuredSize::new(
+                    width,
+                    20.0 * (length / 5.0).ceil().max(1.0),
+                )),
+            });
+        }
+        self.requests.extend_from_slice(requests);
+        Ok(())
+    }
+}
+
+#[test]
+fn custom_payload_tracks_props_and_inherited_style_without_host_views() {
+    whisker::runtime::reactive::__reset_for_tests();
+    let owner = Owner::new(None);
+    let surface = SurfaceRuntime::with_element_registry(
+        SurfaceId::new(1).unwrap(),
+        StyleEnvironment::new(300.0, 600.0, 1.0, 14.0),
+        ElementRegistry::standard_with_linked_providers().unwrap(),
+    );
+    let (value, font_size, decoration, enabled) =
+        with_installed_renderer(surface.renderer(), || {
+            owner.with(|| {
+                let value = signal("short".to_string());
+                let font_size = signal(16.0_f32);
+                let decoration = signal(false);
+                let enabled = signal(true);
+                let root = render! {
+                    View(
+                        style: computed(move || {
+                            Css::new()
+                                .display_flex()
+                                .flex_direction(FlexDirection::Column)
+                                .font_size(px(font_size.get()))
+                        }),
+                    ) {
+                        MeasuredControl(
+                            value: value,
+                            enabled: enabled,
+                            decoration: decoration,
+                            measure_with: payload,
+                            style: Css::new().width(px(150)).max_height(px(60)),
+                        )
+                    }
+                };
+                set_root(root);
+                (value, font_size, decoration, enabled)
+            })
+        });
+    let mut host = Host::default();
+    let mut sink = RecordingRenderer::new(surface.surface());
+    let frame = |host: &mut Host, sink: &mut RecordingRenderer| {
+        surface
+            .render_frame(
+                LayoutSize::new(300.0, 600.0),
+                1,
+                1,
+                host,
+                sink,
+                LayoutOptions::default(),
+            )
+            .unwrap()
+    };
+    frame(&mut host, &mut sink);
+    assert!(!host.requests.is_empty());
+    assert_eq!(sink.frames().len(), 1);
+    let measured_node = host.requests[0].node;
+    let height = |sink: &RecordingRenderer| {
+        sink.frames()
+            .iter()
+            .rev()
+            .flat_map(|frame| frame.packet.operations.iter().rev())
+            .find_map(|operation| match operation {
+                Operation::SetLayout { node, geometry } if *node == measured_node => {
+                    Some(geometry.border_box.height)
+                }
+                _ => None,
+            })
+            .unwrap()
+    };
+    assert_eq!(height(&sink), 20.0);
+    let calls = host.requests.len();
+    frame(&mut host, &mut sink);
+    assert_eq!(host.requests.len(), calls);
+    with_installed_renderer(surface.renderer(), || {
+        decoration.set(true);
+        whisker::flush();
+    });
+    frame(&mut host, &mut sink);
+    assert_eq!(
+        host.requests.len(),
+        calls,
+        "unchanged payload reuses Host results"
+    );
+    with_installed_renderer(surface.renderer(), || {
+        value.set("a much longer value".into());
+        whisker::flush();
+    });
+    frame(&mut host, &mut sink);
+    assert!(host.requests.len() > calls);
+    assert_eq!(height(&sink), 60.0, "CSS clamps the measured height");
+    with_installed_renderer(surface.renderer(), || {
+        font_size.set(24.0);
+        whisker::flush();
+    });
+    frame(&mut host, &mut sink);
+    let MeasurementPayload::Custom(last) = &host.requests.last().unwrap().payload else {
+        unreachable!()
+    };
+    assert!(String::from_utf8_lossy(&last.data).contains(":24:"));
+    with_installed_renderer(surface.renderer(), || {
+        value.set(String::new());
+        whisker::flush();
+    });
+    frame(&mut host, &mut sink);
+    assert_eq!(height(&sink), 20.0, "deleting text shrinks the layout");
+    let calls = host.requests.len();
+    with_installed_renderer(surface.renderer(), || {
+        enabled.set(false);
+        whisker::flush();
+    });
+    frame(&mut host, &mut sink);
+    assert_eq!(host.requests.len(), calls);
+    with_installed_renderer(surface.renderer(), || {
+        owner.dispose();
+        set_root(render! { View() });
+    });
+    frame(&mut host, &mut sink);
+    assert_eq!(
+        host.requests.len(),
+        calls,
+        "disposing the reactive owner does not leave borrowed state in the payload builder"
+    );
+}
+
+#[test]
+fn payload_builders_reject_elements_without_custom_leaf_measurement() {
+    whisker::runtime::reactive::__reset_for_tests();
+    let surface = SurfaceRuntime::new(
+        SurfaceId::new(1).unwrap(),
+        StyleEnvironment::new(300.0, 600.0, 1.0, 14.0),
+    );
+    with_installed_renderer(surface.renderer(), || {
+        let root = View::builder().measure_with(payload).build();
+        assert!(
+            matches!(surface.binding_error(), Some(whisker::RuntimeBindingError::InvalidMeasurementBinding { element }) if element == root)
+        );
+    });
+}

--- a/examples/chat/src/design/tokens.rs
+++ b/examples/chat/src/design/tokens.rs
@@ -17,6 +17,7 @@ pub mod radius {
 
 pub mod size {
     pub const TOUCH: f32 = 44.0;
+    pub const COMPOSER_INPUT_MAX: f32 = 212.0;
     pub const SIDEBAR: f32 = 272.0;
     pub const READING: f32 = 760.0;
     pub const LABEL: f32 = 14.0;

--- a/examples/chat/src/ui/chat.rs
+++ b/examples/chat/src/ui/chat.rs
@@ -40,6 +40,7 @@ pub fn chat_screen() -> Element {
 fn conversation_view(session: Session, sidebar: SidebarState) -> Element {
     let app = use_context::<AppState>().expect("AppState context");
     let actions = use_chat(session);
+    let input_height = signal(theme::size::TOUCH);
     let nav = use_navigator();
     let notice = app.notice();
     let connection = app.connection();
@@ -58,7 +59,7 @@ fn conversation_view(session: Session, sidebar: SidebarState) -> Element {
     render! {
         View(style: theme::fill().position(PositionKind::Relative)) {
             Show(when: move || session.turns.with(Vec::is_empty)) {
-                Welcome(draft: session.draft)
+                Welcome(draft: session.draft, input_height: input_height)
             }
             Show(when: move || !session.turns.with(Vec::is_empty)) {
                 List(
@@ -69,7 +70,15 @@ fn conversation_view(session: Session, sidebar: SidebarState) -> Element {
                     },
                     list_ref: list_ref.clone(),
                     header: || chat_layout::spacer(chat_layout::CONTENT_TOP),
-                    footer: || chat_layout::spacer(chat_layout::CONTENT_BOTTOM),
+                    footer: move || render! {
+                        View(
+                            style: computed(move || {
+                                theme::column()
+                                    .height(px(chat_layout::content_bottom(input_height.get())))
+                                    .flex_shrink(0.0)
+                            }),
+                        )
+                    },
                     on_scroll: move |event| scroll.changed.run(event),
                     style: theme::fill(),
                 )
@@ -120,13 +129,13 @@ fn conversation_view(session: Session, sidebar: SidebarState) -> Element {
             }
             Show(when: move || !scroll.at_end.get() && !session.turns.with(Vec::is_empty)) {
                 View(
-                    style: chat_layout::latest(),
+                    style: computed(move || chat_layout::latest(input_height.get())),
                 ) {
                     Button(label: "Latest", icon: lucide::ArrowDown, on_press: actions.latest)
                 }
             }
             View(style: chat_layout::composer()) {
-                Composer(session: session, actions: actions)
+                Composer(session: session, actions: actions, input_height: input_height)
             }
         }
     }

--- a/examples/chat/src/ui/chat_layout.rs
+++ b/examples/chat/src/ui/chat_layout.rs
@@ -3,9 +3,7 @@ use whisker::css::{AlignSelf, PositionKind};
 use whisker::prelude::*;
 
 pub const HEADER_HEIGHT: f32 = 64.0;
-pub const COMPOSER_HEIGHT: f32 = 160.0;
 pub const CONTENT_TOP: f32 = HEADER_HEIGHT + space::XL;
-pub const CONTENT_BOTTOM: f32 = COMPOSER_HEIGHT + space::LG;
 
 pub fn header() -> Css {
     theme::row()
@@ -25,15 +23,18 @@ pub fn composer() -> Css {
         .left(px(0))
         .right(px(0))
         .bottom(px(0))
-        .height(px(COMPOSER_HEIGHT))
         .align_items(AlignItems::Center)
         .z_index(2)
 }
 
-pub fn latest() -> Css {
+pub fn content_bottom(input_height: f32) -> f32 {
+    input_height + 2.0 * space::SM + 2.0 + 2.0 * space::LG
+}
+
+pub fn latest(input_height: f32) -> Css {
     theme::row()
         .position(PositionKind::Absolute)
-        .bottom(px(CONTENT_BOTTOM))
+        .bottom(px(content_bottom(input_height)))
         .align_self(AlignSelf::Center)
         .z_index(3)
 }

--- a/examples/chat/src/ui/composer.rs
+++ b/examples/chat/src/ui/composer.rs
@@ -1,6 +1,5 @@
 use super::{
-    button::Button,
-    chat_layout,
+    composer_action::ComposerAction,
     theme::{self, radius, size, space},
 };
 use crate::{
@@ -12,7 +11,7 @@ use whisker::prelude::*;
 use whisker_input::{AutoCapitalize, Input};
 
 #[component]
-pub fn composer(session: Session, actions: ChatActions) -> Element {
+pub fn composer(session: Session, actions: ChatActions, input_height: RwSignal<f32>) -> Element {
     let app = use_context::<AppState>().expect("AppState context");
     let busy = app.busy();
     render! {
@@ -24,15 +23,16 @@ pub fn composer(session: Session, actions: ChatActions) -> Element {
                 .padding_left(px(space::LG))
                 .padding_right(px(space::LG))
                 .padding_bottom(px(space::LG))
-                .height(px(chat_layout::COMPOSER_HEIGHT))
-                .gap(px(space::SM))
                 .flex_shrink(0.0),
         ) {
             View(
                 style: theme::style(move |palette| {
                     palette
                         .card()
-                        .padding(px(space::MD))
+                        .flex_direction(FlexDirection::Row)
+                        .align_items(AlignItems::FlexEnd)
+                        .padding(px(space::SM))
+                        .padding_left(px(space::LG))
                         .gap(px(space::SM))
                         .border_radius(px(radius::CARD))
                 }),
@@ -40,42 +40,35 @@ pub fn composer(session: Session, actions: ChatActions) -> Element {
                 Input(
                     text: session.draft,
                     multiline: true,
-                    lines: 3u32,
+                    auto_size: true,
                     auto_capitalize: AutoCapitalize::Sentences,
                     placeholder: "Message Whisker Chat…",
+                    on_size_change: move |rect: whisker_input::InputSize| {
+                        if (input_height.get_untracked() - rect.height).abs() > 0.5 {
+                            input_height.set(rect.height);
+                        }
+                    },
+                    style: theme::style(move |palette| {
+                        palette
+                            .text(size::BODY)
+                            .line_height(px(24))
+                            .min_height(px(size::TOUCH))
+                            .max_height(px(size::COMPOSER_INPUT_MAX))
+                            .padding_top(px(10))
+                            .padding_bottom(px(10))
+                            .flex_grow(1.0)
+                            .flex_basis(px(0))
+                            .min_width(px(0))
+                            .background_color(Color::hex(palette.paper))
+                    }),
                     on_blur: actions.save,
                     on_submit: move |_: String| {
                         if !busy.get_untracked() {
                             actions.send.call();
                         }
                     },
-                    style: theme::style(move |palette| {
-                        palette
-                            .text(size::BODY)
-                            .height(px(64))
-                            .flex_shrink(0.0)
-                            .background_color(Color::hex(palette.paper))
-                    }),
                 )
-                View(
-                    style: theme::row()
-                        .justify_content(JustifyContent::SpaceBetween)
-                        .gap(px(space::SM)),
-                ) {
-                    View(style: theme::fill())
-                    Button(
-                        label: computed(move || {
-                            if busy.get() {
-                                "Stop generation".into()
-                            } else {
-                                "Send ↑".into()
-                            }
-                        }),
-                        primary: true,
-                        disabled: computed(move || !busy.get() && session.draft.with(|s| s.trim().is_empty())),
-                        on_press: actions.send,
-                    )
-                }
+                ComposerAction(busy: busy.read_only(), draft: session.draft, on_press: actions.send)
             }
         }
     }

--- a/examples/chat/src/ui/composer_action.rs
+++ b/examples/chat/src/ui/composer_action.rs
@@ -1,0 +1,62 @@
+use super::theme::{self, size};
+use whisker::css::{Cursor, PointerEvents};
+use whisker::prelude::*;
+use whisker_icons::{Icon, lucide};
+
+#[component]
+pub fn composer_action(
+    busy: ReadSignal<bool>,
+    draft: RwSignal<String>,
+    on_press: Callback,
+) -> Element {
+    let disabled = computed(move || !busy.get() && draft.with(|text| text.trim().is_empty()));
+    let appearance = theme::use_appearance();
+    render! {
+        View(
+            accessibility: computed(move || {
+                Accessibility::new()
+                    .label(if busy.get() {
+                        "Stop generation"
+                    } else {
+                        "Send message"
+                    })
+                    .role(AccessibilityRole::Button)
+                    .state(AccessibilityState::new().disabled(disabled.get()))
+            }),
+            on_tap: move |_| {
+                if !disabled.get_untracked() {
+                    on_press.call();
+                }
+            },
+            style: theme::style(move |palette| {
+                theme::row()
+                    .justify_content(JustifyContent::Center)
+                    .width(px(size::TOUCH))
+                    .height(px(size::TOUCH))
+                    .flex_shrink(0.0)
+                    .border_radius(px(size::TOUCH / 2.0))
+                    .background_color(Color::hex(palette.accent))
+                    .opacity(if disabled.get() { 0.4 } else { 1.0 })
+                    .cursor(if disabled.get() {
+                        Cursor::NotAllowed
+                    } else {
+                        Cursor::Pointer
+                    })
+            }),
+        ) {
+            View(style: Css::new().pointer_events(PointerEvents::None)) {
+                Icon(
+                    svg: computed(move || {
+                        if busy.get() {
+                            lucide::Square.into()
+                        } else {
+                            lucide::ArrowUp.into()
+                        }
+                    }),
+                    color: computed(move || format!("#{:06x}", appearance.get().palette().on_accent)),
+                    size: "20",
+                )
+            }
+        }
+    }
+}

--- a/examples/chat/src/ui/mod.rs
+++ b/examples/chat/src/ui/mod.rs
@@ -3,6 +3,7 @@ mod button;
 mod chat;
 mod chat_layout;
 mod composer;
+mod composer_action;
 mod connection;
 mod history;
 mod history_dialog;

--- a/examples/chat/src/ui/welcome.rs
+++ b/examples/chat/src/ui/welcome.rs
@@ -8,19 +8,21 @@ use whisker::prelude::*;
 use whisker_icons::lucide;
 
 #[component]
-pub fn welcome(draft: RwSignal<String>) -> Element {
+pub fn welcome(draft: RwSignal<String>, input_height: RwSignal<f32>) -> Element {
     render! {
         ScrollView(style: theme::fill()) {
             View(
-                style: theme::column()
-                    .width(percent(100))
-                    .max_width(px(size::READING))
-                    .align_self(AlignSelf::Center)
-                    .padding(px(space::XXL))
-                    .padding_top(px(chat_layout::CONTENT_TOP + space::HERO))
-                    .padding_bottom(px(chat_layout::CONTENT_BOTTOM))
-                    .gap(px(space::XL))
-                    .flex_shrink(0.0),
+                style: computed(move || {
+                    theme::column()
+                        .width(percent(100))
+                        .max_width(px(size::READING))
+                        .align_self(AlignSelf::Center)
+                        .padding(px(space::XXL))
+                        .padding_top(px(chat_layout::CONTENT_TOP + space::HERO))
+                        .padding_bottom(px(chat_layout::content_bottom(input_height.get())))
+                        .gap(px(space::XL))
+                        .flex_shrink(0.0)
+                }),
             ) {
                 View(style: theme::row().gap(px(space::MD))) {
                     Text(

--- a/packages/whisker-input/Cargo.toml
+++ b/packages/whisker-input/Cargo.toml
@@ -44,4 +44,3 @@ desktop = { manifest = "desktop/Cargo.toml" }
 [dependencies]
 whisker = { path = "../../crates/whisker", version = "0.13.8" }
 serde = { workspace = true }
-serde_json = { workspace = true }

--- a/packages/whisker-input/Cargo.toml
+++ b/packages/whisker-input/Cargo.toml
@@ -19,7 +19,7 @@ include = [
     "Cargo.toml",
     "Package.swift",
     "build.gradle.kts",
-    "src/lib.rs",
+    "src/**/*.rs",
     "android/**/*.kt",
     "ios/**/*.swift",
     "desktop/**/*.rs",
@@ -44,3 +44,4 @@ desktop = { manifest = "desktop/Cargo.toml" }
 [dependencies]
 whisker = { path = "../../crates/whisker", version = "0.13.8" }
 serde = { workspace = true }
+serde_json = { workspace = true }

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputMeasurement.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputMeasurement.kt
@@ -1,0 +1,73 @@
+package rs.whisker.elements.input
+
+import android.graphics.Typeface
+import android.os.Build
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.widget.EditText
+import org.json.JSONObject
+import rs.whisker.runtime.WhiskerAvailableSpace
+import rs.whisker.runtime.WhiskerMeasureRequest
+import rs.whisker.runtime.WhiskerMeasuredSize
+import rs.whisker.runtime.WhiskerTextStyle
+import rs.whisker.runtime.WhiskerFontStyle
+import kotlin.math.ceil
+import kotlin.math.max
+
+internal object InputTypography {
+    fun typeface(family: String?, weight: Int, italic: Boolean): Typeface {
+        val base = Typeface.create(family, Typeface.NORMAL)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Typeface.create(base, weight.coerceIn(1, 1000), italic)
+        } else {
+            Typeface.create(base, (if (weight >= 600) Typeface.BOLD else 0) or (if (italic) Typeface.ITALIC else 0))
+        }
+    }
+
+    fun spacing(paint: TextPaint, lineHeight: Float?): Float =
+        lineHeight?.let { it - (paint.fontMetricsInt.descent - paint.fontMetricsInt.ascent) } ?: 0f
+
+    fun apply(view: EditText, style: WhiskerTextStyle) {
+        val density = view.resources.displayMetrics.density
+        view.setTextSize(android.util.TypedValue.COMPLEX_UNIT_PX, inputTextSizePixels(style.fontSize, density))
+        view.typeface = typeface(style.fontFamilies.firstOrNull()?.takeUnless { it == "system" }, style.fontWeight, style.fontStyle != WhiskerFontStyle.NORMAL)
+        view.letterSpacing = style.letterSpacing / style.fontSize
+        view.includeFontPadding = false
+        view.breakStrategy = Layout.BREAK_STRATEGY_SIMPLE
+        view.hyphenationFrequency = Layout.HYPHENATION_FREQUENCY_NONE
+        view.setLineSpacing(spacing(view.paint, style.lineHeight?.times(density)), 1f)
+    }
+}
+
+internal fun measureInput(request: WhiskerMeasureRequest): WhiskerMeasuredSize? {
+    if (request.payloadVersion != 1) return null
+    val bytes = request.payload.asBytes() ?: return null
+    val data = try { JSONObject(bytes.toString(Charsets.UTF_8)) } catch (_: org.json.JSONException) { return null }
+    val scale = data.getDouble("scale_factor").toFloat()
+    val paint = TextPaint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = data.getDouble("font_size").toFloat() * scale
+        typeface = InputTypography.typeface(if (data.isNull("font_family")) null else data.getString("font_family"), data.getInt("font_weight"), data.getBoolean("italic"))
+        letterSpacing = data.getDouble("letter_spacing").toFloat() * scale / textSize
+    }
+    val text = data.getString("text")
+    val multiline = data.getBoolean("multiline")
+    val content = if (multiline) text else text.replace('\n', ' ')
+    val desired = Layout.getDesiredWidth(content, paint)
+    val width = request.knownWidth?.times(scale) ?: when (request.availableWidthKind) {
+        WhiskerAvailableSpace.DEFINITE -> minOf(desired, (request.availableWidth ?: 0f) * scale)
+        WhiskerAvailableSpace.MIN_CONTENT -> if (multiline) 1f else desired
+        WhiskerAvailableSpace.MAX_CONTENT -> desired
+    }
+    val lineHeight = if (data.isNull("line_height")) null else data.getDouble("line_height").toFloat() * scale
+    val layout = StaticLayout.Builder.obtain(content, 0, content.length, paint, ceil(width.toDouble()).toInt().coerceAtLeast(1))
+        .setIncludePad(false)
+        .setBreakStrategy(Layout.BREAK_STRATEGY_SIMPLE)
+        .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE)
+        .setMaxLines(if (multiline) Int.MAX_VALUE else 1)
+        .setLineSpacing(InputTypography.spacing(paint, lineHeight), 1f)
+        .build()
+    var usedWidth = 0f
+    for (line in 0 until layout.lineCount) usedWidth = max(usedWidth, layout.getLineWidth(line))
+    return WhiskerMeasuredSize(request.knownWidth ?: usedWidth / scale, request.knownHeight ?: layout.height / scale)
+}

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputMeasurement.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputMeasurement.kt
@@ -6,7 +6,7 @@ import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.widget.EditText
-import org.json.JSONObject
+import rs.whisker.runtime.WhiskerValue
 import rs.whisker.runtime.WhiskerAvailableSpace
 import rs.whisker.runtime.WhiskerMeasureRequest
 import rs.whisker.runtime.WhiskerMeasuredSize
@@ -42,16 +42,19 @@ internal object InputTypography {
 
 internal fun measureInput(request: WhiskerMeasureRequest): WhiskerMeasuredSize? {
     if (request.payloadVersion != 1) return null
-    val bytes = request.payload.asBytes() ?: return null
-    val data = try { JSONObject(bytes.toString(Charsets.UTF_8)) } catch (_: org.json.JSONException) { return null }
-    val scale = data.getDouble("scale_factor").toFloat()
+    val data = (request.payload as? WhiskerValue.Map)?.value ?: return null
+    val scale = data["scale_factor"]?.asDouble()?.toFloat() ?: return null
+    val fontSize = data["font_size"]?.asDouble()?.toFloat() ?: return null
+    val weight = data["font_weight"]?.asInt()?.toInt() ?: return null
+    val italic = data["italic"]?.asBool() ?: return null
+    val spacing = data["letter_spacing"]?.asDouble()?.toFloat() ?: return null
+    val text = data["text"]?.asString() ?: return null
+    val multiline = data["multiline"]?.asBool() ?: return null
     val paint = TextPaint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
-        textSize = data.getDouble("font_size").toFloat() * scale
-        typeface = InputTypography.typeface(if (data.isNull("font_family")) null else data.getString("font_family"), data.getInt("font_weight"), data.getBoolean("italic"))
-        letterSpacing = data.getDouble("letter_spacing").toFloat() * scale / textSize
+        textSize = fontSize * scale
+        typeface = InputTypography.typeface(data["font_family"]?.asString(), weight, italic)
+        letterSpacing = spacing * scale / textSize
     }
-    val text = data.getString("text")
-    val multiline = data.getBoolean("multiline")
     val content = if (multiline) text else text.replace('\n', ' ')
     val desired = Layout.getDesiredWidth(content, paint)
     val width = request.knownWidth?.times(scale) ?: when (request.availableWidthKind) {
@@ -59,7 +62,7 @@ internal fun measureInput(request: WhiskerMeasureRequest): WhiskerMeasuredSize? 
         WhiskerAvailableSpace.MIN_CONTENT -> if (multiline) 1f else desired
         WhiskerAvailableSpace.MAX_CONTENT -> desired
     }
-    val lineHeight = if (data.isNull("line_height")) null else data.getDouble("line_height").toFloat() * scale
+    val lineHeight = data["line_height"]?.asDouble()?.toFloat()?.times(scale)
     val layout = StaticLayout.Builder.obtain(content, 0, content.length, paint, ceil(width.toDouble()).toInt().coerceAtLeast(1))
         .setIncludePad(false)
         .setBreakStrategy(Layout.BREAK_STRATEGY_SIMPLE)

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/InputModule.kt
@@ -73,6 +73,9 @@ class InputModule : Module() {
             // inside WhiskerInputView. Documents the emittable set.
             Events("input", "change", "focus", "blur", "submit")
 
+            Prop("auto-size") { _: WhiskerInputView, _ -> }
+            Measurement(::measureInput)
+
             TextStyle { view: WhiskerInputView, style ->
                 view.applyTextStyle(style)
             }

--- a/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
+++ b/packages/whisker-input/android/src/main/kotlin/rs/whisker/elements/input/WhiskerInputView.kt
@@ -18,13 +18,11 @@ package rs.whisker.elements.input
 
 import android.content.Context
 import android.graphics.Color
-import android.graphics.Typeface
 import android.os.Build
 import android.text.Editable
 import android.text.InputFilter
 import android.text.InputType
 import android.text.TextWatcher
-import android.util.TypedValue
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.autofill.AutofillValue
@@ -490,17 +488,7 @@ open class WhiskerInputView(context: WhiskerContext) : WhiskerUI<android.widget.
     fun applyTextStyle(style: WhiskerTextStyle) {
         val et = view()
         et.setTextColor(style.color)
-        et.setTextSize(
-            TypedValue.COMPLEX_UNIT_PX,
-            inputTextSizePixels(style.fontSize, et.resources.displayMetrics.density),
-        )
-        val family = style.fontFamilies.firstOrNull()?.takeUnless { it == "system" }
-        val base = Typeface.create(family, Typeface.NORMAL)
-        et.typeface = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            Typeface.create(base, style.fontWeight.coerceIn(1, 1000), false)
-        } else {
-            Typeface.create(base, if (style.fontWeight >= 600) Typeface.BOLD else Typeface.NORMAL)
-        }
+        InputTypography.apply(et, style)
         val horizontal = when (style.alignment) {
             WhiskerTextAlignment.CENTER -> Gravity.CENTER_HORIZONTAL
             WhiskerTextAlignment.END, WhiskerTextAlignment.RIGHT -> Gravity.END

--- a/packages/whisker-input/desktop/Cargo.toml
+++ b/packages/whisker-input/desktop/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 description = "Native Desktop Host implementation for whisker-input."
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
 csscolorparser = "0.7.2"
 glyphon = "0.9.0"
 unicode-segmentation = "1"

--- a/packages/whisker-input/desktop/Cargo.toml
+++ b/packages/whisker-input/desktop/Cargo.toml
@@ -9,7 +9,6 @@ description = "Native Desktop Host implementation for whisker-input."
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 csscolorparser = "0.7.2"
 glyphon = "0.9.0"
 unicode-segmentation = "1"

--- a/packages/whisker-input/desktop/src/lib.rs
+++ b/packages/whisker-input/desktop/src/lib.rs
@@ -4,6 +4,8 @@
 //! `whisker-desktop` only routes window focus, keyboard, clipboard, and IME
 //! messages through its generic editable-text seam.
 
+mod measurement;
+
 use std::fmt;
 use std::sync::{Mutex, OnceLock};
 
@@ -421,42 +423,6 @@ impl InputDesktopView {
             .text_style
             .as_ref()
             .map_or(&default_style, |style| &style.style);
-        let font_size = style.font_size * scale;
-        let line_height = match style.line_height {
-            MeasureLineHeight::Normal => font_size * 1.2,
-            MeasureLineHeight::LogicalPixels(value) => value * scale,
-        };
-        let mut buffer = Buffer::new(&mut state.font_system, Metrics::new(font_size, line_height));
-        buffer.set_size(
-            &mut state.font_system,
-            Some(width as f32),
-            Some(height as f32),
-        );
-        buffer.set_wrap(
-            &mut state.font_system,
-            if self.multiline {
-                Wrap::Word
-            } else {
-                Wrap::None
-            },
-        );
-        let family = style
-            .font_families
-            .iter()
-            .map(|family| match family {
-                MeasureFontFamily::System => Family::SansSerif,
-                MeasureFontFamily::Named(name) => Family::Name(name),
-            })
-            .next()
-            .unwrap_or(Family::SansSerif);
-        let attrs = Attrs::new()
-            .family(family)
-            .weight(Weight(style.font_weight))
-            .style(match style.font_style {
-                MeasureFontStyle::Normal => Style::Normal,
-                MeasureFontStyle::Italic => Style::Italic,
-                MeasureFontStyle::Oblique => Style::Oblique,
-            });
         let placeholder = self.value.is_empty() && !self.placeholder.is_empty();
         let display = if placeholder {
             self.placeholder.clone()
@@ -465,8 +431,22 @@ impl InputDesktopView {
         } else {
             self.value.clone()
         };
-        buffer.set_text(&mut state.font_system, &display, &attrs, Shaping::Advanced);
-        buffer.shape_until_scroll(&mut state.font_system, false);
+        let (mut buffer, line_height) = measurement::text_buffer(
+            &mut state.font_system,
+            &display,
+            style,
+            self.multiline,
+            Some(width as f32),
+            Some(height as f32),
+            scale,
+        );
+        if !placeholder {
+            buffer.shape_until_cursor(
+                &mut state.font_system,
+                text_cursor(&display, self.display_offset(self.selection.1)),
+                false,
+            );
+        }
         InputTextLayout {
             buffer,
             display,
@@ -565,6 +545,8 @@ impl WhiskerModule for InputModule {
     fn definition() -> Self::Definition {
         ModuleDefinition::new().name(MODULE_NAME).view(
             DesktopViewDefinition::new(MODULE_NAME, InputDesktopView::new)
+                .prop("auto-size", |_, _| {}, |_| {})
+                .measurement(measurement::measure)
                 .prop(
                     "value",
                     set_string(|view, value| view.set_value(value)),

--- a/packages/whisker-input/desktop/src/measurement.rs
+++ b/packages/whisker-input/desktop/src/measurement.rs
@@ -1,0 +1,171 @@
+use super::*;
+use whisker_desktop::{WhiskerMeasureRequest, WhiskerMeasuredSize};
+use whisker_protocol::{AvailableSpace, TextMeasureStyle};
+
+mod data {
+    use serde::{Deserialize, Serialize};
+
+    pub const VERSION: u16 = 1;
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct InputMeasureData {
+        pub scale_factor: f32,
+        pub text: String,
+        pub multiline: bool,
+        pub font_family: Option<String>,
+        pub font_size: f32,
+        pub font_weight: u16,
+        pub italic: bool,
+        pub line_height: Option<f32>,
+        pub letter_spacing: f32,
+    }
+}
+
+pub(super) fn text_buffer(
+    fonts: &mut FontSystem,
+    text: &str,
+    style: &TextMeasureStyle,
+    multiline: bool,
+    width: Option<f32>,
+    height: Option<f32>,
+    scale: f32,
+) -> (Buffer, f32) {
+    let font_size = style.font_size * scale;
+    let line_height = match style.line_height {
+        MeasureLineHeight::Normal => font_size * 1.2,
+        MeasureLineHeight::LogicalPixels(value) => value * scale,
+    };
+    let mut buffer = Buffer::new(fonts, Metrics::new(font_size, line_height));
+    buffer.set_size(fonts, width, height);
+    buffer.set_wrap(
+        fonts,
+        if multiline {
+            Wrap::WordOrGlyph
+        } else {
+            Wrap::None
+        },
+    );
+    let family = match style.font_families.first() {
+        Some(MeasureFontFamily::Named(name)) => Family::Name(name),
+        _ => Family::SansSerif,
+    };
+    let attrs = Attrs::new()
+        .family(family)
+        .weight(Weight(style.font_weight))
+        .style(match style.font_style {
+            MeasureFontStyle::Normal => Style::Normal,
+            MeasureFontStyle::Italic => Style::Italic,
+            MeasureFontStyle::Oblique => Style::Oblique,
+        })
+        .letter_spacing(style.letter_spacing * scale);
+    let shaped_text = if text.is_empty() || text.ends_with('\n') {
+        format!("{text}\u{200b}")
+    } else {
+        text.to_owned()
+    };
+    buffer.set_text(fonts, &shaped_text, &attrs, Shaping::Advanced);
+    buffer.shape_until_scroll(fonts, false);
+    (buffer, line_height)
+}
+
+pub(super) fn measure(request: &WhiskerMeasureRequest) -> Option<WhiskerMeasuredSize> {
+    if request.payload_version != data::VERSION {
+        return None;
+    }
+    let WhiskerValue::Bytes(bytes) = &request.payload else {
+        return None;
+    };
+    let input: data::InputMeasureData = serde_json::from_slice(bytes).ok()?;
+    let style = TextMeasureStyle {
+        font_families: vec![
+            input
+                .font_family
+                .map(MeasureFontFamily::Named)
+                .unwrap_or(MeasureFontFamily::System),
+        ],
+        font_size: input.font_size,
+        font_weight: input.font_weight,
+        font_style: if input.italic {
+            MeasureFontStyle::Italic
+        } else {
+            MeasureFontStyle::Normal
+        },
+        line_height: input
+            .line_height
+            .map(MeasureLineHeight::LogicalPixels)
+            .unwrap_or(MeasureLineHeight::Normal),
+        letter_spacing: input.letter_spacing,
+        ..TextMeasureStyle::default()
+    };
+    let mut state = text_rasterizer().lock().ok()?;
+    let width = request.known_dimensions[0].or(match request.available_space[0] {
+        AvailableSpace::Definite(width) => Some(width),
+        AvailableSpace::MinContent => Some(0.0),
+        AvailableSpace::MaxContent => None,
+    });
+    let (buffer, line_height) = text_buffer(
+        &mut state.font_system,
+        &input.text,
+        &style,
+        input.multiline,
+        width,
+        None,
+        1.0,
+    );
+    let mut measured_width = 0.0_f32;
+    let mut measured_height = line_height;
+    for run in buffer.layout_runs() {
+        measured_width = measured_width.max(run.line_w);
+        measured_height = measured_height.max(run.line_top + run.line_height);
+    }
+    Some(WhiskerMeasuredSize::new(
+        request.known_dimensions[0].unwrap_or(measured_width),
+        request.known_dimensions[1].unwrap_or(measured_height),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(text: &str, width: f32) -> WhiskerMeasureRequest {
+        WhiskerMeasureRequest {
+            known_dimensions: [Some(width), None],
+            available_space: [AvailableSpace::Definite(width), AvailableSpace::MaxContent],
+            payload_version: data::VERSION,
+            payload: WhiskerValue::Bytes(
+                serde_json::to_vec(&data::InputMeasureData {
+                    scale_factor: 1.0,
+                    text: text.into(),
+                    multiline: true,
+                    font_family: None,
+                    font_size: 16.0,
+                    font_weight: 400,
+                    italic: false,
+                    line_height: Some(24.0),
+                    letter_spacing: 0.0,
+                })
+                .unwrap(),
+            ),
+        }
+    }
+
+    #[test]
+    fn intrinsic_height_tracks_lines_wrapping_and_empty_content() {
+        let empty = measure(&request("", 200.0)).unwrap();
+        let one = measure(&request("Hello", 200.0)).unwrap();
+        let two = measure(&request("Hello\n", 200.0)).unwrap();
+        let text = "The quick brown fox jumps over the lazy dog";
+        let wide = measure(&request(text, 400.0)).unwrap();
+        let narrow = measure(&request(text, 80.0)).unwrap();
+        assert_eq!(empty.height, 24.0);
+        assert_eq!(one.height, empty.height);
+        assert_eq!(two.height, 48.0);
+        assert!(narrow.height > wide.height);
+        let mut fixed = request(text, 80.0);
+        fixed.known_dimensions[1] = Some(32.0);
+        assert_eq!(measure(&fixed).unwrap().height, 32.0);
+        fixed.payload_version = 2;
+        assert!(measure(&fixed).is_none());
+    }
+}

--- a/packages/whisker-input/desktop/src/measurement.rs
+++ b/packages/whisker-input/desktop/src/measurement.rs
@@ -3,13 +3,12 @@ use whisker_desktop::{WhiskerMeasureRequest, WhiskerMeasuredSize};
 use whisker_protocol::{AvailableSpace, TextMeasureStyle};
 
 mod data {
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
     pub const VERSION: u16 = 1;
 
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct InputMeasureData {
-        pub scale_factor: f32,
         pub text: String,
         pub multiline: bool,
         pub font_family: Option<String>,
@@ -72,10 +71,7 @@ pub(super) fn measure(request: &WhiskerMeasureRequest) -> Option<WhiskerMeasured
     if request.payload_version != data::VERSION {
         return None;
     }
-    let WhiskerValue::Bytes(bytes) = &request.payload else {
-        return None;
-    };
-    let input: data::InputMeasureData = serde_json::from_slice(bytes).ok()?;
+    let input: data::InputMeasureData = request.payload.deserialize_into().ok()?;
     let style = TextMeasureStyle {
         font_families: vec![
             input
@@ -133,20 +129,17 @@ mod tests {
             known_dimensions: [Some(width), None],
             available_space: [AvailableSpace::Definite(width), AvailableSpace::MaxContent],
             payload_version: data::VERSION,
-            payload: WhiskerValue::Bytes(
-                serde_json::to_vec(&data::InputMeasureData {
-                    scale_factor: 1.0,
-                    text: text.into(),
-                    multiline: true,
-                    font_family: None,
-                    font_size: 16.0,
-                    font_weight: 400,
-                    italic: false,
-                    line_height: Some(24.0),
-                    letter_spacing: 0.0,
-                })
-                .unwrap(),
-            ),
+            payload: WhiskerValue::map([
+                ("scale_factor", WhiskerValue::Float(1.0)),
+                ("text", WhiskerValue::String(text.into())),
+                ("multiline", WhiskerValue::Bool(true)),
+                ("font_family", WhiskerValue::Null),
+                ("font_size", WhiskerValue::Float(16.0)),
+                ("font_weight", WhiskerValue::Int(400)),
+                ("italic", WhiskerValue::Bool(false)),
+                ("line_height", WhiskerValue::Float(24.0)),
+                ("letter_spacing", WhiskerValue::Float(0.0)),
+            ]),
         }
     }
 

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputMeasurement.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputMeasurement.swift
@@ -52,7 +52,7 @@ internal struct InputTypography {
   }
 }
 
-private struct InputMeasureData: Decodable {
+private struct InputMeasureData {
   let text: String
   let multiline: Bool
   let fontFamily: String?
@@ -61,13 +61,29 @@ private struct InputMeasureData: Decodable {
   let italic: Bool
   let lineHeight: CGFloat?
   let letterSpacing: CGFloat
+
+  init?(_ payload: WhiskerValue) {
+    guard case .map(let fields) = payload,
+      let text = fields["text"]?.asString,
+      let multiline = fields["multiline"]?.asBool,
+      let fontSize = fields["font_size"]?.asDouble,
+      let fontWeight = fields["font_weight"]?.asInt,
+      let italic = fields["italic"]?.asBool,
+      let letterSpacing = fields["letter_spacing"]?.asDouble
+    else { return nil }
+    self.text = text
+    self.multiline = multiline
+    self.fontFamily = fields["font_family"]?.asString
+    self.fontSize = CGFloat(fontSize)
+    self.fontWeight = Int(fontWeight)
+    self.italic = italic
+    self.lineHeight = fields["line_height"]?.asDouble.map { CGFloat($0) }
+    self.letterSpacing = CGFloat(letterSpacing)
+  }
 }
 
 internal func measureInput(_ request: WhiskerMeasureRequest) -> WhiskerMeasuredSize? {
-  guard request.payloadVersion == 1, case .bytes(let bytes) = request.payload else { return nil }
-  let decoder = JSONDecoder()
-  decoder.keyDecodingStrategy = .convertFromSnakeCase
-  guard let input = try? decoder.decode(InputMeasureData.self, from: bytes) else { return nil }
+  guard request.payloadVersion == 1, let input = InputMeasureData(request.payload) else { return nil }
   let typography = InputTypography(
     family: input.fontFamily, size: input.fontSize, weight: input.fontWeight, italic: input.italic,
     lineHeight: input.lineHeight, letterSpacing: input.letterSpacing)

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputMeasurement.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputMeasurement.swift
@@ -1,0 +1,102 @@
+import UIKit
+import WhiskerModule
+
+internal struct InputTypography {
+  let font: UIFont
+  let lineHeight: CGFloat?
+  let letterSpacing: CGFloat
+
+  init(
+    family: String?, size: CGFloat, weight: Int, italic: Bool, lineHeight: CGFloat?,
+    letterSpacing: CGFloat
+  ) {
+    let base =
+      family.flatMap { UIFont(name: $0, size: size) }
+      ?? UIFont.systemFont(ofSize: size, weight: Self.weight(weight))
+    let descriptor = italic ? base.fontDescriptor.withSymbolicTraits(.traitItalic) : nil
+    self.font = descriptor.map { UIFont(descriptor: $0, size: size) } ?? base
+    self.lineHeight = lineHeight
+    self.letterSpacing = letterSpacing
+  }
+
+  init(_ style: WhiskerTextStyle) {
+    self.init(
+      family: style.fontFamilies.first.flatMap { $0 == "system" ? nil : $0 }, size: style.fontSize,
+      weight: style.fontWeight, italic: style.fontStyle != .normal, lineHeight: style.lineHeight,
+      letterSpacing: style.letterSpacing)
+  }
+
+  func attributes(alignment: NSTextAlignment = .natural) -> [NSAttributedString.Key: Any] {
+    let paragraph = NSMutableParagraphStyle()
+    paragraph.alignment = alignment
+    paragraph.lineBreakMode = .byWordWrapping
+    if let lineHeight {
+      paragraph.minimumLineHeight = lineHeight
+      paragraph.maximumLineHeight = lineHeight
+    }
+    return [.font: font, .kern: letterSpacing, .paragraphStyle: paragraph]
+  }
+
+  private static func weight(_ value: Int) -> UIFont.Weight {
+    switch value {
+    case ...150: .ultraLight
+    case ...250: .thin
+    case ...350: .light
+    case ...450: .regular
+    case ...550: .medium
+    case ...650: .semibold
+    case ...750: .bold
+    case ...850: .heavy
+    default: .black
+    }
+  }
+}
+
+private struct InputMeasureData: Decodable {
+  let text: String
+  let multiline: Bool
+  let fontFamily: String?
+  let fontSize: CGFloat
+  let fontWeight: Int
+  let italic: Bool
+  let lineHeight: CGFloat?
+  let letterSpacing: CGFloat
+}
+
+internal func measureInput(_ request: WhiskerMeasureRequest) -> WhiskerMeasuredSize? {
+  guard request.payloadVersion == 1, case .bytes(let bytes) = request.payload else { return nil }
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+  guard let input = try? decoder.decode(InputMeasureData.self, from: bytes) else { return nil }
+  let typography = InputTypography(
+    family: input.fontFamily, size: input.fontSize, weight: input.fontWeight, italic: input.italic,
+    lineHeight: input.lineHeight, letterSpacing: input.letterSpacing)
+  let text = input.multiline ? input.text : input.text.replacingOccurrences(of: "\n", with: " ")
+  let attributes = typography.attributes()
+  let natural = (text as NSString).boundingRect(
+    with: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+    options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: attributes, context: nil
+  ).width
+  let available: CGFloat
+  switch request.availableWidthKind {
+  case .definite: available = min(natural, request.availableWidth ?? natural)
+  case .minContent: available = input.multiline ? 1 : natural
+  case .maxContent: available = natural
+  }
+  let width = max(1, request.knownWidth ?? available)
+  let storage = NSTextStorage(string: text, attributes: attributes)
+  let layout = NSLayoutManager()
+  let container = NSTextContainer(
+    size: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+  container.lineFragmentPadding = 0
+  container.maximumNumberOfLines = input.multiline ? 0 : 1
+  layout.addTextContainer(container)
+  storage.addLayoutManager(layout)
+  layout.ensureLayout(for: container)
+  let used = layout.usedRect(for: container)
+  let height = max(
+    typography.lineHeight ?? typography.font.lineHeight,
+    max(used.maxY, layout.extraLineFragmentRect.maxY))
+  return WhiskerMeasuredSize(
+    width: request.knownWidth ?? used.width, height: request.knownHeight ?? height)
+}

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputModule.swift
@@ -75,6 +75,9 @@ public final class InputModule: Module {
                     view.setSpellCheck(value.asBool ?? true)
                 }
 
+                Prop("auto-size") { (_: WhiskerInputView, _: WhiskerValue) in }
+                Measurement(measureInput)
+
                 TextStyle { (view: WhiskerInputView, style: WhiskerTextStyle) in
                     view.applyTextStyle(style)
                 }

--- a/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
+++ b/packages/whisker-input/ios/Sources/WhiskerInput/InputView.swift
@@ -94,8 +94,7 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
     private var cachedAutocorrect: UITextAutocorrectionType = .default
     private var cachedSpellCheck: UITextSpellCheckingType = .default
     private var cachedTextColor: UIColor = .label
-    private var cachedFontSize: CGFloat = 17
-    private var cachedFontWeight: UIFont.Weight = .regular
+    private var typography = InputTypography(family: nil, size: 17, weight: 400, italic: false, lineHeight: nil, letterSpacing: 0)
     private var cachedTextAlignment: NSTextAlignment = .natural
 
     /// Distinguishes "no control yet" from "control exists, possibly needs
@@ -199,7 +198,10 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         if let tf = textField {
             if tf.text != s { tf.text = s }
         } else if let tv = textView {
-            if tv.text != s { tv.text = s }
+            if tv.text != s {
+                tv.text = s
+                applyFont()
+            }
         }
     }
 
@@ -228,9 +230,17 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
     }
 
     private func applyFont() {
-        let font = UIFont.systemFont(ofSize: cachedFontSize, weight: cachedFontWeight)
-        textField?.font = font
-        textView?.font = font
+        textField?.font = typography.font
+        textView?.font = typography.font
+        var attributes = typography.attributes(alignment: cachedTextAlignment)
+        attributes[.foregroundColor] = cachedTextColor
+        textField?.defaultTextAttributes = attributes
+        if let view = textView {
+            let selection = view.selectedRange
+            view.textStorage.addAttributes(attributes, range: NSRange(location: 0, length: view.textStorage.length))
+            view.typingAttributes = attributes
+            view.selectedRange = selection
+        }
     }
 
     private func applyTextAlignment() {
@@ -393,8 +403,7 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
 
     public func applyTextStyle(_ style: WhiskerTextStyle) {
         cachedTextColor = style.color
-        cachedFontSize = style.fontSize
-        cachedFontWeight = Self.mapFontWeight(style.fontWeight)
+        typography = InputTypography(style)
         cachedTextAlignment = switch style.alignment {
         case .left: .left
         case .right: .right
@@ -516,20 +525,6 @@ public final class WhiskerInputView: WhiskerUI<UIView> {
         case "words":      return .words
         case "characters": return .allCharacters
         default:           return .sentences
-        }
-    }
-
-    private static func mapFontWeight(_ value: Int) -> UIFont.Weight {
-        switch value {
-        case ...150: .ultraLight
-        case ...250: .thin
-        case ...350: .light
-        case ...450: .regular
-        case ...550: .medium
-        case ...650: .semibold
-        case ...750: .bold
-        case ...850: .heavy
-        default: .black
         }
     }
 

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -391,7 +391,7 @@ impl Default for InputRef {
 #[doc(hidden)]
 #[whisker::module_element(
     name = "whisker-input:Input",
-    measurement = Custom,
+    measurement = Custom(measurement::payload),
     text_style = true,
     commands = [
         ("focus", Null),
@@ -629,9 +629,6 @@ pub fn input(
         .on_blur(on_blur_cb)
         .on_submit(on_submit_cb);
 
-    if auto_size {
-        builder = builder.measure_with(measurement::payload);
-    }
     if let Some(callback) = on_size_change {
         let previous = std::cell::Cell::new(None);
         whisker::runtime::view::observe_layout(

--- a/packages/whisker-input/src/lib.rs
+++ b/packages/whisker-input/src/lib.rs
@@ -93,6 +93,8 @@
 //! | `on_submit`        | `Fn(String)`                          | —             | Return / done key pressed. |
 //! | `placeholder`      | `Signal<String>`                      | `""`          | Placeholder text shown when empty. |
 //! | `multiline`        | `bool`                                | `false`       | Single-line field vs multiline area. |
+//! | `auto_size`        | `bool`                                | `false`       | Measure content at its layout width; respects min/max size and overrides `lines`. |
+//! | `on_size_change`   | `Fn(InputSize)`                        | —             | Final size after padding, borders, and style constraints. |
 //! | `lines`            | `u32`                                 | unset (`0`)   | Fixed visible line count (multiline only). |
 //! | `secure`           | `bool`                                | `false`       | Mask Input (password entry). |
 //! | `editable`         | `bool`                                | `true`        | Allow editing. |
@@ -150,9 +152,18 @@
 //!   Windows, and Linux; OS keyboard/IME events enter through
 //!   `platforms/desktop`)
 
+mod measurement;
+
 use whisker::platform_module::WhiskerValue;
 use whisker::prelude::*;
 use whisker::{Callback, ElementRef, Signal, Style};
+
+/// The input's final border-box size in logical pixels, including padding and border.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct InputSize {
+    pub width: f32,
+    pub height: f32,
+}
 
 /// Payload of an input event (`input` / `change` / `submit`).
 ///
@@ -380,7 +391,7 @@ impl Default for InputRef {
 #[doc(hidden)]
 #[whisker::module_element(
     name = "whisker-input:Input",
-    measurement = None,
+    measurement = Custom,
     text_style = true,
     commands = [
         ("focus", Null),
@@ -396,6 +407,7 @@ pub fn native_input(
     caret_color: Signal<String>,
     selection_color: Signal<String>,
     multiline: Signal<bool>,
+    auto_size: Signal<bool>,
     lines: Signal<i32>,
     secure: Signal<bool>,
     editable: Signal<bool>,
@@ -452,7 +464,12 @@ pub fn input(
     /// Multiline area vs single-line field.
     #[prop(default = false)]
     multiline: bool,
-    /// Fixed visible line count (multiline only).
+    /// Measures content height under the current layout width; CSS min/max height still apply.
+    #[prop(default = false)]
+    auto_size: bool,
+    /// Reports the final input border-box size after layout, in logical pixels.
+    on_size_change: Option<Callback<InputSize>>,
+    /// Fixed visible line count (multiline only); ignored when auto_size is enabled.
     lines: Option<u32>,
     /// Mask Input (password entry).
     #[prop(default = false)]
@@ -594,7 +611,8 @@ pub fn input(
         .caret_color(caret_color_prop)
         .selection_color(selection_color_prop)
         .multiline(multiline)
-        .lines(lines_attr)
+        .auto_size(auto_size)
+        .lines(if auto_size { 0 } else { lines_attr })
         .secure(secure)
         .editable(editable)
         .auto_focus(auto_focus)
@@ -611,6 +629,25 @@ pub fn input(
         .on_blur(on_blur_cb)
         .on_submit(on_submit_cb);
 
+    if auto_size {
+        builder = builder.measure_with(measurement::payload);
+    }
+    if let Some(callback) = on_size_change {
+        let previous = std::cell::Cell::new(None);
+        whisker::runtime::view::observe_layout(
+            builder.__element(),
+            Box::new(move |layout| {
+                let rect = layout.geometry.border_box;
+                let size = InputSize {
+                    width: rect.width,
+                    height: rect.height,
+                };
+                if previous.replace(Some(size)) != Some(size) {
+                    callback.run(size);
+                }
+            }),
+        );
+    }
     builder = builder.element_ref(element_ref);
 
     builder.build()

--- a/packages/whisker-input/src/measurement.rs
+++ b/packages/whisker-input/src/measurement.rs
@@ -1,0 +1,62 @@
+use whisker::runtime::module_measurement::{
+    MeasureFontFamily, MeasureFontStyle, MeasureLineHeight,
+};
+use whisker::{CustomMeasurePayload, ModuleMeasureContext, WhiskerValue};
+
+mod data {
+    use serde::{Deserialize, Serialize};
+
+    pub const VERSION: u16 = 1;
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct InputMeasureData {
+        pub scale_factor: f32,
+        pub text: String,
+        pub multiline: bool,
+        pub font_family: Option<String>,
+        pub font_size: f32,
+        pub font_weight: u16,
+        pub italic: bool,
+        pub line_height: Option<f32>,
+        pub letter_spacing: f32,
+    }
+}
+
+pub(super) fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload> {
+    if context.property("auto-size") != Some(&WhiskerValue::Bool(true)) {
+        return None;
+    }
+    let style = &context.text_style()?.style;
+    let text = match context.property("value") {
+        Some(WhiskerValue::String(value)) => value.clone(),
+        _ => String::new(),
+    };
+    let multiline = context.property("multiline") == Some(&WhiskerValue::Bool(true));
+    let secure = context.property("secure") == Some(&WhiskerValue::Bool(true));
+    let text = if secure {
+        "•".repeat(text.chars().count())
+    } else {
+        text
+    };
+    let input = data::InputMeasureData {
+        scale_factor: context.scale_factor(),
+        text,
+        multiline,
+        font_family: style.font_families.first().and_then(|family| match family {
+            MeasureFontFamily::System => None,
+            MeasureFontFamily::Named(name) => Some(name.clone()),
+        }),
+        font_size: style.font_size,
+        font_weight: style.font_weight,
+        italic: style.font_style != MeasureFontStyle::Normal,
+        line_height: match style.line_height {
+            MeasureLineHeight::Normal => None,
+            MeasureLineHeight::LogicalPixels(value) => Some(value),
+        },
+        letter_spacing: style.letter_spacing,
+    };
+    Some(CustomMeasurePayload {
+        version: data::VERSION,
+        data: serde_json::to_vec(&input).expect("validated input measurement values"),
+    })
+}

--- a/packages/whisker-input/src/measurement.rs
+++ b/packages/whisker-input/src/measurement.rs
@@ -3,25 +3,6 @@ use whisker::runtime::module_measurement::{
 };
 use whisker::{CustomMeasurePayload, ModuleMeasureContext, WhiskerValue};
 
-mod data {
-    use serde::{Deserialize, Serialize};
-
-    pub const VERSION: u16 = 1;
-
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    pub struct InputMeasureData {
-        pub scale_factor: f32,
-        pub text: String,
-        pub multiline: bool,
-        pub font_family: Option<String>,
-        pub font_size: f32,
-        pub font_weight: u16,
-        pub italic: bool,
-        pub line_height: Option<f32>,
-        pub letter_spacing: f32,
-    }
-}
-
 pub(super) fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasurePayload> {
     if context.property("auto-size") != Some(&WhiskerValue::Bool(true)) {
         return None;
@@ -38,25 +19,39 @@ pub(super) fn payload(context: ModuleMeasureContext<'_>) -> Option<CustomMeasure
     } else {
         text
     };
-    let input = data::InputMeasureData {
-        scale_factor: context.scale_factor(),
-        text,
-        multiline,
-        font_family: style.font_families.first().and_then(|family| match family {
-            MeasureFontFamily::System => None,
-            MeasureFontFamily::Named(name) => Some(name.clone()),
-        }),
-        font_size: style.font_size,
-        font_weight: style.font_weight,
-        italic: style.font_style != MeasureFontStyle::Normal,
-        line_height: match style.line_height {
-            MeasureLineHeight::Normal => None,
-            MeasureLineHeight::LogicalPixels(value) => Some(value),
-        },
-        letter_spacing: style.letter_spacing,
-    };
     Some(CustomMeasurePayload {
-        version: data::VERSION,
-        data: serde_json::to_vec(&input).expect("validated input measurement values"),
+        version: 1,
+        data: WhiskerValue::map([
+            (
+                "scale_factor",
+                WhiskerValue::Float(context.scale_factor() as f64),
+            ),
+            ("text", WhiskerValue::String(text)),
+            ("multiline", WhiskerValue::Bool(multiline)),
+            (
+                "font_family",
+                match style.font_families.first() {
+                    Some(MeasureFontFamily::Named(name)) => WhiskerValue::String(name.clone()),
+                    _ => WhiskerValue::Null,
+                },
+            ),
+            ("font_size", WhiskerValue::Float(style.font_size as f64)),
+            ("font_weight", WhiskerValue::Int(style.font_weight as i64)),
+            (
+                "italic",
+                WhiskerValue::Bool(style.font_style != MeasureFontStyle::Normal),
+            ),
+            (
+                "line_height",
+                match style.line_height {
+                    MeasureLineHeight::Normal => WhiskerValue::Null,
+                    MeasureLineHeight::LogicalPixels(value) => WhiskerValue::Float(value as f64),
+                },
+            ),
+            (
+                "letter_spacing",
+                WhiskerValue::Float(style.letter_spacing as f64),
+            ),
+        ]),
     })
 }

--- a/packages/whisker-input/web/Cargo.toml
+++ b/packages/whisker-input/web/Cargo.toml
@@ -9,7 +9,6 @@ description = "Web Host implementation for whisker-input."
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
 whisker-protocol = { path = "../../../crates/whisker-protocol", version = "0.13.8" }
 whisker-web = { path = "../../../platforms/web", version = "0.13.8" }
 web-sys = { version = "0.3", features = [

--- a/packages/whisker-input/web/Cargo.toml
+++ b/packages/whisker-input/web/Cargo.toml
@@ -8,11 +8,15 @@ repository.workspace = true
 description = "Web Host implementation for whisker-input."
 
 [dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
 whisker-protocol = { path = "../../../crates/whisker-protocol", version = "0.13.8" }
 whisker-web = { path = "../../../platforms/web", version = "0.13.8" }
 web-sys = { version = "0.3", features = [
     "CssStyleDeclaration",
     "Document",
+    "DomRect",
+    "Window",
     "Element",
     "Event",
     "EventTarget",

--- a/packages/whisker-input/web/src/lib.rs
+++ b/packages/whisker-input/web/src/lib.rs
@@ -1,5 +1,7 @@
 //! Browser Host implementation for `whisker-input`.
 
+mod measurement;
+
 use std::rc::Rc;
 
 use whisker_protocol::{
@@ -368,6 +370,8 @@ fn input_definition() -> WebViewDefinition<InputWebView> {
         view.set_value(value);
         Ok(())
     })
+    .prop("auto-size", |_, _| Ok(()), |_| Ok(()))
+    .measurement(measurement::measure)
     .text_style(|view, style| view.apply_text_style(style))
 }
 

--- a/packages/whisker-input/web/src/measurement.rs
+++ b/packages/whisker-input/web/src/measurement.rs
@@ -3,13 +3,12 @@ use whisker_protocol::AvailableSpace;
 use whisker_web::{WhiskerMeasureRequest, WhiskerMeasuredSize, WhiskerValue};
 
 mod data {
-    use serde::{Deserialize, Serialize};
+    use serde::Deserialize;
 
     pub const VERSION: u16 = 1;
 
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct InputMeasureData {
-        pub scale_factor: f32,
         pub text: String,
         pub multiline: bool,
         pub font_family: Option<String>,
@@ -25,10 +24,7 @@ pub(super) fn measure(request: &WhiskerMeasureRequest) -> Option<WhiskerMeasured
     if request.payload_version != data::VERSION {
         return None;
     }
-    let WhiskerValue::Bytes(bytes) = &request.payload else {
-        return None;
-    };
-    let input: data::InputMeasureData = serde_json::from_slice(bytes).ok()?;
+    let input: data::InputMeasureData = request.payload.deserialize_into().ok()?;
     let document = web_sys::window()?.document()?;
     let probe = document
         .create_element("div")
@@ -148,20 +144,17 @@ mod tests {
             known_dimensions: [Some(width), None],
             available_space: [AvailableSpace::Definite(width), AvailableSpace::MaxContent],
             payload_version: data::VERSION,
-            payload: WhiskerValue::Bytes(
-                serde_json::to_vec(&data::InputMeasureData {
-                    scale_factor: 1.0,
-                    text: text.into(),
-                    multiline: true,
-                    font_family: None,
-                    font_size: 16.0,
-                    font_weight: 400,
-                    italic: false,
-                    line_height: Some(24.0),
-                    letter_spacing: 0.0,
-                })
-                .unwrap(),
-            ),
+            payload: WhiskerValue::map([
+                ("scale_factor", WhiskerValue::Float(1.0)),
+                ("text", WhiskerValue::String(text.into())),
+                ("multiline", WhiskerValue::Bool(true)),
+                ("font_family", WhiskerValue::Null),
+                ("font_size", WhiskerValue::Float(16.0)),
+                ("font_weight", WhiskerValue::Int(400)),
+                ("italic", WhiskerValue::Bool(false)),
+                ("line_height", WhiskerValue::Float(24.0)),
+                ("letter_spacing", WhiskerValue::Float(0.0)),
+            ]),
         }
     }
 

--- a/packages/whisker-input/web/src/measurement.rs
+++ b/packages/whisker-input/web/src/measurement.rs
@@ -1,6 +1,6 @@
 use web_sys::wasm_bindgen::JsCast;
 use whisker_protocol::AvailableSpace;
-use whisker_web::{WhiskerMeasureRequest, WhiskerMeasuredSize, WhiskerValue};
+use whisker_web::{WhiskerMeasureRequest, WhiskerMeasuredSize};
 
 mod data {
     use serde::Deserialize;
@@ -138,6 +138,7 @@ fn measure_in(
 mod tests {
     use super::*;
     use wasm_bindgen_test::wasm_bindgen_test;
+    use whisker_web::WhiskerValue;
 
     fn request(text: &str, width: f32) -> WhiskerMeasureRequest {
         WhiskerMeasureRequest {

--- a/packages/whisker-input/web/src/measurement.rs
+++ b/packages/whisker-input/web/src/measurement.rs
@@ -1,0 +1,194 @@
+use web_sys::wasm_bindgen::JsCast;
+use whisker_protocol::AvailableSpace;
+use whisker_web::{WhiskerMeasureRequest, WhiskerMeasuredSize, WhiskerValue};
+
+mod data {
+    use serde::{Deserialize, Serialize};
+
+    pub const VERSION: u16 = 1;
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct InputMeasureData {
+        pub scale_factor: f32,
+        pub text: String,
+        pub multiline: bool,
+        pub font_family: Option<String>,
+        pub font_size: f32,
+        pub font_weight: u16,
+        pub italic: bool,
+        pub line_height: Option<f32>,
+        pub letter_spacing: f32,
+    }
+}
+
+pub(super) fn measure(request: &WhiskerMeasureRequest) -> Option<WhiskerMeasuredSize> {
+    if request.payload_version != data::VERSION {
+        return None;
+    }
+    let WhiskerValue::Bytes(bytes) = &request.payload else {
+        return None;
+    };
+    let input: data::InputMeasureData = serde_json::from_slice(bytes).ok()?;
+    let document = web_sys::window()?.document()?;
+    let probe = document
+        .create_element("div")
+        .ok()?
+        .dyn_into::<web_sys::HtmlElement>()
+        .ok()?;
+    let result = measure_in(&document, &probe, request, &input);
+    probe.remove();
+    result.ok()
+}
+
+fn measure_in(
+    document: &web_sys::Document,
+    probe: &web_sys::HtmlElement,
+    request: &WhiskerMeasureRequest,
+    input: &data::InputMeasureData,
+) -> Result<WhiskerMeasuredSize, web_sys::wasm_bindgen::JsValue> {
+    let style = probe.style();
+    for (name, value) in [
+        ("position", "absolute"),
+        ("visibility", "hidden"),
+        ("left", "-100000px"),
+        ("top", "0"),
+        ("padding", "0"),
+        ("border", "0"),
+        (
+            "white-space",
+            if input.multiline { "pre-wrap" } else { "pre" },
+        ),
+        ("overflow-wrap", "anywhere"),
+    ] {
+        style.set_property(name, value)?;
+    }
+    style.set_property(
+        "font-family",
+        &input
+            .font_family
+            .as_ref()
+            .map(|name| format!("{name:?}"))
+            .unwrap_or_else(|| "system-ui".into()),
+    )?;
+    style.set_property("font-size", &format!("{}px", input.font_size))?;
+    style.set_property("font-weight", &input.font_weight.to_string())?;
+    style.set_property("font-style", if input.italic { "italic" } else { "normal" })?;
+    style.set_property(
+        "line-height",
+        &input
+            .line_height
+            .map(|value| format!("{value}px"))
+            .unwrap_or_else(|| "normal".into()),
+    )?;
+    style.set_property("letter-spacing", &format!("{}px", input.letter_spacing))?;
+    let text = if input.text.is_empty() || input.text.ends_with('\n') {
+        format!("{}\u{200b}", input.text)
+    } else {
+        input.text.clone()
+    };
+    probe.set_text_content(Some(&text));
+    let width = match request.known_dimensions[0] {
+        Some(width) => format!("{}px", width.max(0.0)),
+        None => match request.available_space[0] {
+            AvailableSpace::Definite(width) => {
+                style.set_property("max-width", &format!("{}px", width.max(0.0)))?;
+                "max-content".into()
+            }
+            AvailableSpace::MinContent => "min-content".into(),
+            AvailableSpace::MaxContent => "max-content".into(),
+        },
+    };
+    style.set_property("width", &width)?;
+    document
+        .body()
+        .ok_or_else(|| web_sys::wasm_bindgen::JsValue::from_str("missing document body"))?
+        .append_child(probe)?;
+    let rect = probe.get_bounding_client_rect();
+    let height = if input.multiline {
+        let control = document
+            .create_element("textarea")?
+            .dyn_into::<web_sys::HtmlTextAreaElement>()?;
+        control.set_rows(1);
+        control.set_value(&input.text);
+        let css = control.style();
+        for (name, value) in [
+            ("font", "inherit"),
+            ("letter-spacing", "inherit"),
+            ("line-height", "inherit"),
+            ("padding", "0"),
+            ("border", "0"),
+            ("margin", "0"),
+            ("height", "0"),
+            ("overflow", "hidden"),
+            ("resize", "none"),
+            ("box-sizing", "content-box"),
+        ] {
+            css.set_property(name, value)?;
+        }
+        css.set_property("width", &format!("{}px", rect.width()))?;
+        probe.set_text_content(None);
+        probe.append_child(&control)?;
+        control.scroll_height() as f32
+    } else {
+        rect.height() as f32
+    };
+    Ok(WhiskerMeasuredSize::new(
+        request.known_dimensions[0].unwrap_or(rect.width() as f32),
+        request.known_dimensions[1].unwrap_or(height),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    fn request(text: &str, width: f32) -> WhiskerMeasureRequest {
+        WhiskerMeasureRequest {
+            known_dimensions: [Some(width), None],
+            available_space: [AvailableSpace::Definite(width), AvailableSpace::MaxContent],
+            payload_version: data::VERSION,
+            payload: WhiskerValue::Bytes(
+                serde_json::to_vec(&data::InputMeasureData {
+                    scale_factor: 1.0,
+                    text: text.into(),
+                    multiline: true,
+                    font_family: None,
+                    font_size: 16.0,
+                    font_weight: 400,
+                    italic: false,
+                    line_height: Some(24.0),
+                    letter_spacing: 0.0,
+                })
+                .unwrap(),
+            ),
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn intrinsic_height_tracks_lines_wrapping_and_removes_probes() {
+        let body = web_sys::window()
+            .unwrap()
+            .document()
+            .unwrap()
+            .body()
+            .unwrap();
+        let children = body.child_element_count();
+        let empty = measure(&request("", 200.0)).unwrap();
+        let one = measure(&request("Hello", 200.0)).unwrap();
+        let two = measure(&request("Hello\n", 200.0)).unwrap();
+        let text = "The quick brown fox jumps over the lazy dog";
+        let wide = measure(&request(text, 400.0)).unwrap();
+        let narrow = measure(&request(text, 80.0)).unwrap();
+        assert_eq!(empty.height, 24.0);
+        assert_eq!(one.height, empty.height);
+        assert_eq!(two.height, 48.0);
+        assert!(narrow.height > wide.height);
+        let mut fixed = request(text, 80.0);
+        fixed.known_dimensions[1] = Some(32.0);
+        assert_eq!(measure(&fixed).unwrap().height, 32.0);
+        fixed.payload_version = 2;
+        assert!(measure(&fixed).is_none());
+        assert_eq!(body.child_element_count(), children);
+    }
+}

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/HostConformanceTest.kt
@@ -1379,7 +1379,7 @@ private class Driver(
             arrayOf(command.getString("text"), command.optString("locale", "")),
             arrayOf(families),
             arrayOf((featureSettings + variationSettings).toTypedArray()),
-            arrayOf(byteArrayOf()),
+            arrayOf(WhiskerValue.Null),
         )
         val result = floatArrayOf(
             batch.ints[0].toFloat(),

--- a/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/MeasurementBatchAbiTest.kt
+++ b/platforms/android/runtime/src/androidTest/kotlin/rs/whisker/runtime/MeasurementBatchAbiTest.kt
@@ -80,7 +80,7 @@ class MeasurementBatchAbiTest {
                 arrayOf("first", "ja-JP", "second", "en-US"),
                 arrayOf(arrayOf("sans-serif"), arrayOf("serif")),
                 arrayOf(arrayOf("kern=1"), arrayOf("wght=700")),
-                arrayOf(byteArrayOf(1, 2), byteArrayOf(3, 4, 5)),
+                arrayOf(WhiskerValue.Bytes(byteArrayOf(1, 2)), WhiskerValue.Map(mapOf("width" to WhiskerValue.Int(73)))),
             )
 
             assertArrayEquals(

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/WhiskerView.kt
@@ -676,7 +676,7 @@ class WhiskerView(context: Context) :
         requestStrings: Array<String>,
         fontFamilies: Array<Array<String>>,
         fontSettings: Array<Array<String>>,
-        payloads: Array<ByteArray>,
+        payloads: Array<WhiskerValue?>,
         paragraphs: Array<WhiskerValue?> = arrayOfNulls(payloads.size),
     ): HostMeasureBatchResponse = HostMeasureBatchAbi.measure(
         measurements,

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/bridge/MobileAbi.kt
@@ -12,7 +12,7 @@ internal object MobileAbi {
     const val VALUE_MAP: Int = 7
     const val VALUE_ERROR: Int = 8
     const val MOBILE_ABI_MAJOR: Int = 2
-    const val MOBILE_ABI_MINOR: Int = 31
+    const val MOBILE_ABI_MINOR: Int = 32
     const val FRAME_PROTOCOL_MAJOR: Int = 1
     const val FRAME_PROTOCOL_MINOR: Int = 5
     const val CAPABILITY_ELLIPTICAL_BORDER_RADIUS: Long = 0x0001

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/MeasurementBatch.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/MeasurementBatch.kt
@@ -67,7 +67,7 @@ internal object HostMeasureBatchAbi {
         requestStrings: Array<String>,
         fontFamilies: Array<Array<String>>,
         fontSettings: Array<Array<String>>,
-        payloads: Array<ByteArray>,
+        payloads: Array<WhiskerValue?>,
         paragraphs: Array<WhiskerValue?> = arrayOfNulls(payloads.size),
     ): HostMeasureBatchResponse {
         require(requestLongs.size % REQUEST_LONG_STRIDE == 0)

--- a/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
+++ b/platforms/android/runtime/src/main/kotlin/rs/whisker/runtime/measure/TextMeasurement.kt
@@ -43,7 +43,7 @@ internal class HostMeasurementProvider(
         fontStyle: Int, wrap: Int, wordBreak: Int, overflow: Int, letterSpacing: Float,
         lineHeight: Float, indentLogicalPixels: Float, indentPercentage: Float,
         maxLines: Int, fontSettings: Array<String>, fontFeatureCount: Int,
-        fontOpticalSizing: Int, payloadVersion: Int, payload: ByteArray,
+        fontOpticalSizing: Int, payloadVersion: Int, payload: WhiskerValue?,
         intrinsicWidth: Float, intrinsicHeight: Float, intrinsicMask: Int,
         direction: Int, alignment: Int,
         paragraph: WhiskerValue? = null,
@@ -76,7 +76,7 @@ internal class HostMeasurementProvider(
                 if (knownMask and WIDTH != 0) knownWidth else null,
                 if (knownMask and HEIGHT != 0) knownHeight else null,
                 payloadVersion,
-                WhiskerValue.Bytes(payload),
+                payload ?: WhiskerValue.Null,
             ),
         ) ?: return HostMeasurementResult(status = UNSUPPORTED, reason = UNSUPPORTED_FEATURE)
         return ready(

--- a/platforms/desktop/src/element/tests.rs
+++ b/platforms/desktop/src/element/tests.rs
@@ -183,7 +183,7 @@ fn declared_text_style_and_measurement_reach_the_module_handlers() {
         },
         payload: MeasurementPayload::Custom(CustomMeasurePayload {
             version: 1,
-            data: Vec::new(),
+            data: WhiskerValue::Bytes(Vec::new()),
         }),
     };
     assert!(matches!(

--- a/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
+++ b/platforms/ios/Sources/WhiskerCBridge/include/whisker_mobile.h
@@ -32,7 +32,7 @@
 
 #define WHISKER_MOBILE_ABI_MAJOR 2
 
-#define WHISKER_MOBILE_ABI_MINOR 31
+#define WHISKER_MOBILE_ABI_MINOR 32
 
 #define WHISKER_FRAME_PROTOCOL_MAJOR 1
 
@@ -433,7 +433,7 @@ typedef struct WhiskerMobileMeasureRequest {
   float indent_logical_pixels;
   float indent_percentage;
   uint32_t max_lines;
-  struct WhiskerBytesRef payload;
+  const struct WhiskerValueRaw *payload;
   float intrinsic_width;
   float intrinsic_height;
   uint32_t intrinsic_mask;
@@ -852,7 +852,7 @@ WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerKeyValueRaw) == 40, "WhiskerKeyValueRaw 
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileHostCapabilities) == 24, "WhiskerMobileHostCapabilities ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
-WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 232, "WhiskerMobileMeasureRequest ABI drift");
+WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 224, "WhiskerMobileMeasureRequest ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureResponse) == 96, "WhiskerMobileMeasureResponse ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileText) == 256, "WhiskerMobileText ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");

--- a/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
+++ b/platforms/ios/Sources/WhiskerRuntime/measure/TextMeasurement.swift
@@ -300,9 +300,7 @@ private func measureCustomElement(
     _ request: WhiskerMobileMeasureRequest,
     response: inout WhiskerMobileMeasureResponse
 ) {
-    let payload = request.payload.ptr.map {
-        Data(bytes: $0, count: request.payload.len)
-    } ?? Data()
+    let payload = request.payload.map { WhiskerValue.from(raw: $0.pointee) } ?? .null
     let custom = WhiskerElementRegistry.measure(
         Int(request.element_type),
         request: WhiskerMeasureRequest(
@@ -315,7 +313,7 @@ private func measureCustomElement(
             knownWidth: request.known_mask & 1 != 0 ? CGFloat(request.known_width) : nil,
             knownHeight: request.known_mask & 2 != 0 ? CGFloat(request.known_height) : nil,
             payloadVersion: request.payload_version,
-            payload: .bytes(payload)
+            payload: payload
         )
     )
     if let custom {

--- a/platforms/web/src/module_api.rs
+++ b/platforms/web/src/module_api.rs
@@ -678,7 +678,7 @@ mod element_registry_tests {
             },
             payload: MeasurementPayload::Custom(CustomMeasurePayload {
                 version: 1,
-                data: Vec::new(),
+                data: WhiskerValue::Bytes(Vec::new()),
             }),
         };
         let module_request = WhiskerMeasureRequest::from(&request);

--- a/xtask/src/mobile_abi.rs
+++ b/xtask/src/mobile_abi.rs
@@ -323,7 +323,7 @@ WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerKeyValueRaw) == 40, "WhiskerKeyValueRaw 
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileHostCapabilities) == 24, "WhiskerMobileHostCapabilities ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileOperation) == 72, "WhiskerMobileOperation ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileFrame) == 72, "WhiskerMobileFrame ABI drift");
-WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 232, "WhiskerMobileMeasureRequest ABI drift");
+WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureRequest) == 224, "WhiskerMobileMeasureRequest ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileMeasureResponse) == 96, "WhiskerMobileMeasureResponse ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileText) == 256, "WhiskerMobileText ABI drift");
 WHISKER_ABI_STATIC_ASSERT(sizeof(WhiskerMobileBoxPaint) == 272, "WhiskerMobileBoxPaint ABI drift");


### PR DESCRIPTION
Inputs currently require a fixed height even when their content is multiline. Add `Input(auto_size: true)` so Host text measurement supplies intrinsic dimensions to Taffy, with CSS min/max sizing controlling the final result. This PR targets `codex/whisker-chat`.

- Add `#[module_element(measurement = Custom(path::to_payload))]` for Custom leaf module elements. The declaration owns its stateless payload function; consumers only set normal props. The macro registers the function automatically, and Runtime projects current props, resolved text style, and scale into the existing versioned measurement payload before layout. Existing measurement caches and the shared WhiskerValue marshalling are reused. No public builder-side measurement API is added.
- `CustomMeasurePayload.data` is a `WhiskerValue`, so Input sends a typed Map rather than JSON bytes. Mobile ABI 2.32 carries a borrowed `WhiskerValueRaw` tree and both native Hosts decode it with their existing value converters. Generated headers and JNI signatures are updated together. Cache hashing preserves nested structure and value types, including equal hashes for positive and negative zero.
- Implement Input measurement on Android, iOS, Web, and Desktop using each platform's text layout. Share typography setup with the displayed native editor where needed. `auto_size: false` returns no payload and disables intrinsic measurement. `on_size_change` reports the final `InputSize`, including padding/borders and CSS constraints, rather than an intermediate intrinsic measurement.
- Use auto sizing in Chat with a 44–212 px input, an adjacent circular Send/Stop icon, and transcript/Latest spacing that follows the composer height.

Validation:
- Runtime module measurement regression test: passed; module-element integration tests: 16 passed; macro validation tests: 5 passed; existing surface rendering tests: 65 passed. Coverage includes payload invalidation, inherited style, cache reuse, max-height, shrinking, owner disposal, and compile-time rejection of unsupported measurement declarations.
- Input unit tests: 8 passed; Desktop Input tests: 14 passed; headless Chrome Input tests: 4 passed.
- Chat `cargo check`, Android `compileDebugKotlin` / `testDebugUnitTest`, iOS simulator-target Swift type checking, and 49 iOS Host conformance tests passed. Android mobile consumer linking also passed. Native device UI behavior has not been exercised for this change.
- In-app browser Chat verification: 44 px empty, 92 px for three lines, 212 px maximum for twenty lines with internal scrolling, then 44 px after clearing.
- Engine and Protocol coverage passed at 100% lines, functions, and regions. Property tests verify that the measurement snapshot sees current values and removes cleared values.
- Typed payload regression tests verify that an FFI batch owns all nested value trees after the source requests are dropped, and that native-control Bytes remain supported. Generated mobile ABI checks passed.
- Package file lists include the new measurement sources. Whisker macro formatting and Rust 2024 rustfmt applied; `git diff --check` passed.
- Normal Clippy completed with existing warnings. `-D warnings` is blocked by pre-existing `collapsible_if` warnings in core/Desktop code.
