### PR TITLE
fix(web): follow mobile visual viewport changes

### DIFF
--- a/platforms/web/Cargo.toml
+++ b/platforms/web/Cargo.toml
@@ -73,6 +73,7 @@ web-sys = { version = "0.3", features = [
     "ShadowRootMode",
     "SvgElement",
     "Url",
+    "VisualViewport",
     "Window",
 ] }
 

--- a/platforms/web/src/application.rs
+++ b/platforms/web/src/application.rs
@@ -20,8 +20,12 @@ use crate::scene::frame_sink::DomFrameSink;
 use crate::scene::resource_service::WebResourceService;
 use crate::scene::resource_store::WebResourceStore;
 use crate::{
-    BuiltInElementModule, WebAppConfig, WebError, WebModuleDefinition, js_error, set_style,
+    BuiltInElementModule, WebAppConfig, WebError, WebModuleDefinition, js_error, px, set_style,
 };
+
+#[cfg(all(test, target_arch = "wasm32"))]
+#[path = "application_tests.rs"]
+mod tests;
 
 thread_local! {
     static APPLICATION: RefCell<Option<WebApplication>> = const { RefCell::new(None) };
@@ -99,6 +103,13 @@ pub fn run_with_application_hash(
         .add_event_listener_with_callback("resize", resize.as_ref().unchecked_ref())
         .map_err(|error| js_error("register resize listener", error))?;
     resize.forget();
+    if let Some(viewport) = browser_window()?.visual_viewport() {
+        let resize = Closure::<dyn FnMut()>::new(request_frame);
+        viewport
+            .add_event_listener_with_callback("resize", resize.as_ref().unchecked_ref())
+            .map_err(|error| js_error("register visual viewport resize listener", error))?;
+        resize.forget();
+    }
     request_frame();
     Ok(())
 }
@@ -281,11 +292,10 @@ impl WebApplication {
             .get_element_by_id(&config.root_id)
             .ok_or_else(|| WebError(format!("missing Web Host root #{}", config.root_id)))?;
         set_style(&root, "position", "relative")?;
-        set_style(&root, "width", "100vw")?;
-        set_style(&root, "height", "100vh")?;
         set_style(&root, "overflow", "hidden")?;
 
         let viewport = viewport(&window)?;
+        size_root(&root, viewport)?;
         let surface_id = SurfaceId::new(1).expect("the browser surface id is non-zero");
         let registrations = elements.registrations().to_vec();
         let capabilities = crate::capabilities::detect_host_capabilities()
@@ -349,6 +359,7 @@ impl WebApplication {
         }
         let current = viewport(&browser_window()?)?;
         if current != self.viewport {
+            size_root(&self.root, current)?;
             self.viewport = current;
             self.viewport_epoch = self.viewport_epoch.wrapping_add(1).max(1);
             self.environment_epoch = self.environment_epoch.wrapping_add(1).max(1);
@@ -533,6 +544,18 @@ fn browser_window() -> Result<web_sys::Window, WebError> {
 }
 
 fn viewport(window: &web_sys::Window) -> Result<(f32, f32, f32), WebError> {
+    if let Some(viewport) = window.visual_viewport() {
+        // Undo pinch zoom so magnifying the page does not reflow its contents.
+        let width = viewport.width() * viewport.scale();
+        let height = viewport.height() * viewport.scale();
+        if width.is_finite() && width > 0.0 && height.is_finite() && height > 0.0 {
+            return Ok((
+                width as f32,
+                height as f32,
+                window.device_pixel_ratio() as f32,
+            ));
+        }
+    }
     let width = window
         .inner_width()
         .map_err(|error| js_error("read viewport width", error))?
@@ -544,4 +567,9 @@ fn viewport(window: &web_sys::Window) -> Result<(f32, f32, f32), WebError> {
         .as_f64()
         .ok_or_else(|| WebError("viewport height was not numeric".into()))? as f32;
     Ok((width, height, window.device_pixel_ratio() as f32))
+}
+
+fn size_root(root: &web_sys::Element, viewport: (f32, f32, f32)) -> Result<(), WebError> {
+    set_style(root, "width", &px(viewport.0))?;
+    set_style(root, "height", &px(viewport.1))
 }

--- a/platforms/web/src/application_tests.rs
+++ b/platforms/web/src/application_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::wasm_bindgen_test;
+use whisker::prelude::*;
+
+#[wasm_bindgen(inline_js = "
+export function mockViewport() {
+    const descriptor = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    const viewport = new EventTarget();
+    Object.assign(viewport, { width: innerWidth, height: 600, scale: 1 });
+    Object.defineProperty(window, 'visualViewport', { configurable: true, value: viewport });
+    return () => descriptor
+        ? Object.defineProperty(window, 'visualViewport', descriptor)
+        : delete window.visualViewport;
+}
+export function resizeViewport(height, scale) {
+    Object.assign(window.visualViewport, { width: innerWidth / scale, height, scale });
+    window.visualViewport.dispatchEvent(new Event('resize'));
+}
+export function withoutVisualViewport() {
+    Object.defineProperty(window, 'visualViewport', { configurable: true, value: null });
+    window.dispatchEvent(new Event('resize'));
+}
+export function afterFrames() {
+    return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+")]
+extern "C" {
+    #[wasm_bindgen(js_name = mockViewport)]
+    fn mock_viewport() -> js_sys::Function;
+    #[wasm_bindgen(js_name = resizeViewport)]
+    fn resize_viewport(height: f64, scale: f64);
+    #[wasm_bindgen(js_name = withoutVisualViewport)]
+    fn without_visual_viewport();
+    #[wasm_bindgen(js_name = afterFrames)]
+    fn after_frames() -> js_sys::Promise;
+}
+
+struct MountedViewport {
+    root: web_sys::Element,
+    restore: js_sys::Function,
+}
+
+impl Drop for MountedViewport {
+    fn drop(&mut self) {
+        APPLICATION.with(|slot| *slot.borrow_mut() = None);
+        self.root.remove();
+        self.restore.call0(&JsValue::NULL).unwrap();
+    }
+}
+
+fn assert_height(root: &web_sys::Element, expected: f32) {
+    assert_eq!(root.get_bounding_client_rect().height() as f32, expected);
+    APPLICATION.with(|slot| {
+        assert_eq!(slot.borrow().as_ref().unwrap().viewport.1, expected);
+    });
+    let content = root
+        .shadow_root()
+        .unwrap()
+        .query_selector("[data-whisker-node]")
+        .unwrap()
+        .expect("the mounted View must have DOM content");
+    assert_eq!(content.get_bounding_client_rect().height() as f32, expected);
+}
+
+#[wasm_bindgen_test]
+async fn visual_viewport_resize_updates_surface_and_dom_without_window_resize() {
+    let restore = mock_viewport();
+    let document = browser_window().unwrap().document().unwrap();
+    let root = document.create_element("div").unwrap();
+    root.set_id("viewport-test-root");
+    document.body().unwrap().append_child(&root).unwrap();
+    let mounted = MountedViewport { root, restore };
+    let mut config = WebAppConfig::new("Viewport test");
+    config.root_id = "viewport-test-root".into();
+    run(
+        config,
+        || render! { View(style: Css::new().height(percent(100))) },
+    )
+    .unwrap();
+    JsFuture::from(after_frames()).await.unwrap();
+    assert_height(&mounted.root, 600.0);
+
+    for height in [720.0, 560.0, 720.0] {
+        resize_viewport(height, 1.0);
+        JsFuture::from(after_frames()).await.unwrap();
+        assert_height(&mounted.root, height as f32);
+    }
+
+    resize_viewport(360.0, 2.0);
+    JsFuture::from(after_frames()).await.unwrap();
+    assert_height(&mounted.root, 720.0);
+
+    without_visual_viewport();
+    JsFuture::from(after_frames()).await.unwrap();
+    let height = browser_window()
+        .unwrap()
+        .inner_height()
+        .unwrap()
+        .as_f64()
+        .unwrap();
+    assert_height(&mounted.root, height as f32);
+}


### PR DESCRIPTION
Mobile browser chrome can resize the visible viewport without a window resize event. Whisker's Web Host only listened to window resizes, read the layout viewport, and kept its DOM root at `100vh`, leaving the surface out of sync with the visible area.

Listen to `visualViewport.resize` and use the same measured dimensions for the Rust layout environment and DOM root. Normalize visual dimensions by the pinch-zoom scale to retain the layout while magnifying the page. Fall back to window dimensions when VisualViewport is unavailable or has invalid dimensions. No public API changes.

Validation: all 26 Web Host browser tests passed, including a regression that mounts an application and checks the root, rendered View, and runtime dimensions after viewport-only resize events, zoom, and fallback. Chat browser checks covered repeated height changes and actual Chrome page scaling. Formatting and `git diff --check` passed. Physical mobile browser toolbar interaction remains unverified.

Stacked on #703 so this PR shows only the viewport change. The viewport implementation itself does not depend on the deployment configuration feature.

Website bundle update: https://github.com/whiskerrs/website/pull/19.
