### PR TITLE
fix(router): use horizontal slides for Android button back

### DIFF
--- a/packages/whisker-router/src/render/platform_navigation.rs
+++ b/packages/whisker-router/src/render/platform_navigation.rs
@@ -183,6 +183,15 @@ fn install_edge_swipe(container: Element, nav: RouterHandle) {
 /// **predictive-back** pose mode, and return the bridge. `None` means no
 /// gesture should begin.
 pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> {
+    let mode = if cfg!(target_os = "android") {
+        PoseMode::Predictive(edge)
+    } else {
+        PoseMode::Transition(RouteTransition::slide(), transition::Direction::Pop)
+    };
+    begin_with_mode(nav, mode)
+}
+
+pub(super) fn begin_with_mode(nav: &RouterHandle, mode: PoseMode) -> Option<StackBridge> {
     // An active `whisker::back::on_back` handler owns the back action;
     // no interactive preview on either platform.
     if whisker::back::has_active_handler() {
@@ -195,19 +204,7 @@ pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> 
     if !bridge.can_back {
         return None;
     }
-    // The interactive preview is platform-native:
-    //  - Android: the Material **predictive-back** Card (shrink + rounded
-    //    corners + backdrop dim).
-    //  - iOS / others: the interactive **iOS slide-back** (the top slides
-    //    off to the right, the under parallaxes back) — the route's slide
-    //    pose driven by the finger, NOT the Material card.
-    let android = cfg!(target_os = "android");
-    let mode = if android {
-        PoseMode::Predictive(edge)
-    } else {
-        // A swipe-back is a Pop direction.
-        PoseMode::Transition(RouteTransition::slide(), transition::Direction::Pop)
-    };
+    let predictive = matches!(mode, PoseMode::Predictive(_));
     if let (Some(ctrl), Some(top), Some(under)) =
         (&bridge.top_ctrl, &bridge.top_pose, &bridge.under_pose)
     {
@@ -219,7 +216,7 @@ pub(crate) fn begin(nav: &RouterHandle, edge: SwipeEdge) -> Option<StackBridge> 
         point(under, ctrl, Role::Under, mode);
         // The Material backdrop dim is Android-only; the iOS slide carries
         // its own subtle under-screen dim in `slide_pose`.
-        if android {
+        if predictive {
             if let Some(dim_drive) = &bridge.dim_drive {
                 dim_drive.set(Some(ctrl.clone()));
             }

--- a/packages/whisker-router/src/render/tests.rs
+++ b/packages/whisker-router/src/render/tests.rs
@@ -7,6 +7,8 @@
 //! the right active child. The visual transition + gesture + actual
 //! mount/swap behaviour is verified on-device.
 
+mod android_back;
+
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;

--- a/packages/whisker-router/src/render/tests/android_back.rs
+++ b/packages/whisker-router/src/render/tests/android_back.rs
@@ -1,0 +1,118 @@
+use super::*;
+use crate::render::handle::StackBridge;
+use crate::render::platform_navigation::begin_with_mode;
+use crate::render::transition::{
+    AndroidDefault, Direction, PoseContext, PoseMode, Role, Transition, pose_for,
+};
+use whisker::css::{LengthPercentage, TransformFn};
+
+fn android_stack() -> RouterHandle {
+    let tree = CompiledTree::new(RouteTree::Stack(vec![
+        RouteTree::route("", "home"),
+        RouteTree::route("detail/:id", "detail"),
+    ]));
+    let mut registry = RouteRegistry::new();
+    for id in ["home", "detail"] {
+        registry = registry.route_with(
+            id,
+            RouteTransition::custom(AndroidDefault),
+            |_: &RouteInstance| whisker::runtime::view::create_phantom_element(),
+        );
+    }
+    let nav = RouterHandle::new((tree, registry));
+    mount_node(&nav, NodePath::root());
+    flush();
+    nav.navigate("/detail/1").unwrap();
+    flush();
+    settle_animations();
+    nav
+}
+
+fn assert_button_slide(bridge: &StackBridge) {
+    for (binding, translation) in [
+        (bridge.top_pose.as_ref().unwrap(), 50.0),
+        (bridge.under_pose.as_ref().unwrap(), -15.0),
+    ] {
+        let mode = binding.mode.get_untracked();
+        assert!(matches!(mode, PoseMode::Transition(_, Direction::Pop)));
+        let pose = pose_for(&mode, binding.role.get_untracked(), 0.5);
+        let [TransformFn::TranslateX(LengthPercentage::Percentage(x))] =
+            pose.transform.0.as_slice()
+        else {
+            panic!("button back must only translate horizontally: {pose:?}");
+        };
+        assert!((x.0 - translation).abs() < 0.0001);
+        assert_eq!(pose.opacity, 1.0);
+        assert_eq!(pose.radius_px, 0.0);
+    }
+    assert!(bridge.dim_drive.unwrap().get_untracked().is_none());
+}
+
+#[test]
+fn android_button_back_slides_both_routes_without_scale_or_fade() {
+    with_runtime(|| {
+        let nav = android_stack();
+        let bridge = nav.active_stack_bridge().unwrap();
+        nav.back().unwrap();
+        flush();
+        assert_button_slide(&bridge);
+        settle_animations();
+        assert_eq!(nav.current().get().path, NodePath(vec![0]));
+    });
+}
+
+#[test]
+fn android_swipe_back_uses_predictive_preview_on_both_edges() {
+    for edge in [SwipeEdge::Left, SwipeEdge::Right] {
+        with_runtime(|| {
+            let nav = android_stack();
+            let bridge = begin_with_mode(&nav, PoseMode::Predictive(edge)).unwrap();
+            scrub(&bridge, 0.5);
+            flush();
+            for binding in [bridge.top_pose.as_ref(), bridge.under_pose.as_ref()] {
+                let binding = binding.unwrap();
+                let mode = binding.mode.get_untracked();
+                assert!(matches!(mode, PoseMode::Predictive(actual) if actual == edge));
+                let progress = binding.ctrl.get_untracked().value().get_untracked();
+                let pose = pose_for(&mode, binding.role.get_untracked(), progress);
+                assert!(pose.transform.to_css_string().contains("scale(0.9, 0.9)"));
+                assert!(pose.radius_px > 0.0);
+            }
+            assert!(bridge.dim_drive.unwrap().get_untracked().is_some());
+            assert_eq!(nav.current().get().path, NodePath(vec![1]));
+            settle(&nav, &bridge, true, None);
+            settle_animations();
+            assert_eq!(nav.current().get().path, NodePath(vec![0]));
+        });
+    }
+}
+
+#[test]
+fn android_button_back_after_cancelled_swipe_does_not_reuse_predictive_pose() {
+    with_runtime(|| {
+        let nav = android_stack();
+        let bridge = begin_with_mode(&nav, PoseMode::Predictive(SwipeEdge::Left)).unwrap();
+        scrub(&bridge, 0.35);
+        settle(&nav, &bridge, false, None);
+        settle_animations();
+        assert_eq!(nav.current().get().path, NodePath(vec![1]));
+        nav.back().unwrap();
+        flush();
+        assert_button_slide(&bridge);
+        settle_animations();
+        assert_eq!(nav.current().get().path, NodePath(vec![0]));
+    });
+}
+
+#[test]
+fn android_push_keeps_the_slide_fade_transition() {
+    for role in [Role::Top, Role::Under] {
+        for progress in [0.0, 0.5, 1.0] {
+            let ctx = PoseContext::new(role, progress, Direction::Push);
+            let actual = AndroidDefault.pose(ctx);
+            let expected = RouteTransition::slide_fade().pose(ctx);
+            assert_eq!(actual.transform, expected.transform);
+            assert_eq!(actual.opacity, expected.opacity);
+        }
+    }
+}

--- a/packages/whisker-router/src/render/transition.rs
+++ b/packages/whisker-router/src/render/transition.rs
@@ -136,15 +136,14 @@ impl std::fmt::Debug for RouteTransition {
     }
 }
 
-/// The platform default: iOS gets the full [`slide`](RouteTransition::slide),
-/// Android gets the subtler [`slide_fade`](RouteTransition::slide_fade)
-/// (small slide + fade), and Web/Desktop swap instantly. This is whisker's
-/// analogue of Flutter's `PageTransitionsTheme` per-`TargetPlatform` default.
+/// Platform defaults: iOS slides, Android uses slide-fade for pushes and
+/// an opaque horizontal slide for button backs, and Web/Desktop swap instantly.
+/// Android back gestures use the separate interactive predictive-back pose.
 impl Default for RouteTransition {
     fn default() -> Self {
         #[cfg(target_os = "android")]
         {
-            RouteTransition::slide_fade()
+            RouteTransition::custom(AndroidDefault)
         }
         #[cfg(target_os = "ios")]
         {
@@ -547,9 +546,28 @@ impl Transition for Slide {
     }
 }
 
-/// The Android default: a small horizontal slide + a fade (Material
-/// shared-axis feel). The top slides only a short distance from the right
-/// while fading in; the under shifts slightly without becoming transparent.
+#[cfg(any(target_os = "android", test))]
+pub(super) struct AndroidDefault;
+
+#[cfg(any(target_os = "android", test))]
+impl Transition for AndroidDefault {
+    fn config(&self) -> AnimConfig {
+        SlideFade.config()
+    }
+
+    fn name(&self) -> &'static str {
+        "android"
+    }
+
+    fn pose(&self, ctx: PoseContext) -> Pose {
+        match ctx.direction {
+            Direction::Push => SlideFade.pose(ctx),
+            Direction::Pop => Slide.pose(ctx),
+        }
+    }
+}
+
+/// Small horizontal slide plus fade, with an opaque under route.
 struct SlideFade;
 impl Transition for SlideFade {
     fn config(&self) -> AnimConfig {


### PR DESCRIPTION
Android's default button back currently uses a short horizontal movement with a fade. Use an opaque horizontal slide for ordinary pops, including system back buttons and `RouterHandle::back()`, while swipe gestures continue to use the interactive Predictive Back preview with scale, rounded corners, and backdrop dimming.

The Android default chooses its pose by navigation direction: pushes retain slide-fade, and pops use the full horizontal slide at the existing 280 ms easing. Explicit route transitions remain application-controlled. No public API or Kotlin changes are required.

Separate platform pose selection from shared gesture setup so the Android gesture path can be exercised in host tests. Regression coverage checks ordinary button backs, predictive previews from both edges and commit, button back after cancelling a swipe, and existing push behavior.

Validation: `cargo test -p whisker-router` (102 passed, 5 ignored doctests); `cargo fmt -p whisker-router --check`; Clippy with Rust 1.88.0 and the CI lint flags. Physical Android gesture verification has not been performed.
