### PR TITLE
fix(release): install Fontconfig and recover Rust publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@1.98.1
       - uses: Swatinem/rust-cache@v2
+      - name: Install Linux build dependencies
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev
       - name: Resume unpublished crates and finalize the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/resume-rust-release.yml
+++ b/.github/workflows/resume-rust-release.yml
@@ -1,0 +1,41 @@
+name: resume-rust-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_commit:
+        description: Full SHA of the original release-plan merge whose native SDKs are already published
+        required: true
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-push
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.repository == 'whiskerrs/whisker' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Select the immutable release commit
+        env:
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+        run: |
+          [[ "$RELEASE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          git merge-base --is-ancestor "$RELEASE_COMMIT" origin/main
+          git checkout --detach "$RELEASE_COMMIT"
+      - uses: dtolnay/rust-toolchain@1.98.1
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux build dependencies
+        run: bash .github/scripts/install-ubuntu-packages.sh libfontconfig1-dev
+      - name: Verify SDKs, resume unpublished crates, and finalize the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo xtask release publish


### PR DESCRIPTION
Release 20260910.1 stopped before uploading Rust crates because the Linux publishing runner could not compile `yeslogic-fontconfig-sys`: `fontconfig.pc` was missing. Install `libfontconfig1-dev` using the same Ubuntu package helper as normal CI.

Add a manual Rust-only recovery workflow for cases where the publishing environment itself needs a fix. It runs from main, accepts only a full commit SHA already contained in main, and checks out the original release-plan merge. The existing publisher validates the immutable manifests, content hashes and lockfile, verifies native SDK availability, skips already published crates, and creates the unified release only after registry verification. It shares the normal release publishing concurrency group.

This lets the already published Android SDK 0.1.25 and SwiftPM 0.1.16 keep their original tags at e027acc1f39d8a76b5c9feac8fea7a54479988f7. No packaged Rust sources, versions, release inventory or native tags change.

Validation: YAML parsing and `git diff --check` pass. The original CI run passed all tests; the actual recovery run will verify packaged crate builds with the missing system dependency installed.
