### PR TITLE
fix(whisker-cng): suppress plugin build progress logs

### DIFF
--- a/crates/whisker-cng/src/generator.rs
+++ b/crates/whisker-cng/src/generator.rs
@@ -343,6 +343,7 @@ fn build_discovered_plugins(
     for plugin in discovered {
         let output = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
             .arg("build")
+            .arg("--quiet")
             .arg("--manifest-path")
             .arg(workspace_root.join("Cargo.toml"))
             .arg("--package")


### PR DESCRIPTION
`whisker run` leaked Cargo's `Compiling` and `Finished` lines while preparing CNG plugins. The isolated configuration build already uses `--quiet`, but the separate plugin build did not. Add `--quiet` to that build as well, retaining stderr forwarding for warnings and errors.

Validation: reproduced the progress leak by executing chat's generated configuration binary for iOS, then verified the same invocation emits no Cargo progress lines after the change. An injected Cargo profile error still reaches stderr and fails generation; normal generation succeeds afterward. `cargo fmt --all -- --check` and `git diff --check` pass. No Xcode build was needed to exercise this generation-stage change.
