### PR TITLE
Configure Web deployment paths and favicons in whisker.rs

### DIFF
--- a/crates/whisker-cli/src/run.rs
+++ b/crates/whisker-cli/src/run.rs
@@ -207,6 +207,15 @@ fn run_inner(
     };
     let web = match target {
         Target::Web => Some(WebParams {
+            base_path: format!(
+                "{}/",
+                m.config
+                    .web
+                    .base_path
+                    .as_deref()
+                    .unwrap_or("/")
+                    .trim_end_matches('/')
+            ),
             project_dir: sync.gen_dir.clone(),
             target_dir: workspace_root.join("target/.whisker/web"),
             dist_dir: sync.gen_dir.join("dist"),

--- a/crates/whisker-cng/src/templates/web/index.html
+++ b/crates/whisker-cng/src/templates/web/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="whisker-base-path" content="{{base_path}}" />
     <title>{{app_name_html}}</title>
+    {{favicon_html}}
     <style>
       html, body, #whisker-root {
         width: 100%;
@@ -17,7 +19,7 @@
     <div id="whisker-root"></div>
     <pre id="whisker-dev-error" hidden></pre>
     <script type="module">
-      import init, * as whisker from "/whisker_app.js";
+      import init, * as whisker from "{{base_path}}whisker_app.js";
       const reportDevelopmentError = (error) => {
         const output = document.getElementById("whisker-dev-error");
         output.hidden = false;

--- a/crates/whisker-cng/src/web.rs
+++ b/crates/whisker-cng/src/web.rs
@@ -18,6 +18,10 @@ pub struct WebInputs {
     pub app_name: String,
     /// Static document background configured in `whisker.rs` (`#RRGGBB`).
     pub background: String,
+    /// Embedded favicon included in the generated document and its fingerprint.
+    pub favicon_data_url: Option<String>,
+    /// Normalized absolute deployment path, including a trailing slash.
+    pub base_path: String,
     /// Cargo package name of the generated WASM composition root.
     pub generated_package: String,
     /// Cargo package name of the user's application crate.
@@ -44,16 +48,58 @@ pub fn inputs_from(
         .clone()
         .ok_or_else(|| anyhow!("whisker.rs: app.name(\"…\") is required for Web"))?;
     let background = crate::background::AppBackground::resolve(app_config)?;
+    let favicon_data_url = favicon_data_url(app_config, &user_crate_path)?;
     Ok(WebInputs {
         app_name,
         background: background.hex().to_string(),
+        favicon_data_url,
+        base_path: normalize_base_path(app_config.web.base_path.as_deref().unwrap_or("/"))?,
         generated_package: format!("{user_package}-whisker-web"),
         user_package,
         user_crate_path,
         whisker_web_dependency,
         element_modules: Vec::new(),
-        template_version: 13,
+        template_version: 14,
     })
+}
+
+fn normalize_base_path(path: &str) -> Result<String> {
+    if !path.starts_with('/')
+        || path.contains("//")
+        || !path
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"/-._~".contains(&b))
+        || path.split('/').any(|part| matches!(part, "." | ".."))
+    {
+        bail!(
+            "Web base path must be an absolute URL path without query, fragment, or dot segments: {path}"
+        );
+    }
+    Ok(format!("{}/", path.trim_end_matches('/')))
+}
+
+fn favicon_data_url(config: &Config, app_dir: &Path) -> Result<Option<String>> {
+    let Some(path) = &config.web.favicon else {
+        return Ok(None);
+    };
+    let path = app_dir.join(path);
+    let mime = match path.extension().and_then(|value| value.to_str()) {
+        Some("svg") => "image/svg+xml",
+        Some("png") => "image/png",
+        Some("ico") => "image/x-icon",
+        _ => bail!(
+            "Web favicon must be an SVG, PNG, or ICO file: {}",
+            path.display()
+        ),
+    };
+    let bytes =
+        std::fs::read(&path).with_context(|| format!("read Web favicon {}", path.display()))?;
+    let mut url = format!("data:{mime},");
+    for byte in bytes {
+        use std::fmt::Write;
+        write!(url, "%{byte:02X}").expect("write favicon URL");
+    }
+    Ok(Some(url))
 }
 
 /// Generates or reuses the complete `gen/web` project.
@@ -92,6 +138,10 @@ fn validate(inputs: &WebInputs) -> Result<()> {
     if inputs.generated_package.trim().is_empty() || inputs.user_package.trim().is_empty() {
         bail!("Web Cargo package names must not be empty");
     }
+    anyhow::ensure!(
+        normalize_base_path(&inputs.base_path)? == inputs.base_path,
+        "Web base path must have a trailing slash"
+    );
     crate::background::AppBackground::parse(&inputs.background)
         .context("validate Web application background")?;
     Ok(())
@@ -101,6 +151,16 @@ fn template_vars(inputs: &WebInputs) -> std::collections::HashMap<&'static str, 
     let mut vars = std::collections::HashMap::new();
     vars.insert("app_name_html", html_escape(&inputs.app_name));
     vars.insert("background_css", inputs.background.clone());
+    vars.insert("base_path", inputs.base_path.clone());
+    vars.insert(
+        "favicon_html",
+        inputs
+            .favicon_data_url
+            .as_ref()
+            .map_or_else(String::new, |url| {
+                format!("<link rel=\"icon\" href=\"{}\" />", html_escape(url))
+            }),
+    );
     vars.insert("app_title_rust", format!("{:?}", inputs.app_name));
     vars.insert("generated_package", inputs.generated_package.clone());
     vars.insert("user_package_toml", format!("{:?}", inputs.user_package));
@@ -181,12 +241,14 @@ mod tests {
         WebInputs {
             app_name: "Hello Web".into(),
             background: "#FFFFFF".into(),
+            favicon_data_url: None,
+            base_path: "/".into(),
             generated_package: "hello-whisker-web".into(),
             user_package: "hello".into(),
             user_crate_path: PathBuf::from("/tmp/hello"),
             whisker_web_dependency: "{ path = \"/tmp/whisker/platforms/web\" }".into(),
             element_modules: Vec::new(),
-            template_version: 13,
+            template_version: 14,
         }
     }
 
@@ -236,6 +298,70 @@ mod tests {
         sync(&out, &inputs).unwrap();
         let html = std::fs::read_to_string(out.join("index.html")).unwrap();
         assert!(html.contains("background: #101018"));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn subpath_build_resolves_modules_and_declares_router_base() {
+        assert_eq!(
+            normalize_base_path("/examples/chat").unwrap(),
+            "/examples/chat/"
+        );
+        assert_eq!(normalize_base_path("/").unwrap(), "/");
+        for invalid in [
+            "chat",
+            "//other.test",
+            "/../chat",
+            "/chat?x",
+            "/chat#x",
+            "/chat\\x",
+            "/chat/./",
+        ] {
+            assert!(normalize_base_path(invalid).is_err(), "{invalid}");
+        }
+        let root = tempdir();
+        let mut config = Config::default();
+        config.name("Chat").web(|web| {
+            web.base_path("/examples/chat");
+        });
+        let inputs = inputs_from(&config, "chat".into(), root.clone(), "\"0.12\"".into()).unwrap();
+        sync(&root, &inputs).unwrap();
+        let html = std::fs::read_to_string(root.join("index.html")).unwrap();
+        assert!(html.contains("from \"/examples/chat/whisker_app.js\""));
+        assert!(html.contains("name=\"whisker-base-path\" content=\"/examples/chat/\""));
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn favicon_is_embedded_and_content_changes_invalidate_the_project() {
+        let root = tempdir();
+        let icon = root.join("icon.svg");
+        let first = "<svg xmlns=\"http://www.w3.org/2000/svg\"><path fill=\"#fff\"/></svg>";
+        std::fs::write(&icon, first).unwrap();
+        let mut config = Config::default();
+        config.name("Icon").web(|web| {
+            web.favicon("icon.svg");
+        });
+        let inputs =
+            || inputs_from(&config, "icon".into(), root.clone(), "\"0.12\"".into()).unwrap();
+        let out = root.join("gen/web");
+        let original = inputs();
+        assert!(
+            original
+                .favicon_data_url
+                .as_ref()
+                .unwrap()
+                .starts_with("data:image/svg+xml,%3C")
+        );
+        assert!(sync(&out, &original).unwrap());
+        assert!(!sync(&out, &inputs()).unwrap());
+        let html = std::fs::read_to_string(out.join("index.html")).unwrap();
+        assert!(html.contains("<link rel=\"icon\" href=\"data:image/svg+xml,"));
+        assert!(!html.contains(first));
+        std::fs::write(&icon, first.replace("#fff", "#000")).unwrap();
+        assert!(sync(&out, &inputs()).unwrap());
+        std::fs::remove_file(icon).unwrap();
+        assert!(inputs_from(&config, "icon".into(), root.clone(), "\"0.12\"".into()).is_err());
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/whisker-config/src/lib.rs
+++ b/crates/whisker-config/src/lib.rs
@@ -65,6 +65,8 @@ pub struct Config {
     pub url_schemes: Vec<String>,
     pub ios: IosConfig,
     pub android: AndroidConfig,
+    #[serde(default)]
+    pub web: WebConfig,
     /// Per-plugin Config serialized as JSON, keyed by the Config
     /// struct's `PluginConfig::NAME`. `whisker-cng` reads this map
     /// when composing the plugin pipeline — every entry corresponds
@@ -75,6 +77,26 @@ pub struct Config {
     /// and HashMap's random ordering would break the skip path.
     #[serde(default)]
     pub plugins: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct WebConfig {
+    /// URL path under which the Web app is served; defaults to `/`.
+    pub base_path: Option<String>,
+    /// SVG, PNG, or ICO favicon path relative to the application directory.
+    pub favicon: Option<PathBuf>,
+}
+
+impl WebConfig {
+    pub fn base_path(&mut self, path: impl Into<String>) -> &mut Self {
+        self.base_path = Some(path.into());
+        self
+    }
+
+    pub fn favicon(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.favicon = Some(path.into());
+        self
+    }
 }
 
 impl Config {
@@ -125,6 +147,11 @@ impl Config {
 
     pub fn android(&mut self, f: impl FnOnce(&mut AndroidConfig)) -> &mut Self {
         f(&mut self.android);
+        self
+    }
+
+    pub fn web(&mut self, f: impl FnOnce(&mut WebConfig)) -> &mut Self {
+        f(&mut self.web);
         self
     }
 

--- a/crates/whisker-dev-server/src/installer.rs
+++ b/crates/whisker-dev-server/src/installer.rs
@@ -145,10 +145,7 @@ impl Installer {
                 );
                 Ok(())
             }
-            Target::Web => {
-                whisker_build::ui::info(format!("Local: http://127.0.0.1:{}/", self.dev_port));
-                Ok(())
-            }
+            Target::Web => Ok(()),
         }
     }
 

--- a/crates/whisker-dev-server/src/lib.rs
+++ b/crates/whisker-dev-server/src/lib.rs
@@ -205,6 +205,8 @@ pub struct MacosParams {
 /// Flat parameters for Whisker's generated browser Host.
 #[derive(Debug, Clone)]
 pub struct WebParams {
+    /// Normalized URL prefix used for browser assets and routes.
+    pub base_path: String,
     /// Generated `gen/web` Cargo project.
     pub project_dir: PathBuf,
     /// Dedicated Cargo output directory for the wasm target.
@@ -465,11 +467,21 @@ impl DevServer {
             self.config.bind_addr,
             self.on_event.clone(),
             self.config.dev_token.clone(),
-            self.config.web.as_ref().map(|web| web.dist_dir.clone()),
+            self.config.web.as_ref().map(|web| server::StaticFiles {
+                root: web.dist_dir.clone(),
+                base_path: web.base_path.clone(),
+            }),
         )
         .await?;
         whisker_build::ui::set_status(format!("ws://{bound} · 0 client(s)"));
         whisker_build::ui::debug(format!("ws://{bound}/whisker-dev"));
+        if let Some(web) = &self.config.web {
+            whisker_build::ui::info(format!(
+                "Local: http://127.0.0.1:{}{}",
+                bound.port(),
+                web.base_path
+            ));
+        }
 
         // One notify root per workspace path dep's `src/`; the change
         // loop maps a changed file back to its owning crate through

--- a/crates/whisker-dev-server/src/server.rs
+++ b/crates/whisker-dev-server/src/server.rs
@@ -166,6 +166,11 @@ enum ServerUpdate {
     Reload,
 }
 
+pub struct StaticFiles {
+    pub root: PathBuf,
+    pub base_path: String,
+}
+
 /// Bind on `addr`, spawn the axum server on the current tokio
 /// runtime, and return:
 ///   - a [`PatchSender`] for the rest of the dev loop to push patches
@@ -178,7 +183,7 @@ pub async fn serve(
     addr: SocketAddr,
     on_event: Option<Arc<dyn Fn(Event) + Send + Sync>>,
     expected_token: Option<String>,
-    static_root: Option<PathBuf>,
+    static_files: Option<StaticFiles>,
 ) -> Result<(PatchSender, SocketAddr, tokio::task::JoinHandle<()>)> {
     let (tx, _rx) = broadcast::channel::<ServerUpdate>(16);
     let aslr_reference: Arc<Mutex<Option<u64>>> = Arc::new(Mutex::new(None));
@@ -192,10 +197,17 @@ pub async fn serve(
     let mut app = Router::new()
         .route("/whisker-dev", get(ws_handler))
         .with_state(state);
-    if let Some(root) = static_root {
-        app = app.fallback_service(
-            ServeDir::new(root.clone()).fallback(ServeFile::new(root.join("index.html"))),
-        );
+    if let Some(StaticFiles { root, base_path }) = static_files {
+        let files = ServeDir::new(root.clone()).fallback(ServeFile::new(root.join("index.html")));
+        let prefix = base_path.trim_end_matches('/');
+        if prefix.is_empty() {
+            app = app.fallback_service(files);
+        } else {
+            app = app.nest_service(prefix, files).route(
+                "/",
+                get(move || std::future::ready(axum::response::Redirect::temporary(&base_path))),
+            );
+        }
     }
 
     let listener = tokio::net::TcpListener::bind(addr).await?;
@@ -573,9 +585,17 @@ mod tests {
         std::fs::write(root.join("index.html"), b"INDEX").unwrap();
         std::fs::write(root.join("whisker_app.js"), b"JAVASCRIPT").unwrap();
         let any: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let (_sender, addr, _handle) = serve(any, None, None, Some(root.clone()))
-            .await
-            .expect("serve");
+        let (_sender, addr, _handle) = serve(
+            any,
+            None,
+            None,
+            Some(StaticFiles {
+                root: root.clone(),
+                base_path: "/".into(),
+            }),
+        )
+        .await
+        .expect("serve");
 
         async fn get(addr: SocketAddr, path: &str) -> String {
             let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
@@ -594,6 +614,39 @@ mod tests {
         assert!(get(addr, "/").await.ends_with("INDEX"));
         assert!(get(addr, "/detail/42").await.ends_with("INDEX"));
         assert!(get(addr, "/whisker_app.js").await.ends_with("JAVASCRIPT"));
+        let (_sender, nested_addr, nested_handle) = serve(
+            any,
+            None,
+            None,
+            Some(StaticFiles {
+                root: root.clone(),
+                base_path: "/examples/chat/".into(),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(
+            get(nested_addr, "/")
+                .await
+                .contains("location: /examples/chat/")
+        );
+        assert!(get(nested_addr, "/examples/chat/").await.ends_with("INDEX"));
+        assert!(
+            get(nested_addr, "/examples/chat/settings/connection")
+                .await
+                .ends_with("INDEX")
+        );
+        assert!(
+            get(nested_addr, "/examples/chat/whisker_app.js")
+                .await
+                .ends_with("JAVASCRIPT")
+        );
+        assert!(
+            get(nested_addr, "/whisker_app.js")
+                .await
+                .starts_with("HTTP/1.1 404")
+        );
+        nested_handle.abort();
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/examples/chat/assets/favicon.svg
+++ b/examples/chat/assets/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="surface" x2="0" y2="1">
+      <stop stop-color="#34373d"/>
+      <stop offset="1" stop-color="#17191d"/>
+    </linearGradient>
+  </defs>
+  <rect x="1" y="1" width="62" height="62" rx="15" fill="url(#surface)" stroke="#555960" stroke-width="2"/>
+  <path d="m12 22 5 20h7l5-12 5 12h7l5-20h-7l-2.8 12-4.7-12h-5L22 34l-3-12Z" fill="#f4f5f7"/>
+  <circle cx="50" cy="40" r="3.5" fill="#f99d68"/>
+</svg>

--- a/examples/chat/whisker.rs
+++ b/examples/chat/whisker.rs
@@ -3,6 +3,10 @@ pub fn configure(app: &mut whisker_config::Config) {
         .bundle_id("rs.whisker.chat")
         .version("0.1.0")
         .build_number(1);
+    app.web(|web| {
+        web.base_path("/examples/chat/")
+            .favicon("assets/favicon.svg");
+    });
     app.android(|android| {
         android
             .package("rs.whisker.chat")

--- a/packages/whisker-router/web/Cargo.toml
+++ b/packages/whisker-router/web/Cargo.toml
@@ -12,6 +12,8 @@ whisker = { path = "../../../crates/whisker", version = "0.13.9" }
 whisker-web = { path = "../../../platforms/web", version = "0.13.9" }
 wasm-bindgen = "0.2"
 web-sys = { version = "0.3", features = [
+    "Document",
+    "Element",
     "EventTarget",
     "History",
     "Location",

--- a/packages/whisker-router/web/src/base_path.rs
+++ b/packages/whisker-router/web/src/base_path.rs
@@ -1,0 +1,45 @@
+pub(super) fn app_path(base: &str, pathname: &str) -> Result<String, String> {
+    let prefix = base.trim_end_matches('/');
+    match pathname.strip_prefix(prefix) {
+        Some("") => Ok("/".into()),
+        Some(path) if path.starts_with('/') => Ok(path.into()),
+        _ => Err("browser location is outside the application base path".into()),
+    }
+}
+
+pub(super) fn browser_url(base: &str, app_url: &str) -> Result<String, String> {
+    if !app_url.starts_with('/') || app_url.starts_with("//") {
+        return Err("router URL must be an absolute application path".into());
+    }
+    Ok(format!("{}{app_url}", base.trim_end_matches('/')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subpath_navigation_preserves_queries_and_fragments() {
+        let base = "/examples/chat/";
+        assert_eq!(app_path(base, "/examples/chat").unwrap(), "/");
+        assert_eq!(app_path(base, "/examples/chat/").unwrap(), "/");
+        assert_eq!(
+            app_path(base, "/examples/chat/settings").unwrap(),
+            "/settings"
+        );
+        assert_eq!(
+            browser_url(base, "/settings?q=rust#key").unwrap(),
+            "/examples/chat/settings?q=rust#key"
+        );
+        assert_eq!(browser_url(base, "/").unwrap(), "/examples/chat/");
+        assert!(app_path(base, "/examples/chat-other").is_err());
+        assert!(app_path(base, "/settings").is_err());
+        assert!(browser_url(base, "//other.test/").is_err());
+    }
+
+    #[test]
+    fn root_deployment_keeps_existing_urls() {
+        assert_eq!(app_path("/", "/settings").unwrap(), "/settings");
+        assert_eq!(browser_url("/", "/settings?q=x").unwrap(), "/settings?q=x");
+    }
+}

--- a/packages/whisker-router/web/src/lib.rs
+++ b/packages/whisker-router/web/src/lib.rs
@@ -1,5 +1,7 @@
 //! Web History API Host adapter for `whisker-router`.
 
+mod base_path;
+
 use std::cell::RefCell;
 
 use wasm_bindgen::JsCast;
@@ -79,11 +81,23 @@ fn window() -> Result<web_sys::Window, String> {
     web_sys::window().ok_or_else(|| "browser Window is unavailable".into())
 }
 
+fn deployment_base(window: &web_sys::Window) -> Result<String, String> {
+    let document = window.document().ok_or("browser Document is unavailable")?;
+    Ok(document
+        .query_selector("meta[name=\"whisker-base-path\"]")
+        .map_err(js_error)?
+        .and_then(|element| element.get_attribute("content"))
+        .unwrap_or_else(|| "/".into()))
+}
+
 fn current_url(window: &web_sys::Window) -> Result<String, String> {
     let location = window.location();
     Ok(format!(
         "{}{}{}",
-        location.pathname().map_err(js_error)?,
+        base_path::app_path(
+            &deployment_base(window)?,
+            &location.pathname().map_err(js_error)?
+        )?,
         location.search().map_err(js_error)?,
         location.hash().map_err(js_error)?,
     ))
@@ -106,7 +120,7 @@ fn initialize() -> Result<WhiskerValue, String> {
         .replace_state_with_url(
             &wasm_bindgen::JsValue::from_str(&state.encode()),
             "",
-            Some(&url),
+            Some(&base_path::browser_url(&deployment_base(&window)?, &url)?),
         )
         .map_err(js_error)?;
     Ok(location_payload(url, state.target))
@@ -116,7 +130,9 @@ fn write(args: &[WhiskerValue], replace: bool) -> Result<WhiskerValue, String> {
     let [WhiskerValue::String(url), WhiskerValue::String(target)] = args else {
         return Err("History push/replace requires public URL and internal target strings".into());
     };
-    let history = window()?.history().map_err(js_error)?;
+    let window = window()?;
+    let url = base_path::browser_url(&deployment_base(&window)?, url)?;
+    let history = window.history().map_err(js_error)?;
     let current_index = history
         .state()
         .ok()
@@ -134,11 +150,11 @@ fn write(args: &[WhiskerValue], replace: bool) -> Result<WhiskerValue, String> {
     let encoded = wasm_bindgen::JsValue::from_str(&state.encode());
     if replace {
         history
-            .replace_state_with_url(&encoded, "", Some(url))
+            .replace_state_with_url(&encoded, "", Some(&url))
             .map_err(js_error)?;
     } else {
         history
-            .push_state_with_url(&encoded, "", Some(url))
+            .push_state_with_url(&encoded, "", Some(&url))
             .map_err(js_error)?;
     }
     Ok(WhiskerValue::Null)


### PR DESCRIPTION
Web apps can configure their deployment path and favicon in `whisker.rs`. For example, Chat now runs at `/examples/chat/`, and navigating to Settings keeps the browser under `/examples/chat/settings` while application routes still use `/settings`.

- Add `web.base_path(...)` and `web.favicon(...)` to application configuration. Embed the favicon and deployment metadata in generated HTML, including them in the generation fingerprint.
- Apply the prefix to JavaScript loading and the router's Web History adapter, including initial location, push/replace, and browser back navigation.
- Mount development assets and SPA fallback at the configured path, redirect the dev-server root, and print the matching local URL.
- Configure Whisker Chat and add its SVG favicon. Both build and run use `whisker.rs` as the configuration source.

Validation: Web generation tests, router URL-conversion tests, root/subpath development-server integration test, CLI build, and formatting checks passed. Built Chat in release mode and verified direct links, reloads, and browser back navigation under `/examples/chat/` with the website's local Cloudflare preview.

Website integration: https://github.com/whiskerrs/website/pull/17.
